### PR TITLE
Require explicit full Codex review signals

### DIFF
--- a/.github/scripts/review_gate.py
+++ b/.github/scripts/review_gate.py
@@ -70,6 +70,7 @@ CODEX_SETUP_REQUIRED = re.compile(r"To use Codex here,", re.IGNORECASE)
 CODEX_REVIEWED_COMMIT = re.compile(
     r"(?:\*\*)?Reviewed commit:(?:\*\*)?\s*`?([0-9a-f]{7,40})`?", re.IGNORECASE
 )
+CODEX_FULL_REVIEW = re.compile(r"###\s+💡\s+Codex Review", re.IGNORECASE)
 
 POLL_INTERVAL_SECONDS: Final = 15
 # Codex's re-review latency is not stable. It has been ~8.5 min in PR #71
@@ -94,6 +95,7 @@ query($owner: String!, $repo: String!, $pr: Int!) {
         nodes {
           databaseId
           submittedAt
+          body
           author { login }
           commit { oid }
         }
@@ -364,7 +366,13 @@ def _codex_setup_required(
 
     if head_sha is None or head_time is None:
         return False
-    latest_review_id = _latest_review_id_on_head(state, CODEX_LOGIN, head_sha, not_before=head_time)
+    latest_review_id = _latest_review_id_on_head(
+        state,
+        CODEX_LOGIN,
+        head_sha,
+        not_before=head_time,
+        require_full_review=False,
+    )
     if latest_review_id is None:
         return False
     threads_obj = state.get("reviewThreads")
@@ -424,6 +432,7 @@ def engaged_bots(
             if (
                 login in BOT_LABELS
                 and commit_sha == head_sha
+                and (login != CODEX_LOGIN or _is_full_codex_review(r, head_sha))
                 and submitted is not None
                 and (freshness_time is None or submitted >= freshness_time)
             ):
@@ -443,6 +452,7 @@ def _latest_review_id_on_head(
     bot_login: str,
     head_sha: str,
     not_before: datetime | None = None,
+    require_full_review: bool = True,
 ) -> int | None:
     """Return the databaseId of the bot's most recent review on `head_sha`,
     or None if it hasn't done a fresh review on this commit. Used to scope
@@ -456,6 +466,12 @@ def _latest_review_id_on_head(
             continue
         if _author_login(r) != bot_login:
             continue
+        if (
+            require_full_review
+            and bot_login == CODEX_LOGIN
+            and not _is_full_codex_review(r, head_sha)
+        ):
+            continue
         commit = r.get("commit")
         commit_sha = commit.get("oid") if isinstance(commit, dict) else None
         if commit_sha != head_sha:
@@ -468,6 +484,14 @@ def _latest_review_id_on_head(
         return None
     candidates.sort()
     return candidates[-1][1]
+
+
+def _is_full_codex_review(review: dict[str, object], head_sha: str) -> bool:
+    body = review.get("body")
+    if not isinstance(body, str) or not CODEX_FULL_REVIEW.search(body):
+        return False
+    match = CODEX_REVIEWED_COMMIT.search(body)
+    return match is not None and head_sha.lower().startswith(match.group(1).lower())
 
 
 def _codex_thumbed_up_head(state: dict[str, object], head_time: datetime | None) -> bool:
@@ -556,6 +580,8 @@ def _latest_review_time_on_head(
         if not isinstance(r, dict):
             continue
         if _author_login(r) != bot_login:
+            continue
+        if bot_login == CODEX_LOGIN and not _is_full_codex_review(r, head_sha):
             continue
         commit = r.get("commit")
         commit_sha = commit.get("oid") if isinstance(commit, dict) else None

--- a/.github/scripts/review_gate.py
+++ b/.github/scripts/review_gate.py
@@ -431,6 +431,7 @@ def engaged_bots(
             return set()
 
     engaged: set[str] = set()
+    codex_blocking_review_ids = _blocking_review_ids(state, CODEX_LOGIN)
 
     reviews_obj = state.get("reviews")
     if isinstance(reviews_obj, dict):
@@ -438,13 +439,17 @@ def engaged_bots(
             if not isinstance(r, dict):
                 continue
             login = _author_login(r)
+            review_id = r.get("databaseId")
+            codex_review_is_substantive = _is_full_codex_review(r, head_sha) or (
+                isinstance(review_id, int) and review_id in codex_blocking_review_ids
+            )
             commit = r.get("commit")
             commit_sha = commit.get("oid") if isinstance(commit, dict) else None
             submitted = _parse_iso(r.get("submittedAt") or "")
             if (
                 login in BOT_LABELS
                 and commit_sha == head_sha
-                and (login != CODEX_LOGIN or _is_full_codex_review(r, head_sha))
+                and (login != CODEX_LOGIN or codex_review_is_substantive)
                 and submitted is not None
                 and (freshness_time is None or submitted >= freshness_time)
             ):

--- a/.github/scripts/review_gate.py
+++ b/.github/scripts/review_gate.py
@@ -70,7 +70,7 @@ CODEX_SETUP_REQUIRED = re.compile(r"To use Codex here,", re.IGNORECASE)
 CODEX_REVIEWED_COMMIT = re.compile(
     r"(?:\*\*)?Reviewed commit:(?:\*\*)?\s*`?([0-9a-f]{7,40})`?", re.IGNORECASE
 )
-CODEX_FULL_REVIEW = re.compile(r"###\s+💡\s+Codex Review", re.IGNORECASE)
+CODEX_FULL_REVIEW = re.compile(r"###\s+(?:💡\s+)?Codex Review\b", re.IGNORECASE)
 
 POLL_INTERVAL_SECONDS: Final = 15
 # Codex's re-review latency is not stable. It has been ~8.5 min in PR #71

--- a/.github/scripts/review_gate.py
+++ b/.github/scripts/review_gate.py
@@ -123,6 +123,7 @@ query($owner: String!, $repo: String!, $pr: Int!) {
         nodes {
           body
           createdAt
+          updatedAt
           author { login }
         }
       }
@@ -265,6 +266,17 @@ def _parse_iso(s: str) -> datetime | None:
         return None
 
 
+def _comment_request_time(comment: dict[str, object]) -> datetime | None:
+    """Return when the comment most recently authorized its current body."""
+    updated = comment.get("updatedAt")
+    if isinstance(updated, str):
+        parsed = _parse_iso(updated)
+        if parsed is not None:
+            return parsed
+    created = comment.get("createdAt")
+    return _parse_iso(created) if isinstance(created, str) else None
+
+
 def _head_time(state: dict[str, object], head_sha: str) -> datetime | None:
     """Return the timestamp for when the head commit became reviewable.
 
@@ -307,9 +319,9 @@ def _latest_codex_request_time(state: dict[str, object], head_sha: str) -> datet
             continue
         if head_sha not in body:
             continue
-        created = _parse_iso(c.get("createdAt") or "")
-        if created is not None:
-            candidates.append(created)
+        request_time = _comment_request_time(c)
+        if request_time is not None:
+            candidates.append(request_time)
     if not candidates:
         return None
     candidates.sort()
@@ -328,9 +340,9 @@ def _owner_codex_request_time(
             continue
         body = comment.get("body")
         if isinstance(body, str) and "@codex review" in body.lower() and head_sha in body:
-            created = _parse_iso(comment.get("createdAt") or "")
-            if created is not None:
-                requests.append(created)
+            request_time = _comment_request_time(comment)
+            if request_time is not None:
+                requests.append(request_time)
     return max(requests) if requests else None
 
 
@@ -454,22 +466,28 @@ def _latest_review_id_on_head(
     not_before: datetime | None = None,
     require_full_review: bool = True,
 ) -> int | None:
-    """Return the databaseId of the bot's most recent review on `head_sha`,
-    or None if it hasn't done a fresh review on this commit. Used to scope
-    findings to the bot's latest assessment, ignoring re-anchored stale ones."""
+    """Return the bot's latest substantive review ID on ``head_sha``.
+
+    A Codex review is substantive when it is a stamped full review or carries
+    a blocking inline finding. Empty task reviews do not supersede findings.
+    """
     reviews_obj = state.get("reviews")
     if not isinstance(reviews_obj, dict):
         return None
+    blocking_review_ids = _blocking_review_ids(state, bot_login)
     candidates: list[tuple[datetime, int]] = []
     for r in reviews_obj.get("nodes") or []:
         if not isinstance(r, dict):
             continue
         if _author_login(r) != bot_login:
             continue
+        rid = r.get("databaseId")
+        has_blocking_findings = isinstance(rid, int) and rid in blocking_review_ids
         if (
             require_full_review
             and bot_login == CODEX_LOGIN
             and not _is_full_codex_review(r, head_sha)
+            and not has_blocking_findings
         ):
             continue
         commit = r.get("commit")
@@ -477,7 +495,6 @@ def _latest_review_id_on_head(
         if commit_sha != head_sha:
             continue
         when = _parse_iso(r.get("submittedAt") or "")
-        rid = r.get("databaseId")
         if when is not None and isinstance(rid, int) and (not_before is None or when >= not_before):
             candidates.append((when, rid))
     if not candidates:
@@ -494,6 +511,29 @@ def _is_full_codex_review(review: dict[str, object], head_sha: str) -> bool:
     return match is not None and head_sha.lower().startswith(match.group(1).lower())
 
 
+def _blocking_review_ids(state: dict[str, object], bot_login: str) -> set[int]:
+    """Return review IDs containing blocking inline findings from this bot."""
+    review_ids: set[int] = set()
+    threads_obj = state.get("reviewThreads")
+    if not isinstance(threads_obj, dict):
+        return review_ids
+    for thread in threads_obj.get("nodes") or []:
+        if not isinstance(thread, dict):
+            continue
+        comments_obj = thread.get("comments")
+        if not isinstance(comments_obj, dict):
+            continue
+        for comment in comments_obj.get("nodes") or []:
+            if not isinstance(comment, dict) or _author_login(comment) != bot_login:
+                continue
+            body = comment.get("body")
+            review = comment.get("pullRequestReview")
+            review_id = review.get("databaseId") if isinstance(review, dict) else None
+            if isinstance(body, str) and CODEX_BLOCKING.search(body) and isinstance(review_id, int):
+                review_ids.add(review_id)
+    return review_ids
+
+
 def _codex_thumbed_up_head(state: dict[str, object], head_time: datetime | None) -> bool:
     """True iff Codex added a 👍 reaction newer than the head commit's
     pushed timestamp — Codex's documented signal for "evaluated this
@@ -507,26 +547,31 @@ def _codex_thumbed_up_head(state: dict[str, object], head_time: datetime | None)
     the secondary check; rely solely on head_time. If head_time is null, we
     conservatively don't infer cleanliness.
     """
+    return _codex_thumbed_up_time(state, head_time) is not None
+
+
+def _codex_thumbed_up_time(state: dict[str, object], head_time: datetime | None) -> datetime | None:
     if head_time is None:
-        return False
+        return None
+    candidates: list[datetime] = []
     reactions_obj = state.get("reactions")
     if not isinstance(reactions_obj, dict):
-        return False
-    for r in reactions_obj.get("nodes") or []:
-        if not isinstance(r, dict):
+        return None
+    for reaction in reactions_obj.get("nodes") or []:
+        if not isinstance(reaction, dict):
             continue
-        user = r.get("user")
+        user = reaction.get("user")
         if not isinstance(user, dict):
             continue
         login = user.get("login")
-        if not isinstance(login, str):
+        if not isinstance(login, str) or login.removesuffix("[bot]") != CODEX_LOGIN:
             continue
-        if login.removesuffix("[bot]") != CODEX_LOGIN:
-            continue
-        created = _parse_iso(r.get("createdAt") or "")
+        created = _parse_iso(reaction.get("createdAt") or "")
         if created is not None and created >= head_time:
-            return True
-    return False
+            candidates.append(created)
+    if not candidates:
+        return None
+    return max(candidates)
 
 
 def _codex_clean_comment_time_on_head(
@@ -575,13 +620,20 @@ def _latest_review_time_on_head(
     reviews_obj = state.get("reviews")
     if not isinstance(reviews_obj, dict):
         return None
+    blocking_review_ids = _blocking_review_ids(state, bot_login)
     candidates: list[datetime] = []
     for r in reviews_obj.get("nodes") or []:
         if not isinstance(r, dict):
             continue
         if _author_login(r) != bot_login:
             continue
-        if bot_login == CODEX_LOGIN and not _is_full_codex_review(r, head_sha):
+        review_id = r.get("databaseId")
+        has_blocking_findings = isinstance(review_id, int) and review_id in blocking_review_ids
+        if (
+            bot_login == CODEX_LOGIN
+            and not _is_full_codex_review(r, head_sha)
+            and not has_blocking_findings
+        ):
             continue
         commit = r.get("commit")
         commit_sha = commit.get("oid") if isinstance(commit, dict) else None
@@ -621,7 +673,11 @@ def collect_findings(
     codex_clean_comment_latest = codex_clean_comment_time is not None and (
         latest_codex_review_time is None or codex_clean_comment_time >= latest_codex_review_time
     )
-    codex_clean = _codex_thumbed_up_head(state, head_time) or codex_clean_comment_latest
+    codex_reaction_time = _codex_thumbed_up_time(state, head_time)
+    codex_reaction_latest = codex_reaction_time is not None and (
+        latest_codex_review_time is None or codex_reaction_time >= latest_codex_review_time
+    )
+    codex_clean = codex_reaction_latest or codex_clean_comment_latest
     latest_per_bot: dict[str, int | None] = {
         login: _latest_review_id_on_head(state, login, head_sha) for login in BOT_LABELS
     }

--- a/.github/workflows/review-gate-retrigger.yml
+++ b/.github/workflows/review-gate-retrigger.yml
@@ -32,8 +32,8 @@ permissions:
 jobs:
   retrigger:
     # Bot reviews, Codex clean comments, and exact-head owner review requests
-    # can change the gate's verdict. Skip fork PRs too: their GITHUB_TOKEN is
-    # read-only, so the re-run API call would fail.
+    # can change the gate's verdict. Owner issue comments run in the base
+    # repository, so they can re-run the base workflow for fork PR heads.
     if: >-
       (
         github.event_name == 'pull_request_review'
@@ -79,11 +79,6 @@ jobs:
 
           if [ "${GITHUB_EVENT_NAME}" = "issue_comment" ]; then
             pr_json=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
-            head_repo=$(jq -r '.head.repo.full_name' <<<"${pr_json}")
-            if [ "${head_repo}" != "${REPO}" ]; then
-              echo "Skipping fork PR from ${head_repo}."
-              exit 0
-            fi
             HEAD_SHA=$(jq -r '.head.sha' <<<"${pr_json}")
             if [ "${COMMENT_AUTHOR}" = "${REPO_OWNER}" ] \
               && [[ "${COMMENT_BODY}" != *"${HEAD_SHA}"* ]]; then

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -95,7 +95,7 @@ def _path(value: str, base_dir: Path) -> Path:
 
 def _executable_path(value: str, base_dir: Path) -> Path:
     path = Path(value).expanduser()
-    if path.is_absolute() or len(path.parts) > 1:
+    if path.is_absolute() or value.startswith("./") or len(path.parts) > 1:
         return _path(value, base_dir)
     resolved = which(value)
     return Path(resolved) if resolved is not None else path

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
+from shutil import which
 from typing import Final
 
 from .birds import ObservationWindow, parse_observation_window
@@ -92,6 +93,14 @@ def _path(value: str, base_dir: Path) -> Path:
     return path if path.is_absolute() else (base_dir / path).resolve()
 
 
+def _executable_path(value: str, base_dir: Path) -> Path:
+    path = Path(value).expanduser()
+    if path.is_absolute() or len(path.parts) > 1:
+        return _path(value, base_dir)
+    resolved = which(value)
+    return Path(resolved) if resolved is not None else path
+
+
 def load_config(path: Path) -> AppConfig:
     try:
         raw = tomllib.loads(path.read_text())
@@ -130,7 +139,7 @@ def load_config(path: Path) -> AppConfig:
             workspace_dir=_path(_string(controller, "workspace_dir"), base_dir),
             catalog_dir=_path(_string(controller, "catalog_dir"), base_dir),
             state_dir=_path(_string(controller, "state_dir"), base_dir),
-            codex_path=_path(_string(controller, "codex_path"), base_dir),
+            codex_path=_executable_path(_string(controller, "codex_path"), base_dir),
             bind_host=_string(controller, "bind_host"),
             port=_integer(controller, "port"),
             references_per_species=_integer(controller, "references_per_species"),

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -389,6 +389,8 @@ def run_controller_cycle(config: AppConfig) -> dict[str, object]:
                         "terminal": True,
                     }
                 )
+            except CatalogError:
+                raise
             except InkyBirdFrameError as exc:
                 failures.append(
                     {

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -29,6 +29,7 @@ from .errors import (
     GenerationError,
     InkyBirdFrameError,
     InsufficientReferencesError,
+    QualityReviewError,
 )
 from .geo import ZipLocation, lookup_us_zip
 from .images import prepare_generated_plate
@@ -196,7 +197,7 @@ def generate_candidate(config: AppConfig, species: BirdSpecies, workspace: Path)
             history.append({"attempt": attempt, "quality_review": review.as_dict()})
             if review.passed:
                 shutil.copy2(profile_path, attempt_dir / "profile.json")
-                write_json_atomic(attempt_dir / "attempt-history.json", history)
+                write_json_atomic(logs / "attempt-history.json", history)
                 write_candidate_manifest(
                     attempt_dir,
                     species,
@@ -221,7 +222,7 @@ def generate_candidate(config: AppConfig, species: BirdSpecies, workspace: Path)
         failed = state_dir / "failed" / f"{species.taxon_id}-{_timestamp()}"
         failed.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(work, failed)
-        raise GenerationError(
+        raise QualityReviewError(
             "Generated plate failed automated quality review after "
             f"{config.controller.max_generation_attempts} attempts; artifacts retained at {failed}"
         )
@@ -377,7 +378,7 @@ def run_controller_cycle(config: AppConfig) -> dict[str, object]:
                         "terminal": False,
                     }
                 )
-            except InkyBirdFrameError as exc:
+            except QualityReviewError as exc:
                 failure_path = record_failure(config.controller.state_dir, species, exc)
                 failures.append(
                     {
@@ -386,6 +387,15 @@ def run_controller_cycle(config: AppConfig) -> dict[str, object]:
                         "error": str(exc),
                         "failure": str(failure_path),
                         "terminal": True,
+                    }
+                )
+            except InkyBirdFrameError as exc:
+                failures.append(
+                    {
+                        "taxon_id": species.taxon_id,
+                        "common_name": species.common_name,
+                        "error": str(exc),
+                        "terminal": False,
                     }
                 )
 

--- a/src/inky_bird_frame/errors.py
+++ b/src/inky_bird_frame/errors.py
@@ -31,3 +31,7 @@ class CatalogError(InkyBirdFrameError):
 
 class GenerationError(InkyBirdFrameError):
     """Raised when Codex cannot produce or validate an artifact."""
+
+
+class QualityReviewError(GenerationError):
+    """Raised when a species exhausts its automated visual-review attempts."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from inky_bird_frame.birds import ObservationWindow
 from inky_bird_frame.config import load_config
@@ -53,6 +54,20 @@ class ConfigTests(unittest.TestCase):
 
             with self.assertRaises(ConfigurationError):
                 load_config(path)
+
+    def test_resolves_bare_codex_name_from_path(self) -> None:
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(
+                CONFIG.replace(
+                    'codex_path = "/Applications/Codex.app/Contents/Resources/codex"',
+                    'codex_path = "codex"',
+                )
+            )
+            with patch("inky_bird_frame.config.which", return_value="/opt/local/bin/codex"):
+                config = load_config(path)
+
+        self.assertEqual(config.controller.codex_path, Path("/opt/local/bin/codex"))
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -69,6 +69,20 @@ class ConfigTests(unittest.TestCase):
 
         self.assertEqual(config.controller.codex_path, Path("/opt/local/bin/codex"))
 
+    def test_resolves_explicit_relative_codex_path_from_config_directory(self) -> None:
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(
+                CONFIG.replace(
+                    'codex_path = "/Applications/Codex.app/Contents/Resources/codex"',
+                    'codex_path = "./codex"',
+                )
+            )
+
+            config = load_config(path)
+
+        self.assertEqual(config.controller.codex_path, (Path(temporary) / "codex").resolve())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -10,7 +10,12 @@ from inky_bird_frame.birds import BirdSpecies
 from inky_bird_frame.catalog import candidate_directory, write_candidate_manifest
 from inky_bird_frame.config import load_config
 from inky_bird_frame.controller import generate_candidate, run_controller_cycle
-from inky_bird_frame.errors import DataSourceError, GenerationError, InsufficientReferencesError
+from inky_bird_frame.errors import (
+    DataSourceError,
+    GenerationError,
+    InsufficientReferencesError,
+    QualityReviewError,
+)
 from inky_bird_frame.geo import ZipLocation
 from inky_bird_frame.models import QualityReview, SpeciesProfileData
 from inky_bird_frame.prompts import PROMPT_VERSION
@@ -245,12 +250,17 @@ class ControllerTests(unittest.TestCase):
             ):
                 candidate = generate_candidate(config, species, config.controller.workspace_dir)
             manifest = json.loads((candidate / "manifest.json").read_text())
+            private_histories = list(
+                (config.controller.state_dir / "runs").glob("*/attempt-history.json")
+            )
 
         self.assertEqual(FakeRunner.corrections, [(), ("Crest is too short",)])
         self.assertEqual(manifest["generation"]["attempt"], 2)
         self.assertEqual(manifest["status"], "pending")
+        self.assertFalse((candidate / "attempt-history.json").exists())
+        self.assertEqual(len(private_histories), 1)
 
-    def test_expected_generation_failure_becomes_terminal(self) -> None:
+    def test_runtime_generation_failure_remains_eligible(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
         location = ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0)
         with TemporaryDirectory() as temporary:
@@ -269,7 +279,7 @@ class ControllerTests(unittest.TestCase):
 
             failures = list((config.controller.state_dir / "failed").glob("9083-*"))
 
-        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures, [])
         self.assertEqual(result["eligible_count"], 1)
         failure_results = result["failures"]
         self.assertIsInstance(failure_results, list)
@@ -277,6 +287,32 @@ class ControllerTests(unittest.TestCase):
         self.assertIsInstance(first_failure, dict)
         if isinstance(first_failure, dict):
             self.assertEqual(first_failure["error"], "profile failed")
+            self.assertFalse(first_failure["terminal"])
+
+    def test_exhausted_quality_review_becomes_terminal(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        location = ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            with (
+                patch(
+                    "inky_bird_frame.controller.discover_species",
+                    return_value=(location, [species]),
+                ),
+                patch("inky_bird_frame.controller.generate_candidate") as generate,
+            ):
+                generate.side_effect = QualityReviewError("review attempts exhausted")
+                result = run_controller_cycle(config)
+
+            failures = list((config.controller.state_dir / "failed").glob("9083-*"))
+
+        self.assertEqual(len(failures), 1)
+        failure_results = result["failures"]
+        self.assertIsInstance(failure_results, list)
+        if isinstance(failure_results, list):
+            self.assertTrue(failure_results[0]["terminal"])
 
 
 if __name__ == "__main__":

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -11,6 +11,7 @@ from inky_bird_frame.catalog import candidate_directory, write_candidate_manifes
 from inky_bird_frame.config import load_config
 from inky_bird_frame.controller import generate_candidate, run_controller_cycle
 from inky_bird_frame.errors import (
+    CatalogError,
     DataSourceError,
     GenerationError,
     InsufficientReferencesError,
@@ -288,6 +289,28 @@ class ControllerTests(unittest.TestCase):
         if isinstance(first_failure, dict):
             self.assertEqual(first_failure["error"], "profile failed")
             self.assertFalse(first_failure["terminal"])
+
+    def test_catalog_failure_aborts_cycle_without_terminal_species_state(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        location = ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            with (
+                patch(
+                    "inky_bird_frame.controller.discover_species",
+                    return_value=(location, [species]),
+                ),
+                patch("inky_bird_frame.controller.generate_candidate") as generate,
+            ):
+                generate.side_effect = CatalogError("cached references are invalid")
+                with self.assertRaisesRegex(CatalogError, "cached references are invalid"):
+                    run_controller_cycle(config)
+
+            failures = list((config.controller.state_dir / "failed").glob("9083-*"))
+
+        self.assertEqual(failures, [])
 
     def test_exhausted_quality_review_becomes_terminal(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")

--- a/tests/test_review_gate_script.py
+++ b/tests/test_review_gate_script.py
@@ -100,6 +100,10 @@ def _full_codex_review_body(head_sha: str) -> str:
     )
 
 
+def _plain_codex_review_body(head_sha: str) -> str:
+    return f"### Codex Review\n\n**Reviewed commit:** `{head_sha[:10]}`"
+
+
 def test_codex_reaction_does_not_engage_when_pushed_date_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -257,6 +261,53 @@ def test_empty_codex_task_review_does_not_satisfy_full_review_request() -> None:
         )
         == set()
     )
+
+
+def test_plain_codex_review_header_satisfies_full_review_request() -> None:
+    review_gate = _load_review_gate()
+    state = _state_with_commit(pushed="2026-06-15T11:59:00Z", committed="2026-06-01T12:00:00Z")
+    state["headRefOid"] = "abc1234"
+    state["commits"] = {
+        "nodes": [
+            {
+                "commit": {
+                    "oid": "abc1234",
+                    "pushedDate": "2026-06-15T11:59:00Z",
+                    "committedDate": "2026-06-01T12:00:00Z",
+                }
+            }
+        ]
+    }
+    state["comments"] = {
+        "nodes": [
+            {
+                "body": "@codex review\n\nhead: abc1234",
+                "createdAt": "2026-06-15T12:00:00Z",
+                "author": {"login": "owner"},
+            }
+        ]
+    }
+    state["reactions"] = {"nodes": []}
+    state["reviews"] = {
+        "nodes": [
+            {
+                "databaseId": 10,
+                "submittedAt": "2026-06-15T12:01:00Z",
+                "body": _plain_codex_review_body("abc1234"),
+                "author": {"login": "chatgpt-codex-connector"},
+                "commit": {"oid": "abc1234"},
+            }
+        ]
+    }
+    head_time = review_gate._head_time(state, "abc1234")
+
+    assert review_gate.engaged_bots(
+        state,
+        "owner/repo",
+        "abc1234",
+        head_time,
+        owner_login="owner",
+    ) == {review_gate.CODEX_LOGIN}
 
 
 def test_codex_setup_comment_blocks_reaction_engagement() -> None:

--- a/tests/test_review_gate_script.py
+++ b/tests/test_review_gate_script.py
@@ -267,6 +267,59 @@ def test_empty_codex_task_review_does_not_satisfy_full_review_request() -> None:
     )
 
 
+def test_blocking_codex_review_counts_as_engagement() -> None:
+    review_gate = _load_review_gate()
+    state = _state_with_commit(pushed="2026-06-15T11:59:00Z", committed="2026-06-01T12:00:00Z")
+    state["comments"] = {
+        "nodes": [
+            {
+                "body": "@codex review\n\nhead: abc123",
+                "createdAt": "2026-06-15T12:00:00Z",
+                "author": {"login": "owner"},
+            }
+        ]
+    }
+    state["reviews"] = {
+        "nodes": [
+            {
+                "databaseId": 10,
+                "submittedAt": "2026-06-15T12:01:00Z",
+                "body": "",
+                "author": {"login": "chatgpt-codex-connector"},
+                "commit": {"oid": "abc123"},
+            }
+        ]
+    }
+    state["reviewThreads"] = {
+        "nodes": [
+            {
+                "isResolved": False,
+                "comments": {
+                    "nodes": [
+                        {
+                            "databaseId": 1,
+                            "author": {"login": "chatgpt-codex-connector"},
+                            "body": "![P1 Badge](https://example.invalid/badge/P1-red.svg)\nissue",
+                            "path": "example.py",
+                            "line": 1,
+                            "pullRequestReview": {"databaseId": 10},
+                        }
+                    ]
+                },
+            }
+        ]
+    }
+    head_time = review_gate._head_time(state, "abc123")
+
+    assert review_gate.engaged_bots(
+        state,
+        "owner/repo",
+        "abc123",
+        head_time,
+        owner_login="owner",
+    ) == {review_gate.CODEX_LOGIN}
+
+
 def test_plain_codex_review_header_satisfies_full_review_request() -> None:
     review_gate = _load_review_gate()
     state = _state_with_commit(pushed="2026-06-15T11:59:00Z", committed="2026-06-01T12:00:00Z")

--- a/tests/test_review_gate_script.py
+++ b/tests/test_review_gate_script.py
@@ -92,6 +92,14 @@ def _state_with_commit(*, pushed: str | None, committed: str) -> dict[str, objec
     }
 
 
+def _full_codex_review_body(head_sha: str) -> str:
+    return (
+        "\n### 💡 Codex Review\n\n"
+        "Here are some automated review suggestions.\n\n"
+        f"**Reviewed commit:** `{head_sha[:10]}`"
+    )
+
+
 def test_codex_reaction_does_not_engage_when_pushed_date_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -163,6 +171,7 @@ def test_codex_engagement_must_follow_latest_owner_request() -> None:
             {
                 "databaseId": 10,
                 "submittedAt": "2026-06-15T12:01:00Z",
+                "body": _full_codex_review_body("abc123"),
                 "author": {"login": "chatgpt-codex-connector"},
                 "commit": {"oid": "abc123"},
             }
@@ -210,6 +219,44 @@ def test_codex_engagement_must_follow_latest_owner_request() -> None:
         head_time,
         owner_login="owner",
     ) == {review_gate.CODEX_LOGIN}
+
+
+def test_empty_codex_task_review_does_not_satisfy_full_review_request() -> None:
+    review_gate = _load_review_gate()
+    state = _state_with_commit(pushed="2026-06-15T11:59:00Z", committed="2026-06-01T12:00:00Z")
+    state["comments"] = {
+        "nodes": [
+            {
+                "body": "@codex review\n\nhead: abc123",
+                "createdAt": "2026-06-15T12:00:00Z",
+                "author": {"login": "owner"},
+            }
+        ]
+    }
+    state["reactions"] = {"nodes": []}
+    state["reviews"] = {
+        "nodes": [
+            {
+                "databaseId": 10,
+                "submittedAt": "2026-06-15T12:01:00Z",
+                "body": "",
+                "author": {"login": "chatgpt-codex-connector"},
+                "commit": {"oid": "abc123"},
+            }
+        ]
+    }
+    head_time = review_gate._head_time(state, "abc123")
+
+    assert (
+        review_gate.engaged_bots(
+            state,
+            "owner/repo",
+            "abc123",
+            head_time,
+            owner_login="owner",
+        )
+        == set()
+    )
 
 
 def test_codex_setup_comment_blocks_reaction_engagement() -> None:
@@ -494,6 +541,7 @@ def test_newer_codex_review_overrides_older_clean_comment() -> None:
             {
                 "databaseId": 10,
                 "submittedAt": "2026-06-15T12:03:00Z",
+                "body": _full_codex_review_body("abc1234"),
                 "author": {"login": "chatgpt-codex-connector"},
                 "commit": {"oid": "abc1234"},
             }
@@ -521,6 +569,64 @@ def test_newer_codex_review_overrides_older_clean_comment() -> None:
     head_time = review_gate._head_time(state, "abc1234")
 
     assert review_gate._codex_clean_comment_time_on_head(state, "abc1234", head_time) is not None
+    assert len(review_gate.collect_findings(state, "abc1234", head_time)) == 1
+
+
+def test_empty_codex_task_review_does_not_supersede_full_review_findings() -> None:
+    review_gate = _load_review_gate()
+    state = _state_with_commit(pushed="2026-06-15T12:01:00Z", committed="2026-06-01T12:00:00Z")
+    state["headRefOid"] = "abc1234"
+    state["commits"] = {
+        "nodes": [
+            {
+                "commit": {
+                    "oid": "abc1234",
+                    "pushedDate": "2026-06-15T12:01:00Z",
+                    "committedDate": "2026-06-01T12:00:00Z",
+                }
+            }
+        ]
+    }
+    state["reactions"] = {"nodes": []}
+    state["reviews"] = {
+        "nodes": [
+            {
+                "databaseId": 10,
+                "submittedAt": "2026-06-15T12:02:00Z",
+                "body": _full_codex_review_body("abc1234"),
+                "author": {"login": "chatgpt-codex-connector"},
+                "commit": {"oid": "abc1234"},
+            },
+            {
+                "databaseId": 11,
+                "submittedAt": "2026-06-15T12:03:00Z",
+                "body": "",
+                "author": {"login": "chatgpt-codex-connector"},
+                "commit": {"oid": "abc1234"},
+            },
+        ]
+    }
+    state["reviewThreads"] = {
+        "nodes": [
+            {
+                "isResolved": False,
+                "comments": {
+                    "nodes": [
+                        {
+                            "databaseId": 1,
+                            "author": {"login": "chatgpt-codex-connector"},
+                            "body": "![P1 Badge](https://example.invalid/badge/P1-red.svg)\nissue",
+                            "path": "example.py",
+                            "line": 1,
+                            "pullRequestReview": {"databaseId": 10},
+                        }
+                    ]
+                },
+            }
+        ]
+    }
+    head_time = review_gate._head_time(state, "abc1234")
+
     assert len(review_gate.collect_findings(state, "abc1234", head_time)) == 1
 
 

--- a/tests/test_review_gate_script.py
+++ b/tests/test_review_gate_script.py
@@ -18,6 +18,10 @@ class ReviewGateModule(Protocol):
 
     def _head_time(self, state: dict[str, object], head_sha: str) -> datetime | None: ...
 
+    def _owner_codex_request_time(
+        self, state: dict[str, object], owner_login: str, head_sha: str
+    ) -> datetime | None: ...
+
     def _codex_thumbed_up_head(
         self, state: dict[str, object], head_time: datetime | None
     ) -> bool: ...
@@ -592,7 +596,7 @@ def test_newer_codex_review_overrides_older_clean_comment() -> None:
             {
                 "databaseId": 10,
                 "submittedAt": "2026-06-15T12:03:00Z",
-                "body": _full_codex_review_body("abc1234"),
+                "body": "",
                 "author": {"login": "chatgpt-codex-connector"},
                 "commit": {"oid": "abc1234"},
             }
@@ -620,6 +624,91 @@ def test_newer_codex_review_overrides_older_clean_comment() -> None:
     head_time = review_gate._head_time(state, "abc1234")
 
     assert review_gate._codex_clean_comment_time_on_head(state, "abc1234", head_time) is not None
+    assert len(review_gate.collect_findings(state, "abc1234", head_time)) == 1
+
+
+def test_newer_blocking_review_overrides_older_clean_reaction() -> None:
+    review_gate = _load_review_gate()
+    state = _state_with_commit(pushed="2026-06-15T11:59:00Z", committed="2026-06-01T12:00:00Z")
+    state["headRefOid"] = "abc1234"
+    state["reviews"] = {
+        "nodes": [
+            {
+                "databaseId": 10,
+                "submittedAt": "2026-06-15T12:03:00Z",
+                "body": "",
+                "author": {"login": "chatgpt-codex-connector"},
+                "commit": {"oid": "abc1234"},
+            }
+        ]
+    }
+    state["reviewThreads"] = {
+        "nodes": [
+            {
+                "isResolved": False,
+                "comments": {
+                    "nodes": [
+                        {
+                            "databaseId": 1,
+                            "author": {"login": "chatgpt-codex-connector"},
+                            "body": "![P1 Badge](https://example.invalid/badge/P1-red.svg)\nnew",
+                            "path": "new.py",
+                            "line": 1,
+                            "pullRequestReview": {"databaseId": 10},
+                        }
+                    ]
+                },
+            }
+        ]
+    }
+    head_time = review_gate._head_time(state, "abc1234")
+
+    assert len(review_gate.collect_findings(state, "abc1234", head_time)) == 1
+
+
+def test_blocking_unrecognized_review_supersedes_older_full_review() -> None:
+    review_gate = _load_review_gate()
+    state = _state_with_commit(pushed="2026-06-15T12:01:00Z", committed="2026-06-01T12:00:00Z")
+    state["headRefOid"] = "abc1234"
+    state["reviews"] = {
+        "nodes": [
+            {
+                "databaseId": 10,
+                "submittedAt": "2026-06-15T12:02:00Z",
+                "body": _full_codex_review_body("abc1234"),
+                "author": {"login": "chatgpt-codex-connector"},
+                "commit": {"oid": "abc1234"},
+            },
+            {
+                "databaseId": 11,
+                "submittedAt": "2026-06-15T12:03:00Z",
+                "body": "",
+                "author": {"login": "chatgpt-codex-connector"},
+                "commit": {"oid": "abc1234"},
+            },
+        ]
+    }
+    state["reviewThreads"] = {
+        "nodes": [
+            {
+                "isResolved": False,
+                "comments": {
+                    "nodes": [
+                        {
+                            "databaseId": 1,
+                            "author": {"login": "chatgpt-codex-connector"},
+                            "body": "![P1 Badge](https://example.invalid/badge/P1-red.svg)\nnew",
+                            "path": "new.py",
+                            "line": 1,
+                            "pullRequestReview": {"databaseId": 11},
+                        }
+                    ]
+                },
+            }
+        ]
+    }
+    head_time = review_gate._head_time(state, "abc1234")
+
     assert len(review_gate.collect_findings(state, "abc1234", head_time)) == 1
 
 
@@ -725,6 +814,26 @@ def test_codex_request_fallback_ignores_other_head_comments(
     assert head_time is None
     assert not review_gate._codex_thumbed_up_head(state, head_time)
     assert review_gate.engaged_bots(state, "owner/repo", "abc123", head_time) == set()
+
+
+def test_owner_request_uses_edit_time_for_current_body() -> None:
+    review_gate = _load_review_gate()
+    state = _state_with_commit(pushed=None, committed="2026-06-01T12:00:00Z")
+    state["comments"] = {
+        "nodes": [
+            {
+                "body": "@codex review\n\nhead: abc1234",
+                "createdAt": "2026-06-15T11:00:00Z",
+                "updatedAt": "2026-06-15T12:04:00Z",
+                "author": {"login": "owner"},
+            }
+        ]
+    }
+
+    cutoff = review_gate._owner_codex_request_time(state, "owner", "abc1234")
+
+    assert cutoff is not None
+    assert cutoff.isoformat() == "2026-06-15T12:04:00+00:00"
 
 
 def test_engagement_poll_refreshes_head_time_from_updated_pr_state(

--- a/tests/test_workflow_pinning_script.py
+++ b/tests/test_workflow_pinning_script.py
@@ -122,3 +122,4 @@ def test_review_gate_retrigger_accepts_only_exact_head_owner_requests() -> None:
 
     assert "github.event.comment.user.login == github.repository_owner" in workflow
     assert '[[ "${COMMENT_BODY}" != *"${HEAD_SHA}"* ]]' in workflow
+    assert "Skipping fork PR" not in workflow


### PR DESCRIPTION
## Summary

- require Codex full-review bodies to carry the standard review marker and exact reviewed commit
- prevent unrelated empty Codex task reviews from satisfying engagement or superseding real findings
- preserve empty setup-error review detection
- add regressions reproducing the premature-merge event sequence

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest` (59 passed)
- `actionlint -color`
- workflow action pinning check

## Incident context

PR #1 merged after the gate misclassified an empty review from a separate Codex feedback task as the requested final full review. This change fails closed unless Codex emits a semantically valid full-review or clean signal.