### PR TITLE
Make runtime schedules and rotation configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ The frame follows public bird observations within a configurable distance and
 rolling time window. When a new species appears, a controller researches it,
 collects licensed reference photographs, creates a plate through Codex, and
 subjects the result to an independent factual and visual review. Passing plates
-join an immutable, reusable catalog; a lightweight Raspberry Pi rotates that
-catalog on the display.
+join an immutable, reusable catalog. A lightweight Raspberry Pi rotates the
+approved birds that are active in the installation's current observation
+window.
 
 ## How it works
 
@@ -33,13 +34,15 @@ flowchart LR
     D --> E{"Independent AI review"}
     E -->|pass| F["Immutable public catalog"]
     E -->|revise| D
-    F --> G["E-paper display"]
+    F --> G["Active local rotation"]
+    G --> H["E-paper display"]
 ```
 
 The system has two deliberately small roles:
 
-- The **controller** discovers species, downloads references, researches facts,
-  generates and reviews candidates, and serves the approved catalog.
+- The **controller** refreshes observations, builds a private active catalog,
+  downloads references, researches facts, generates and reviews candidates,
+  and serves approved assets.
 - The **display node** downloads approved assets, verifies their checksums, and
   rotates them on the Inky panel. It does no AI or discovery work.
 
@@ -95,9 +98,9 @@ cp config.example.toml config.toml
 uv run inky-bird-frame discover --config config.toml
 ```
 
-Set the private discovery ZIP, radius, rolling window, local paths, and
-controller URL in `config.toml`. The file is ignored by Git and must remain
-private.
+Set the private discovery ZIP, radius, rolling window, local paths, controller
+URL, schedules, display geometry, and rotation policy in `config.toml`. The file
+is ignored by Git and must remain private.
 
 On the Pi, install the hardware extra into the Python environment that contains
 the Pimoroni drivers:
@@ -109,8 +112,11 @@ python -m pip install -e '.[inky]'
 ## Operate
 
 ```bash
-# Generate and AI-review a bounded number of missing species.
-uv run inky-bird-frame controller-cycle --config config.toml
+# Refresh observations and the private active catalog without invoking Codex.
+uv run inky-bird-frame refresh --config config.toml
+
+# Generate and AI-review missing plates from the latest refresh.
+uv run inky-bird-frame generate --config config.toml
 
 # Inspect approved, pending, and failed work.
 uv run inky-bird-frame status --config config.toml
@@ -122,6 +128,10 @@ uv run inky-bird-frame display-cycle --config config.toml
 
 Observation windows are `last-day`, `last-week`, `last-30-days`, and
 `all-time`. Discovery distance is configured in kilometers with `radius_km`.
+Rotation modes are `sequential`, `shuffle`, and `weighted`. Shuffle visits every
+active bird before repeating; weighted selection uses local observation counts
+and avoids displaying the same bird twice in succession when alternatives are
+available.
 Recovery and operator-override commands are documented in
 [`docs/operations.md`](docs/operations.md).
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -25,13 +25,6 @@ state_dir = "var/display-node"
 # repeating, and weighted uses local observation counts as selection weights.
 rotation_mode = "shuffle"
 
-[display]
-portrait_width = 1200
-portrait_height = 1600
-hardware_width = 1600
-hardware_height = 1200
-rotation_degrees = 90
-
 [schedule]
 refresh_minutes = 15
 # Generation can consume substantial Codex usage. Start conservatively.

--- a/config.example.toml
+++ b/config.example.toml
@@ -21,3 +21,21 @@ max_generation_attempts = 3
 [display_node]
 controller_url = "http://controller.example:8793"
 state_dir = "var/display-node"
+# sequential visits the sorted active catalog, shuffle visits every active bird before
+# repeating, and weighted uses local observation counts as selection weights.
+rotation_mode = "shuffle"
+
+[display]
+portrait_width = 1200
+portrait_height = 1600
+hardware_width = 1600
+hardware_height = 1200
+rotation_degrees = 90
+
+[schedule]
+refresh_minutes = 15
+# Generation can consume substantial Codex usage. Start conservatively.
+generation_minutes = 360
+rotation_minutes = 30
+rotation_jitter_seconds = 0
+display_startup_delay_seconds = 120

--- a/deploy/install-controller.sh
+++ b/deploy/install-controller.sh
@@ -15,7 +15,9 @@ python_version=${INKY_BIRD_PYTHON_VERSION:-3.11}
 log_dir="${support_dir}/logs"
 agents_dir="${HOME}/Library/LaunchAgents"
 serve_plist="${agents_dir}/com.inky-bird-frame.serve.plist"
-cycle_plist="${agents_dir}/com.inky-bird-frame.controller-cycle.plist"
+refresh_plist="${agents_dir}/com.inky-bird-frame.refresh.plist"
+generation_plist="${agents_dir}/com.inky-bird-frame.generate.plist"
+legacy_cycle_plist="${agents_dir}/com.inky-bird-frame.controller-cycle.plist"
 
 if [ ! -f "${config_path}" ]; then
   echo "Controller configuration is missing: ${config_path}" >&2
@@ -35,13 +37,20 @@ done
 
 "${uv_bin}" sync --project "${app_dir}" --python "${python_version}" --locked
 
-/usr/bin/python3 - "${serve_plist}" "${cycle_plist}" "${app_dir}" "${config_path}" "${log_dir}" <<'PY'
+"${app_dir}/.venv/bin/python" - \
+  "${serve_plist}" "${refresh_plist}" "${generation_plist}" \
+  "${app_dir}" "${config_path}" "${log_dir}" <<'PY'
 import plistlib
 import sys
 from pathlib import Path
 
-serve_path, cycle_path, app_dir, config_path, log_dir = map(Path, sys.argv[1:])
+from inky_bird_frame.config import load_config
+
+serve_path, refresh_path, generation_path, app_dir, config_path, log_dir = map(
+    Path, sys.argv[1:]
+)
 executable = app_dir / ".venv/bin/inky-bird-frame"
+schedule = load_config(config_path).schedule
 
 common = {
     "WorkingDirectory": str(app_dir),
@@ -58,15 +67,28 @@ serve = {
     "StandardOutPath": str(log_dir / "serve.log"),
     "StandardErrorPath": str(log_dir / "serve.error.log"),
 }
-cycle = {
+refresh = {
     **common,
-    "Label": "com.inky-bird-frame.controller-cycle",
-    "ProgramArguments": [str(executable), "controller-cycle", "--config", str(config_path)],
-    "StartInterval": 21600,
-    "StandardOutPath": str(log_dir / "controller-cycle.log"),
-    "StandardErrorPath": str(log_dir / "controller-cycle.error.log"),
+    "Label": "com.inky-bird-frame.refresh",
+    "ProgramArguments": [str(executable), "refresh", "--config", str(config_path)],
+    "RunAtLoad": True,
+    "StartInterval": schedule.refresh_minutes * 60,
+    "StandardOutPath": str(log_dir / "refresh.log"),
+    "StandardErrorPath": str(log_dir / "refresh.error.log"),
 }
-for path, payload in ((serve_path, serve), (cycle_path, cycle)):
+generation = {
+    **common,
+    "Label": "com.inky-bird-frame.generate",
+    "ProgramArguments": [str(executable), "generate", "--config", str(config_path)],
+    "StartInterval": schedule.generation_minutes * 60,
+    "StandardOutPath": str(log_dir / "generate.log"),
+    "StandardErrorPath": str(log_dir / "generate.error.log"),
+}
+for path, payload in (
+    (serve_path, serve),
+    (refresh_path, refresh),
+    (generation_path, generation),
+):
     with path.open("wb") as handle:
         plistlib.dump(payload, handle, sort_keys=True)
 PY
@@ -74,10 +96,15 @@ PY
 uid=$(id -u)
 launchctl bootout "gui/${uid}/com.inky-bird-frame.serve" 2>/dev/null || true
 launchctl bootout "gui/${uid}/com.inky-bird-frame.controller-cycle" 2>/dev/null || true
+launchctl bootout "gui/${uid}/com.inky-bird-frame.refresh" 2>/dev/null || true
+launchctl bootout "gui/${uid}/com.inky-bird-frame.generate" 2>/dev/null || true
+rm -f "${legacy_cycle_plist}"
 launchctl bootstrap "gui/${uid}" "${serve_plist}"
-launchctl bootstrap "gui/${uid}" "${cycle_plist}"
+launchctl bootstrap "gui/${uid}" "${refresh_plist}"
+launchctl bootstrap "gui/${uid}" "${generation_plist}"
 launchctl print "gui/${uid}/com.inky-bird-frame.serve" >/dev/null
-launchctl print "gui/${uid}/com.inky-bird-frame.controller-cycle" >/dev/null
+launchctl print "gui/${uid}/com.inky-bird-frame.refresh" >/dev/null
+launchctl print "gui/${uid}/com.inky-bird-frame.generate" >/dev/null
 
 echo "Controller installed from ${root} into ${app_dir}."
 echo "Configuration: ${config_path}"

--- a/deploy/install-display-node.sh
+++ b/deploy/install-display-node.sh
@@ -51,6 +51,22 @@ fi
 
 "${venv}/bin/python" -m pip install --disable-pip-version-check -e "${app_dir}"
 
+read -r startup_delay_seconds rotation_seconds rotation_jitter_seconds < <(
+  "${venv}/bin/python" - "${config_path}" <<'PY'
+import sys
+from pathlib import Path
+
+from inky_bird_frame.config import load_config
+
+schedule = load_config(Path(sys.argv[1])).schedule
+print(
+    schedule.display_startup_delay_seconds,
+    schedule.rotation_minutes * 60,
+    schedule.rotation_jitter_seconds,
+)
+PY
+)
+
 sudo tee /etc/systemd/system/inky-bird-frame-display.service >/dev/null <<UNIT
 [Unit]
 Description=Rotate the next approved Inky Bird Frame plate
@@ -66,14 +82,14 @@ ExecStart=${venv}/bin/inky-bird-frame display-cycle --config ${config_path}
 TimeoutStartSec=15min
 UNIT
 
-sudo tee /etc/systemd/system/inky-bird-frame-display.timer >/dev/null <<'UNIT'
+sudo tee /etc/systemd/system/inky-bird-frame-display.timer >/dev/null <<UNIT
 [Unit]
-Description=Rotate the Inky Bird Frame every 30 minutes
+Description=Rotate the Inky Bird Frame on its configured schedule
 
 [Timer]
-OnBootSec=2min
-OnUnitActiveSec=30min
-RandomizedDelaySec=2min
+OnBootSec=${startup_delay_seconds}s
+OnUnitActiveSec=${rotation_seconds}s
+RandomizedDelaySec=${rotation_jitter_seconds}s
 Persistent=true
 Unit=inky-bird-frame-display.service
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,19 +4,26 @@
 
 ### Controller
 
-The controller owns discovery and generation. One locked cycle:
+The controller owns discovery and generation through independent schedules.
+An observation refresh:
 
 1. resolves the private discovery location;
 2. queries iNaturalist species counts for the configured radius and window;
-3. selects taxa without a terminal local state;
-4. acquires and verifies licensed references;
-5. creates a sourced, structured species profile through Codex;
-6. generates a plate through the built-in `$imagegen` skill;
-7. prepares portrait and display assets;
-8. runs an independent, sourced Codex factual and visual review;
-9. regenerates failed reviews with corrective findings, within a configured
+3. atomically stores the private observation snapshot; and
+4. publishes a private active catalog containing only observed taxa that
+   already have approved plates.
+
+A locked generation cycle reads the latest non-stale snapshot, then:
+
+1. selects taxa without a terminal local state;
+2. acquires and verifies licensed references;
+3. creates a sourced, structured species profile through Codex;
+4. generates a plate through the built-in `$imagegen` skill;
+5. prepares portrait and display assets;
+6. runs an independent, sourced Codex factual and visual review;
+7. regenerates failed reviews with corrective findings, within a configured
    attempt limit; and
-10. atomically publishes passing output through the pending queue.
+8. atomically publishes passing output through the pending queue.
 
 The controller also exposes a read-only HTTP catalog:
 
@@ -28,15 +35,17 @@ The controller also exposes a read-only HTTP catalog:
 
 The display node does not discover birds or generate art. Each timer cycle:
 
-1. fetches the approved catalog;
-2. selects the next entry from durable local state;
+1. fetches the private active catalog;
+2. selects an entry using the configured sequential, shuffle, or
+   observation-weighted policy and durable local state;
 3. downloads the display asset;
 4. verifies its SHA-256 checksum;
 5. writes it to a local cache atomically; and
 6. updates the Inky panel before advancing state.
 
 This pull model keeps display addressing out of controller state and limits the
-node to a read-only catalog relationship.
+node to a read-only catalog relationship. If refresh, generation, or controller
+access fails, the current e-paper image remains visible.
 
 ## State model
 
@@ -53,9 +62,10 @@ eligible. There is deliberately no implicit replacement path for approved art.
 
 ## Privacy and licensing
 
-The private ZIP code and observation window influence only the queue order.
-They are not passed to image generation and are not stored in public catalog
-manifests.
+The private ZIP code and observation window influence the generation queue and
+active rotation. They are not passed to image generation and are not stored in
+public catalog manifests. Observation snapshots and counts stay in ignored
+controller state.
 
 Reference acquisition accepts only iNaturalist research-grade photos marked
 CC0 or CC BY, uses distinct observers, records attribution and source URLs, and

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -31,7 +31,9 @@ published.
 - `weighted`: random selection weighted by current observation count, without
   immediate repeats when another species is active.
 
-Display dimensions and orientation live in `[display]`. Controller and display
+Approved plates use the project's canonical 1200x1600 portrait and 1600x1200
+display assets. This geometry is a catalog contract so committed plates remain
+portable across installations using the supported panel. Controller and display
 state paths remain TOML configuration. Installer bootstrap paths, including the
 TOML path itself, remain environment variables because the installer must find
 the configuration before it can load it.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -10,14 +10,31 @@ copies its final image there. `catalog_dir` and `state_dir` must persist across
 deployments. `codex_path` must point to a Codex CLI whose `login status` reports
 a ChatGPT-authenticated session.
 
-Recommended schedule:
+Schedules are configured in `[schedule]`. Conservative starting values are:
 
 - controller HTTP service: always running;
+- observation refresh: every 15 minutes;
 - generation cycle: every six hours, one candidate per cycle;
 - display cycle: every 30 minutes.
 
-The cycle limit and `max_generation_attempts` keep subscription use bounded.
-Only a candidate that passes the independent AI review is published.
+The refresh command does not invoke Codex. `generation_minutes`,
+`generations_per_cycle`, and `max_generation_attempts` jointly bound
+subscription use. If generation takes longer than its interval, the service
+manager does not start a second copy and the generation lock also rejects
+manual overlap. Only a candidate that passes the independent AI review is
+published.
+
+`rotation_mode` is configured under `[display_node]`:
+
+- `sequential`: stable round-robin order;
+- `shuffle`: every active species once per shuffled round; or
+- `weighted`: random selection weighted by current observation count, without
+  immediate repeats when another species is active.
+
+Display dimensions and orientation live in `[display]`. Controller and display
+state paths remain TOML configuration. Installer bootstrap paths, including the
+TOML path itself, remain environment variables because the installer must find
+the configuration before it can load it.
 
 ## Maintainer deployment on macOS
 
@@ -58,8 +75,9 @@ generation quota on it.
 
 ## Failure recovery
 
-- Network or source failure: inspect `var/controller/runs/` and the JSON command
-  result. The taxon remains eligible for the next scheduled cycle.
+- Network or source failure: inspect the refresh or generation log and JSON
+  result. Generation refuses a discovery snapshot older than twice the
+  configured refresh interval.
 - Unsuitable licensed references: inspect the reference manifest and source
   pages. Retry only after deciding the source set can be improved.
 - Generated image or text defect: the controller feeds review findings into a

--- a/src/inky_bird_frame/birds.py
+++ b/src/inky_bird_frame/birds.py
@@ -79,6 +79,8 @@ def parse_inaturalist_species_counts(payload: object) -> list[BirdSpecies]:
     results = payload.get("results")
     if not isinstance(results, list):
         raise DataSourceError("iNaturalist response did not include a results list")
+    if not results:
+        return []
 
     species: list[BirdSpecies] = []
     for item in results:

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -30,9 +30,10 @@ class CatalogEntry:
     display_path: str
     display_sha256: str
     approved_at: str
+    observation_count: int | None = None
 
     def as_dict(self) -> dict[str, object]:
-        return {
+        value: dict[str, object] = {
             "taxon_id": self.taxon_id,
             "common_name": self.common_name,
             "scientific_name": self.scientific_name,
@@ -43,6 +44,9 @@ class CatalogEntry:
             "display_sha256": self.display_sha256,
             "approved_at": self.approved_at,
         }
+        if self.observation_count is not None:
+            value["observation_count"] = self.observation_count
+        return value
 
 
 def utc_now() -> str:

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -17,7 +17,12 @@ from .catalog import (
     reject_candidate,
 )
 from .config import AppConfig, load_config
-from .controller import discover_species, run_controller_cycle
+from .controller import (
+    discover_species,
+    run_controller_cycle,
+    run_generation_cycle,
+    run_refresh_cycle,
+)
 from .display import show_on_inky
 from .display_node import run_display_cycle
 from .errors import InkyBirdFrameError
@@ -77,6 +82,16 @@ def discover_command(args: argparse.Namespace) -> int:
 
 def controller_cycle_command(args: argparse.Namespace) -> int:
     print_result(run_controller_cycle(_config(args)))
+    return 0
+
+
+def refresh_command(args: argparse.Namespace) -> int:
+    print_result(run_refresh_cycle(_config(args)))
+    return 0
+
+
+def generate_command(args: argparse.Namespace) -> int:
+    print_result(run_generation_cycle(_config(args)))
     return 0
 
 
@@ -208,6 +223,20 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_config_argument(cycle_parser)
     cycle_parser.set_defaults(func=controller_cycle_command)
+
+    refresh_parser = subparsers.add_parser(
+        "refresh",
+        help="Refresh local observations and the active display catalog",
+    )
+    add_config_argument(refresh_parser)
+    refresh_parser.set_defaults(func=refresh_command)
+
+    generate_parser = subparsers.add_parser(
+        "generate",
+        help="Generate missing plates from the latest observation refresh",
+    )
+    add_config_argument(generate_parser)
+    generate_parser.set_defaults(func=generate_command)
 
     approve_parser = subparsers.add_parser("approve", help="Publish a pending candidate")
     add_config_argument(approve_parser)

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -7,13 +7,9 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 from shutil import which
-from typing import Final
 
 from .birds import ObservationWindow, parse_observation_window
 from .errors import ConfigurationError
-
-PORTRAIT_SIZE: Final = (1200, 1600)
-HARDWARE_SIZE: Final = (1600, 1200)
 
 
 class RotationMode(StrEnum):
@@ -28,13 +24,6 @@ def parse_rotation_mode(value: str) -> RotationMode:
     except ValueError as exc:
         allowed = ", ".join(item.value for item in RotationMode)
         raise ValueError(f"rotation_mode must be one of: {allowed}") from exc
-
-
-@dataclass(frozen=True)
-class DisplayConfig:
-    portrait_size: tuple[int, int] = PORTRAIT_SIZE
-    hardware_size: tuple[int, int] = HARDWARE_SIZE
-    rotation_degrees: int = 90
 
 
 @dataclass(frozen=True)
@@ -79,7 +68,6 @@ class AppConfig:
     discovery: DiscoveryConfig
     controller: ControllerConfig
     display_node: DisplayNodeConfig
-    display: DisplayConfig = DisplayConfig()
     schedule: ScheduleConfig = ScheduleConfig()
 
 
@@ -153,7 +141,6 @@ def load_config(path: Path) -> AppConfig:
     discovery = _section(raw, "discovery")
     controller = _section(raw, "controller")
     display_node = _section(raw, "display_node")
-    display = _optional_section(raw, "display")
     schedule = _optional_section(raw, "schedule")
     base_dir = path.parent.resolve()
 
@@ -179,10 +166,6 @@ def load_config(path: Path) -> AppConfig:
     except ValueError as exc:
         raise ConfigurationError(str(exc)) from exc
 
-    rotation_degrees = _optional_integer(display, "rotation_degrees", default=90, minimum=0)
-    if rotation_degrees not in (0, 90, 180, 270):
-        raise ConfigurationError("rotation_degrees must be one of: 0, 90, 180, 270")
-
     return AppConfig(
         discovery=DiscoveryConfig(
             zip_code=zip_code,
@@ -207,17 +190,6 @@ def load_config(path: Path) -> AppConfig:
             controller_url=controller_url,
             state_dir=_path(_string(display_node, "state_dir"), base_dir),
             rotation_mode=rotation_mode,
-        ),
-        display=DisplayConfig(
-            portrait_size=(
-                _optional_integer(display, "portrait_width", default=PORTRAIT_SIZE[0]),
-                _optional_integer(display, "portrait_height", default=PORTRAIT_SIZE[1]),
-            ),
-            hardware_size=(
-                _optional_integer(display, "hardware_width", default=HARDWARE_SIZE[0]),
-                _optional_integer(display, "hardware_height", default=HARDWARE_SIZE[1]),
-            ),
-            rotation_degrees=rotation_degrees,
         ),
         schedule=ScheduleConfig(
             refresh_minutes=_optional_integer(schedule, "refresh_minutes", default=15),

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import tomllib
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 from shutil import which
 from typing import Final
@@ -13,6 +14,20 @@ from .errors import ConfigurationError
 
 PORTRAIT_SIZE: Final = (1200, 1600)
 HARDWARE_SIZE: Final = (1600, 1200)
+
+
+class RotationMode(StrEnum):
+    SEQUENTIAL = "sequential"
+    SHUFFLE = "shuffle"
+    WEIGHTED = "weighted"
+
+
+def parse_rotation_mode(value: str) -> RotationMode:
+    try:
+        return RotationMode(value)
+    except ValueError as exc:
+        allowed = ", ".join(item.value for item in RotationMode)
+        raise ValueError(f"rotation_mode must be one of: {allowed}") from exc
 
 
 @dataclass(frozen=True)
@@ -47,6 +62,16 @@ class ControllerConfig:
 class DisplayNodeConfig:
     controller_url: str
     state_dir: Path
+    rotation_mode: RotationMode = RotationMode.SEQUENTIAL
+
+
+@dataclass(frozen=True)
+class ScheduleConfig:
+    refresh_minutes: int = 15
+    generation_minutes: int = 360
+    rotation_minutes: int = 30
+    rotation_jitter_seconds: int = 0
+    display_startup_delay_seconds: int = 120
 
 
 @dataclass(frozen=True)
@@ -55,6 +80,7 @@ class AppConfig:
     controller: ControllerConfig
     display_node: DisplayNodeConfig
     display: DisplayConfig = DisplayConfig()
+    schedule: ScheduleConfig = ScheduleConfig()
 
 
 def _section(data: object, name: str) -> dict[str, object]:
@@ -63,6 +89,15 @@ def _section(data: object, name: str) -> dict[str, object]:
     value = data.get(name)
     if not isinstance(value, dict):
         raise ConfigurationError(f"Missing [{name}] configuration section")
+    return value
+
+
+def _optional_section(data: object, name: str) -> dict[str, object]:
+    if not isinstance(data, dict):
+        raise ConfigurationError("Configuration root must be a TOML table")
+    value = data.get(name, {})
+    if not isinstance(value, dict):
+        raise ConfigurationError(f"[{name}] must be a TOML table")
     return value
 
 
@@ -86,6 +121,12 @@ def _optional_integer(
     if name not in section:
         return default
     return _integer(section, name, minimum=minimum)
+
+
+def _optional_string(section: dict[str, object], name: str, *, default: str) -> str:
+    if name not in section:
+        return default
+    return _string(section, name)
 
 
 def _path(value: str, base_dir: Path) -> Path:
@@ -112,6 +153,8 @@ def load_config(path: Path) -> AppConfig:
     discovery = _section(raw, "discovery")
     controller = _section(raw, "controller")
     display_node = _section(raw, "display_node")
+    display = _optional_section(raw, "display")
+    schedule = _optional_section(raw, "schedule")
     base_dir = path.parent.resolve()
 
     zip_code = _string(discovery, "zip_code")
@@ -127,6 +170,18 @@ def load_config(path: Path) -> AppConfig:
     controller_url = _string(display_node, "controller_url").rstrip("/")
     if not controller_url.startswith(("http://", "https://")):
         raise ConfigurationError("controller_url must start with http:// or https://")
+
+    rotation_mode_value = _optional_string(
+        display_node, "rotation_mode", default=RotationMode.SEQUENTIAL.value
+    )
+    try:
+        rotation_mode = parse_rotation_mode(rotation_mode_value)
+    except ValueError as exc:
+        raise ConfigurationError(str(exc)) from exc
+
+    rotation_degrees = _optional_integer(display, "rotation_degrees", default=90, minimum=0)
+    if rotation_degrees not in (0, 90, 180, 270):
+        raise ConfigurationError("rotation_degrees must be one of: 0, 90, 180, 270")
 
     return AppConfig(
         discovery=DiscoveryConfig(
@@ -151,5 +206,28 @@ def load_config(path: Path) -> AppConfig:
         display_node=DisplayNodeConfig(
             controller_url=controller_url,
             state_dir=_path(_string(display_node, "state_dir"), base_dir),
+            rotation_mode=rotation_mode,
+        ),
+        display=DisplayConfig(
+            portrait_size=(
+                _optional_integer(display, "portrait_width", default=PORTRAIT_SIZE[0]),
+                _optional_integer(display, "portrait_height", default=PORTRAIT_SIZE[1]),
+            ),
+            hardware_size=(
+                _optional_integer(display, "hardware_width", default=HARDWARE_SIZE[0]),
+                _optional_integer(display, "hardware_height", default=HARDWARE_SIZE[1]),
+            ),
+            rotation_degrees=rotation_degrees,
+        ),
+        schedule=ScheduleConfig(
+            refresh_minutes=_optional_integer(schedule, "refresh_minutes", default=15),
+            generation_minutes=_optional_integer(schedule, "generation_minutes", default=360),
+            rotation_minutes=_optional_integer(schedule, "rotation_minutes", default=30),
+            rotation_jitter_seconds=_optional_integer(
+                schedule, "rotation_jitter_seconds", default=0, minimum=0
+            ),
+            display_startup_delay_seconds=_optional_integer(
+                schedule, "display_startup_delay_seconds", default=120, minimum=0
+            ),
         ),
     )

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -74,6 +74,20 @@ def catalog_state_lock(state_dir: Path) -> Iterator[None]:
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
+@contextmanager
+def exclusive_refresh_lock(state_dir: Path) -> Iterator[None]:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    with (state_dir / "refresh.lock").open("a+") as handle:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise DataSourceError("Another observation refresh is already running") from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
 def discover_species(config: AppConfig) -> tuple[ZipLocation, list[BirdSpecies]]:
     location = lookup_us_zip(config.discovery.zip_code)
     species = fetch_inaturalist_birds(
@@ -127,20 +141,21 @@ def _write_active_catalog(config: AppConfig, species_list: list[BirdSpecies]) ->
 
 
 def run_refresh_cycle(config: AppConfig) -> dict[str, object]:
-    location, species_list = discover_species(config)
-    with catalog_state_lock(config.controller.state_dir):
-        refreshed_at = datetime.now(UTC).replace(microsecond=0)
-        write_json_atomic(
-            _snapshot_path(config),
-            {
-                "schema_version": 1,
-                "refreshed_at": refreshed_at.isoformat(),
-                "place_name": location.place_name,
-                "state": location.state,
-                "species": [_species_payload(species) for species in species_list],
-            },
-        )
-        active_count = _write_active_catalog(config, species_list)
+    with exclusive_refresh_lock(config.controller.state_dir):
+        location, species_list = discover_species(config)
+        with catalog_state_lock(config.controller.state_dir):
+            refreshed_at = datetime.now(UTC).replace(microsecond=0)
+            write_json_atomic(
+                _snapshot_path(config),
+                {
+                    "schema_version": 1,
+                    "refreshed_at": refreshed_at.isoformat(),
+                    "place_name": location.place_name,
+                    "state": location.state,
+                    "species": [_species_payload(species) for species in species_list],
+                },
+            )
+            active_count = _write_active_catalog(config, species_list)
     return {
         "refreshed_at": refreshed_at.isoformat(),
         "place_name": location.place_name,
@@ -475,7 +490,8 @@ def _is_bounded_generation(generation: object) -> bool:
 
 def run_generation_cycle(config: AppConfig) -> dict[str, object]:
     with exclusive_cycle_lock(config.controller.state_dir):
-        published = approve_passing_candidates(config)
+        with catalog_state_lock(config.controller.state_dir):
+            published = approve_passing_candidates(config)
         snapshot = _read_discovery_snapshot(config)
         maximum_age = timedelta(minutes=config.schedule.refresh_minutes * 2)
         if datetime.now(UTC) - snapshot.refreshed_at.astimezone(UTC) > maximum_age:
@@ -495,11 +511,12 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
         for species in eligible[: config.controller.generations_per_cycle]:
             try:
                 generate_candidate(config, species, config.controller.workspace_dir)
-                entry = approve_candidate(
-                    config.controller.state_dir,
-                    config.controller.catalog_dir,
-                    species.taxon_id,
-                )
+                with catalog_state_lock(config.controller.state_dir):
+                    entry = approve_candidate(
+                        config.controller.state_dir,
+                        config.controller.catalog_dir,
+                        species.taxon_id,
+                    )
                 generated.append(
                     {
                         "taxon_id": species.taxon_id,

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -7,7 +7,8 @@ import json
 import shutil
 from collections.abc import Iterator
 from contextlib import contextmanager
-from datetime import UTC, datetime
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import cast
@@ -18,6 +19,7 @@ from .catalog import (
     approved_taxon_ids,
     candidate_directory,
     find_taxon_directory,
+    rebuild_catalog_index,
     write_candidate_manifest,
     write_json_atomic,
 )
@@ -36,6 +38,14 @@ from .images import prepare_generated_plate
 from .models import ReferencePhoto
 from .prompts import PROMPT_VERSION
 from .references import download_references, fetch_reference_candidates
+
+
+@dataclass(frozen=True)
+class DiscoverySnapshot:
+    refreshed_at: datetime
+    place_name: str
+    state: str
+    species: list[BirdSpecies]
 
 
 @contextmanager
@@ -63,6 +73,128 @@ def discover_species(config: AppConfig) -> tuple[ZipLocation, list[BirdSpecies]]
         window=config.discovery.observation_window,
     )
     return location, species
+
+
+def _snapshot_path(config: AppConfig) -> Path:
+    return config.controller.state_dir / "discovery.json"
+
+
+def _active_catalog_path(config: AppConfig) -> Path:
+    return config.controller.state_dir / "active-catalog.json"
+
+
+def _species_payload(species: BirdSpecies) -> dict[str, object]:
+    return {
+        "taxon_id": species.taxon_id,
+        "common_name": species.common_name,
+        "scientific_name": species.scientific_name,
+        "observation_count": species.observation_count,
+        "source": species.source,
+    }
+
+
+def _write_active_catalog(config: AppConfig, species_list: list[BirdSpecies]) -> int:
+    approved = {
+        entry.taxon_id: entry for entry in rebuild_catalog_index(config.controller.catalog_dir)
+    }
+    active: list[dict[str, object]] = []
+    for species in species_list:
+        entry = approved.get(species.taxon_id)
+        if entry is None:
+            continue
+        value = entry.as_dict()
+        value["observation_count"] = species.observation_count
+        active.append(value)
+    write_json_atomic(
+        _active_catalog_path(config),
+        {
+            "schema_version": 1,
+            "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+            "species": active,
+        },
+    )
+    return len(active)
+
+
+def run_refresh_cycle(config: AppConfig) -> dict[str, object]:
+    location, species_list = discover_species(config)
+    refreshed_at = datetime.now(UTC).replace(microsecond=0)
+    write_json_atomic(
+        _snapshot_path(config),
+        {
+            "schema_version": 1,
+            "refreshed_at": refreshed_at.isoformat(),
+            "place_name": location.place_name,
+            "state": location.state,
+            "species": [_species_payload(species) for species in species_list],
+        },
+    )
+    active_count = _write_active_catalog(config, species_list)
+    return {
+        "refreshed_at": refreshed_at.isoformat(),
+        "place_name": location.place_name,
+        "state": location.state,
+        "window": config.discovery.observation_window.value,
+        "radius_km": config.discovery.radius_km,
+        "species_count": len(species_list),
+        "active_approved_count": active_count,
+    }
+
+
+def _read_discovery_snapshot(config: AppConfig) -> DiscoverySnapshot:
+    path = _snapshot_path(config)
+    try:
+        raw = json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise DataSourceError("Discovery state is missing; run refresh before generation") from exc
+    except json.JSONDecodeError as exc:
+        raise CatalogError(f"Invalid discovery state: {path}") from exc
+    if not isinstance(raw, dict) or raw.get("schema_version") != 1:
+        raise CatalogError(f"Unsupported discovery state: {path}")
+    refreshed_at = raw.get("refreshed_at")
+    place_name = raw.get("place_name")
+    state = raw.get("state")
+    species_raw = raw.get("species")
+    if (
+        not isinstance(refreshed_at, str)
+        or not isinstance(place_name, str)
+        or not isinstance(state, str)
+        or not isinstance(species_raw, list)
+    ):
+        raise CatalogError(f"Invalid discovery state: {path}")
+    try:
+        refreshed = datetime.fromisoformat(refreshed_at)
+    except ValueError as exc:
+        raise CatalogError(f"Invalid discovery timestamp: {path}") from exc
+    if refreshed.tzinfo is None:
+        raise CatalogError(f"Discovery timestamp has no timezone: {path}")
+
+    species: list[BirdSpecies] = []
+    for item in species_raw:
+        if not isinstance(item, dict):
+            raise CatalogError(f"Invalid species in discovery state: {path}")
+        taxon_id = item.get("taxon_id")
+        observation_count = item.get("observation_count")
+        strings = [item.get(name) for name in ("common_name", "scientific_name", "source")]
+        if (
+            not isinstance(taxon_id, int)
+            or isinstance(taxon_id, bool)
+            or not isinstance(observation_count, int)
+            or isinstance(observation_count, bool)
+            or observation_count < 0
+            or any(not isinstance(value, str) or not value for value in strings)
+        ):
+            raise CatalogError(f"Invalid species in discovery state: {path}")
+        species.append(
+            BirdSpecies(
+                taxon_id=taxon_id,
+                common_name=cast(str, strings[0]),
+                scientific_name=cast(str, strings[1]),
+                observation_count=observation_count,
+                source=cast(str, strings[2]),
+            )
+        )
+    return DiscoverySnapshot(refreshed, place_name, state, species)
 
 
 def _reference_from_dict(raw: object) -> ReferencePhoto:
@@ -181,7 +313,12 @@ def generate_candidate(config: AppConfig, species: BirdSpecies, workspace: Path)
             )
             portrait_path = attempt_dir / "portrait.png"
             display_path = attempt_dir / "display.png"
-            prepare_generated_plate(generated_path, portrait_path, display_path)
+            prepare_generated_plate(
+                generated_path,
+                portrait_path,
+                display_path,
+                config=config.display,
+            )
             generated_path.unlink()
 
             review = runner.review_plate(
@@ -330,10 +467,16 @@ def _is_bounded_generation(generation: object) -> bool:
     )
 
 
-def run_controller_cycle(config: AppConfig) -> dict[str, object]:
+def run_generation_cycle(config: AppConfig) -> dict[str, object]:
     with exclusive_cycle_lock(config.controller.state_dir):
+        snapshot = _read_discovery_snapshot(config)
+        maximum_age = timedelta(minutes=config.schedule.refresh_minutes * 2)
+        if datetime.now(UTC) - snapshot.refreshed_at.astimezone(UTC) > maximum_age:
+            raise DataSourceError(
+                "Discovery state is stale; a successful refresh is required before generation"
+            )
         published = approve_passing_candidates(config)
-        location, species_list = discover_species(config)
+        species_list = snapshot.species
         approved = approved_taxon_ids(config.controller.catalog_dir)
         eligible = [
             species
@@ -403,8 +546,9 @@ def run_controller_cycle(config: AppConfig) -> dict[str, object]:
 
         return {
             "discovery": {
-                "place_name": location.place_name,
-                "state": location.state,
+                "refreshed_at": snapshot.refreshed_at.isoformat(),
+                "place_name": snapshot.place_name,
+                "state": snapshot.state,
                 "window": config.discovery.observation_window.value,
                 "radius_km": config.discovery.radius_km,
                 "species_count": len(species_list),
@@ -415,3 +559,9 @@ def run_controller_cycle(config: AppConfig) -> dict[str, object]:
             "generated": generated,
             "failures": failures,
         }
+
+
+def run_controller_cycle(config: AppConfig) -> dict[str, object]:
+    refresh = run_refresh_cycle(config)
+    generation = run_generation_cycle(config)
+    return {**generation, "refresh": refresh}

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -94,13 +94,12 @@ def _species_payload(species: BirdSpecies) -> dict[str, object]:
 
 
 def _write_active_catalog(config: AppConfig, species_list: list[BirdSpecies]) -> int:
-    approved = {
-        entry.taxon_id: entry for entry in rebuild_catalog_index(config.controller.catalog_dir)
-    }
+    approved = rebuild_catalog_index(config.controller.catalog_dir)
+    observed = {species.taxon_id: species for species in species_list}
     active: list[dict[str, object]] = []
-    for species in species_list:
-        entry = approved.get(species.taxon_id)
-        if entry is None:
+    for entry in approved:
+        species = observed.get(entry.taxon_id)
+        if species is None:
             continue
         value = entry.as_dict()
         value["observation_count"] = species.observation_count

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -63,6 +63,17 @@ def exclusive_cycle_lock(state_dir: Path) -> Iterator[None]:
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
+@contextmanager
+def catalog_state_lock(state_dir: Path) -> Iterator[None]:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    with (state_dir / "catalog-state.lock").open("a+") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
 def discover_species(config: AppConfig) -> tuple[ZipLocation, list[BirdSpecies]]:
     location = lookup_us_zip(config.discovery.zip_code)
     species = fetch_inaturalist_birds(
@@ -117,18 +128,19 @@ def _write_active_catalog(config: AppConfig, species_list: list[BirdSpecies]) ->
 
 def run_refresh_cycle(config: AppConfig) -> dict[str, object]:
     location, species_list = discover_species(config)
-    refreshed_at = datetime.now(UTC).replace(microsecond=0)
-    write_json_atomic(
-        _snapshot_path(config),
-        {
-            "schema_version": 1,
-            "refreshed_at": refreshed_at.isoformat(),
-            "place_name": location.place_name,
-            "state": location.state,
-            "species": [_species_payload(species) for species in species_list],
-        },
-    )
-    active_count = _write_active_catalog(config, species_list)
+    with catalog_state_lock(config.controller.state_dir):
+        refreshed_at = datetime.now(UTC).replace(microsecond=0)
+        write_json_atomic(
+            _snapshot_path(config),
+            {
+                "schema_version": 1,
+                "refreshed_at": refreshed_at.isoformat(),
+                "place_name": location.place_name,
+                "state": location.state,
+                "species": [_species_payload(species) for species in species_list],
+            },
+        )
+        active_count = _write_active_catalog(config, species_list)
     return {
         "refreshed_at": refreshed_at.isoformat(),
         "place_name": location.place_name,
@@ -312,12 +324,7 @@ def generate_candidate(config: AppConfig, species: BirdSpecies, workspace: Path)
             )
             portrait_path = attempt_dir / "portrait.png"
             display_path = attempt_dir / "display.png"
-            prepare_generated_plate(
-                generated_path,
-                portrait_path,
-                display_path,
-                config=config.display,
-            )
+            prepare_generated_plate(generated_path, portrait_path, display_path)
             generated_path.unlink()
 
             review = runner.review_plate(
@@ -468,13 +475,13 @@ def _is_bounded_generation(generation: object) -> bool:
 
 def run_generation_cycle(config: AppConfig) -> dict[str, object]:
     with exclusive_cycle_lock(config.controller.state_dir):
+        published = approve_passing_candidates(config)
         snapshot = _read_discovery_snapshot(config)
         maximum_age = timedelta(minutes=config.schedule.refresh_minutes * 2)
         if datetime.now(UTC) - snapshot.refreshed_at.astimezone(UTC) > maximum_age:
             raise DataSourceError(
                 "Discovery state is stale; a successful refresh is required before generation"
             )
-        published = approve_passing_candidates(config)
         species_list = snapshot.species
         approved = approved_taxon_ids(config.controller.catalog_dir)
         eligible = [
@@ -543,7 +550,9 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                     }
                 )
 
-        active_count = _write_active_catalog(config, species_list)
+        with catalog_state_lock(config.controller.state_dir):
+            latest_snapshot = _read_discovery_snapshot(config)
+            active_count = _write_active_catalog(config, latest_snapshot.species)
         return {
             "discovery": {
                 "refreshed_at": snapshot.refreshed_at.isoformat(),

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -543,6 +543,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                     }
                 )
 
+        active_count = _write_active_catalog(config, species_list)
         return {
             "discovery": {
                 "refreshed_at": snapshot.refreshed_at.isoformat(),
@@ -553,6 +554,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 "species_count": len(species_list),
             },
             "approved_count": len(approved_taxon_ids(config.controller.catalog_dir)),
+            "active_approved_count": active_count,
             "published_pending": published,
             "eligible_count": len(eligible),
             "generated": generated,

--- a/src/inky_bird_frame/display_node.py
+++ b/src/inky_bird_frame/display_node.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import random
+from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 from urllib.parse import quote
@@ -13,6 +15,15 @@ from .config import DisplayNodeConfig
 from .display import show_on_inky
 from .errors import CatalogError
 from .http import get_bytes, get_json, write_bytes_atomic
+from .selection import select_catalog_entry
+
+
+@dataclass(frozen=True)
+class DisplayState:
+    next_index: int = 0
+    last_sha256: str = ""
+    last_taxon_id: int | None = None
+    shuffle_remaining: tuple[int, ...] = ()
 
 
 def parse_catalog_entries(payload: object) -> list[CatalogEntry]:
@@ -43,6 +54,13 @@ def parse_catalog_entries(payload: object) -> list[CatalogEntry]:
             not isinstance(value, str) for value in strings.values()
         ):
             raise CatalogError("Controller catalog entry has invalid fields")
+        observation_count = raw.get("observation_count", 1)
+        if (
+            not isinstance(observation_count, int)
+            or isinstance(observation_count, bool)
+            or observation_count < 0
+        ):
+            raise CatalogError("Controller catalog entry has invalid observation count")
         entries.append(
             CatalogEntry(
                 taxon_id=taxon_id,
@@ -54,6 +72,7 @@ def parse_catalog_entries(payload: object) -> list[CatalogEntry]:
                 display_path=cast(str, strings["display_path"]),
                 display_sha256=cast(str, strings["display_sha256"]),
                 approved_at=cast(str, strings["approved_at"]),
+                observation_count=observation_count,
             )
         )
     if not entries:
@@ -61,9 +80,9 @@ def parse_catalog_entries(payload: object) -> list[CatalogEntry]:
     return entries
 
 
-def _read_state(path: Path) -> tuple[int, str]:
+def _read_state(path: Path) -> DisplayState:
     if not path.is_file():
-        return 0, ""
+        return DisplayState()
     try:
         raw = json.loads(path.read_text())
     except json.JSONDecodeError as exc:
@@ -72,27 +91,74 @@ def _read_state(path: Path) -> tuple[int, str]:
         raise CatalogError(f"Invalid display-node state: {path}")
     next_index = raw.get("next_index", 0)
     last_sha256 = raw.get("last_sha256", "")
-    if not isinstance(next_index, int) or not isinstance(last_sha256, str):
+    last_taxon_id = raw.get("last_taxon_id")
+    shuffle_remaining = raw.get("shuffle_remaining", [])
+    if (
+        not isinstance(next_index, int)
+        or isinstance(next_index, bool)
+        or next_index < 0
+        or not isinstance(last_sha256, str)
+        or (
+            last_taxon_id is not None
+            and (not isinstance(last_taxon_id, int) or isinstance(last_taxon_id, bool))
+        )
+        or not isinstance(shuffle_remaining, list)
+        or any(not isinstance(item, int) or isinstance(item, bool) for item in shuffle_remaining)
+    ):
         raise CatalogError(f"Invalid display-node state: {path}")
-    return next_index, last_sha256
+    return DisplayState(
+        next_index=next_index,
+        last_sha256=last_sha256,
+        last_taxon_id=last_taxon_id,
+        shuffle_remaining=tuple(shuffle_remaining),
+    )
 
 
-def run_display_cycle(config: DisplayNodeConfig, *, force: bool = False) -> dict[str, object]:
+def _write_state(
+    path: Path,
+    *,
+    selected: CatalogEntry,
+    next_index: int,
+    shuffle_remaining: list[int],
+    last_sha256: str,
+) -> None:
+    write_json_atomic(
+        path,
+        {
+            "schema_version": 1,
+            "next_index": next_index,
+            "last_sha256": last_sha256,
+            "last_taxon_id": selected.taxon_id,
+            "shuffle_remaining": shuffle_remaining,
+        },
+    )
+
+
+def run_display_cycle(
+    config: DisplayNodeConfig,
+    *,
+    force: bool = False,
+    rng: random.Random | random.SystemRandom | None = None,
+) -> dict[str, object]:
     catalog_payload = get_json(f"{config.controller_url}/v1/catalog", 20.0)
     entries = parse_catalog_entries(catalog_payload)
     state_path = config.state_dir / "state.json"
-    next_index, last_sha256 = _read_state(state_path)
-    selected = entries[next_index % len(entries)]
-    following_index = (next_index + 1) % len(entries)
-    if selected.display_sha256 == last_sha256 and not force:
-        write_json_atomic(
+    state = _read_state(state_path)
+    selected, following_index, shuffle_remaining = select_catalog_entry(
+        entries,
+        config.rotation_mode,
+        next_index=state.next_index,
+        last_taxon_id=state.last_taxon_id,
+        shuffle_remaining=list(state.shuffle_remaining),
+        rng=rng,
+    )
+    if selected.display_sha256 == state.last_sha256 and not force:
+        _write_state(
             state_path,
-            {
-                "schema_version": 1,
-                "next_index": following_index,
-                "last_sha256": last_sha256,
-                "last_taxon_id": selected.taxon_id,
-            },
+            selected=selected,
+            next_index=following_index,
+            shuffle_remaining=shuffle_remaining,
+            last_sha256=state.last_sha256,
         )
         return {
             "display_update": "unchanged",
@@ -110,14 +176,12 @@ def run_display_cycle(config: DisplayNodeConfig, *, force: bool = False) -> dict
     image_path = config.state_dir / "cache" / f"{selected.taxon_id}-{actual_hash[:12]}.png"
     write_bytes_atomic(image_path, image_bytes)
     display_size = show_on_inky(image_path)
-    write_json_atomic(
+    _write_state(
         state_path,
-        {
-            "schema_version": 1,
-            "next_index": following_index,
-            "last_sha256": actual_hash,
-            "last_taxon_id": selected.taxon_id,
-        },
+        selected=selected,
+        next_index=following_index,
+        shuffle_remaining=shuffle_remaining,
+        last_sha256=actual_hash,
     )
     return {
         "display_update": "sent",

--- a/src/inky_bird_frame/images.py
+++ b/src/inky_bird_frame/images.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Final
 
-from .config import DisplayConfig
 from .errors import MissingDependencyError
 
-DEFAULT_DISPLAY_CONFIG = DisplayConfig()
+PORTRAIT_SIZE: Final = (1200, 1600)
+HARDWARE_SIZE: Final = (1600, 1200)
+ROTATION_DEGREES: Final = 90
 
 
 def slugify(value: str) -> str:
@@ -27,7 +29,6 @@ def prepare_uploaded_image(
     source_path: Path,
     output_dir: Path,
     *,
-    config: DisplayConfig = DEFAULT_DISPLAY_CONFIG,
     paper_color: tuple[int, int, int] = (238, 222, 184),
 ) -> tuple[Path, Path]:
     try:
@@ -40,20 +41,20 @@ def prepare_uploaded_image(
 
     output_dir.mkdir(parents=True, exist_ok=True)
     image = Image.open(source_path).convert("RGB")
-    portrait = Image.new("RGB", config.portrait_size, paper_color)
-    fitted = ImageOps.contain(image, config.portrait_size, Image.Resampling.LANCZOS)
+    portrait = Image.new("RGB", PORTRAIT_SIZE, paper_color)
+    fitted = ImageOps.contain(image, PORTRAIT_SIZE, Image.Resampling.LANCZOS)
     portrait.paste(
         fitted,
         (
-            (config.portrait_size[0] - fitted.width) // 2,
-            (config.portrait_size[1] - fitted.height) // 2,
+            (PORTRAIT_SIZE[0] - fitted.width) // 2,
+            (PORTRAIT_SIZE[1] - fitted.height) // 2,
         ),
     )
 
     portrait_path = output_dir / f"{source_path.stem}-portrait.png"
     display_path = output_dir / f"{source_path.stem}-display.png"
     portrait.save(portrait_path)
-    portrait.rotate(config.rotation_degrees, expand=True).save(display_path)
+    portrait.rotate(ROTATION_DEGREES, expand=True).save(display_path)
     return portrait_path, display_path
 
 
@@ -61,8 +62,6 @@ def prepare_generated_plate(
     source_path: Path,
     portrait_path: Path,
     display_path: Path,
-    *,
-    config: DisplayConfig = DEFAULT_DISPLAY_CONFIG,
 ) -> None:
     try:
         from PIL import Image, ImageOps
@@ -74,14 +73,12 @@ def prepare_generated_plate(
     with Image.open(source_path) as source:
         image = ImageOps.fit(
             source.convert("RGB"),
-            config.portrait_size,
+            PORTRAIT_SIZE,
             method=Image.Resampling.LANCZOS,
         )
         portrait_path.parent.mkdir(parents=True, exist_ok=True)
         image.save(portrait_path, format="PNG")
-        display = image.rotate(config.rotation_degrees, expand=True)
-        if display.size != config.hardware_size:
-            raise ValueError(
-                f"rotated image size {display.size} does not match {config.hardware_size}"
-            )
+        display = image.rotate(ROTATION_DEGREES, expand=True)
+        if display.size != HARDWARE_SIZE:
+            raise ValueError(f"rotated image size {display.size} does not match {HARDWARE_SIZE}")
         display.save(display_path, format="PNG")

--- a/src/inky_bird_frame/selection.py
+++ b/src/inky_bird_frame/selection.py
@@ -1,8 +1,12 @@
-"""Species selection policies."""
+"""Species and display rotation selection policies."""
 
 from __future__ import annotations
 
+import random
+
 from .birds import BirdSpecies
+from .catalog import CatalogEntry
+from .config import RotationMode
 
 
 def select_rotating_species(species: list[BirdSpecies], step: int = 0) -> BirdSpecies:
@@ -11,3 +15,41 @@ def select_rotating_species(species: list[BirdSpecies], step: int = 0) -> BirdSp
     if step < 0:
         raise ValueError("step must be zero or greater")
     return species[step % len(species)]
+
+
+def select_catalog_entry(
+    entries: list[CatalogEntry],
+    mode: RotationMode,
+    *,
+    next_index: int,
+    last_taxon_id: int | None,
+    shuffle_remaining: list[int],
+    rng: random.Random | random.SystemRandom | None = None,
+) -> tuple[CatalogEntry, int, list[int]]:
+    if not entries:
+        raise ValueError("catalog entries must not be empty")
+    if next_index < 0:
+        raise ValueError("next_index must be zero or greater")
+
+    if mode is RotationMode.SEQUENTIAL:
+        selected = entries[next_index % len(entries)]
+        return selected, (next_index + 1) % len(entries), []
+
+    random_source = rng or random.SystemRandom()
+    by_taxon = {entry.taxon_id: entry for entry in entries}
+    candidates = [entry for entry in entries if entry.taxon_id != last_taxon_id] or entries
+
+    if mode is RotationMode.WEIGHTED:
+        selected = random_source.choices(
+            candidates,
+            weights=[max(entry.observation_count or 1, 1) for entry in candidates],
+            k=1,
+        )[0]
+        return selected, next_index, []
+
+    remaining = [taxon_id for taxon_id in shuffle_remaining if taxon_id in by_taxon]
+    if not remaining:
+        remaining = [entry.taxon_id for entry in candidates]
+        random_source.shuffle(remaining)
+    selected = by_taxon[remaining.pop(0)]
+    return selected, next_index, remaining

--- a/src/inky_bird_frame/selection.py
+++ b/src/inky_bird_frame/selection.py
@@ -49,7 +49,9 @@ def select_catalog_entry(
 
     remaining = [taxon_id for taxon_id in shuffle_remaining if taxon_id in by_taxon]
     if not remaining:
-        remaining = [entry.taxon_id for entry in candidates]
+        remaining = list(by_taxon)
         random_source.shuffle(remaining)
+        if len(remaining) > 1 and remaining[0] == last_taxon_id:
+            remaining[0], remaining[1] = remaining[1], remaining[0]
     selected = by_taxon[remaining.pop(0)]
     return selected, next_index, remaining

--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -62,7 +62,7 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
                     {"ok": False, "error": "active catalog unavailable", "schema_version": 1},
                 )
                 return
-            self._send_file(self.active_catalog_path)
+            self._send_json(HTTPStatus.OK, read_json(self.active_catalog_path))
             return
         prefix = "/v1/assets/"
         if request_path.startswith(prefix):

--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -9,12 +9,13 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import unquote, urlsplit
 
-from .catalog import rebuild_catalog_index
+from .catalog import read_json, rebuild_catalog_index
 from .config import ControllerConfig
 
 
 class CatalogRequestHandler(BaseHTTPRequestHandler):
     catalog_dir: Path
+    active_catalog_path: Path
 
     def _send_json(self, status: HTTPStatus, payload: object) -> None:
         body = json.dumps(payload, sort_keys=True).encode()
@@ -39,14 +40,29 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
         request_path = urlsplit(self.path).path
         if request_path == "/health":
             entries = rebuild_catalog_index(self.catalog_dir)
+            active_count = 0
+            if self.active_catalog_path.is_file():
+                active = read_json(self.active_catalog_path)
+                if isinstance(active, dict) and isinstance(active.get("species"), list):
+                    active_count = len(active["species"])
             self._send_json(
                 HTTPStatus.OK,
-                {"ok": True, "approved_species": len(entries), "schema_version": 1},
+                {
+                    "ok": True,
+                    "approved_species": len(entries),
+                    "active_species": active_count,
+                    "schema_version": 1,
+                },
             )
             return
         if request_path == "/v1/catalog":
-            rebuild_catalog_index(self.catalog_dir)
-            self._send_file(self.catalog_dir / "index.json")
+            if not self.active_catalog_path.is_file():
+                self._send_json(
+                    HTTPStatus.SERVICE_UNAVAILABLE,
+                    {"ok": False, "error": "active catalog unavailable", "schema_version": 1},
+                )
+                return
+            self._send_file(self.active_catalog_path)
             return
         prefix = "/v1/assets/"
         if request_path.startswith(prefix):
@@ -75,7 +91,10 @@ def serve_catalog(config: ControllerConfig) -> None:
     handler = type(
         "ConfiguredCatalogRequestHandler",
         (CatalogRequestHandler,),
-        {"catalog_dir": config.catalog_dir},
+        {
+            "catalog_dir": config.catalog_dir,
+            "active_catalog_path": config.state_dir / "active-catalog.json",
+        },
     )
     server = ThreadingHTTPServer((config.bind_host, config.port), handler)
     try:

--- a/tests/test_birds.py
+++ b/tests/test_birds.py
@@ -43,6 +43,9 @@ class InaturalistParsingTests(unittest.TestCase):
         with self.assertRaises(DataSourceError):
             parse_inaturalist_species_counts({"results": [{"taxon": {}}]})
 
+    def test_parse_species_counts_accepts_an_empty_result_set(self) -> None:
+        self.assertEqual(parse_inaturalist_species_counts({"results": []}), [])
+
     def test_date_range_for_window(self) -> None:
         today = date(2026, 7, 9)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,13 +32,6 @@ controller_url = "http://controller.test:8793/"
 state_dir = "var/display"
 rotation_mode = "weighted"
 
-[display]
-portrait_width = 1000
-portrait_height = 1400
-hardware_width = 1400
-hardware_height = 1000
-rotation_degrees = 270
-
 [schedule]
 refresh_minutes = 15
 generation_minutes = 5
@@ -62,9 +55,6 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(config.controller.max_generation_attempts, 3)
         self.assertEqual(config.display_node.controller_url, "http://controller.test:8793")
         self.assertEqual(config.display_node.rotation_mode, RotationMode.WEIGHTED)
-        self.assertEqual(config.display.portrait_size, (1000, 1400))
-        self.assertEqual(config.display.hardware_size, (1400, 1000))
-        self.assertEqual(config.display.rotation_degrees, 270)
         self.assertEqual(config.schedule.refresh_minutes, 15)
         self.assertEqual(config.schedule.generation_minutes, 5)
         self.assertEqual(config.schedule.rotation_minutes, 3)
@@ -107,8 +97,8 @@ class ConfigTests(unittest.TestCase):
 
         self.assertEqual(config.controller.codex_path, (Path(temporary) / "codex").resolve())
 
-    def test_uses_backward_compatible_schedule_and_display_defaults(self) -> None:
-        legacy = CONFIG.split("\n[display]\n", maxsplit=1)[0].replace(
+    def test_uses_backward_compatible_schedule_defaults(self) -> None:
+        legacy = CONFIG.split("\n[schedule]\n", maxsplit=1)[0].replace(
             'rotation_mode = "weighted"\n', ""
         )
         with TemporaryDirectory() as temporary:
@@ -118,8 +108,6 @@ class ConfigTests(unittest.TestCase):
             config = load_config(path)
 
         self.assertEqual(config.display_node.rotation_mode, RotationMode.SEQUENTIAL)
-        self.assertEqual(config.display.portrait_size, (1200, 1600))
-        self.assertEqual(config.display.hardware_size, (1600, 1200))
         self.assertEqual(config.schedule.refresh_minutes, 15)
         self.assertEqual(config.schedule.generation_minutes, 360)
         self.assertEqual(config.schedule.rotation_minutes, 30)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from inky_bird_frame.birds import ObservationWindow
-from inky_bird_frame.config import load_config
+from inky_bird_frame.config import RotationMode, load_config
 from inky_bird_frame.errors import ConfigurationError
 
 CONFIG = """
@@ -30,6 +30,21 @@ max_generation_attempts = 3
 [display_node]
 controller_url = "http://controller.test:8793/"
 state_dir = "var/display"
+rotation_mode = "weighted"
+
+[display]
+portrait_width = 1000
+portrait_height = 1400
+hardware_width = 1400
+hardware_height = 1000
+rotation_degrees = 270
+
+[schedule]
+refresh_minutes = 15
+generation_minutes = 5
+rotation_minutes = 3
+rotation_jitter_seconds = 7
+display_startup_delay_seconds = 30
 """
 
 
@@ -46,6 +61,15 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(config.controller.catalog_dir, (Path(temporary) / "catalog").resolve())
         self.assertEqual(config.controller.max_generation_attempts, 3)
         self.assertEqual(config.display_node.controller_url, "http://controller.test:8793")
+        self.assertEqual(config.display_node.rotation_mode, RotationMode.WEIGHTED)
+        self.assertEqual(config.display.portrait_size, (1000, 1400))
+        self.assertEqual(config.display.hardware_size, (1400, 1000))
+        self.assertEqual(config.display.rotation_degrees, 270)
+        self.assertEqual(config.schedule.refresh_minutes, 15)
+        self.assertEqual(config.schedule.generation_minutes, 5)
+        self.assertEqual(config.schedule.rotation_minutes, 3)
+        self.assertEqual(config.schedule.rotation_jitter_seconds, 7)
+        self.assertEqual(config.schedule.display_startup_delay_seconds, 30)
 
     def test_rejects_invalid_zip(self) -> None:
         with TemporaryDirectory() as temporary:
@@ -82,6 +106,31 @@ class ConfigTests(unittest.TestCase):
             config = load_config(path)
 
         self.assertEqual(config.controller.codex_path, (Path(temporary) / "codex").resolve())
+
+    def test_uses_backward_compatible_schedule_and_display_defaults(self) -> None:
+        legacy = CONFIG.split("\n[display]\n", maxsplit=1)[0].replace(
+            'rotation_mode = "weighted"\n', ""
+        )
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(legacy)
+
+            config = load_config(path)
+
+        self.assertEqual(config.display_node.rotation_mode, RotationMode.SEQUENTIAL)
+        self.assertEqual(config.display.portrait_size, (1200, 1600))
+        self.assertEqual(config.display.hardware_size, (1600, 1200))
+        self.assertEqual(config.schedule.refresh_minutes, 15)
+        self.assertEqual(config.schedule.generation_minutes, 360)
+        self.assertEqual(config.schedule.rotation_minutes, 30)
+
+    def test_rejects_invalid_rotation_policy(self) -> None:
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(CONFIG.replace('rotation_mode = "weighted"', 'rotation_mode = "chaos"'))
+
+            with self.assertRaises(ConfigurationError):
+                load_config(path)
 
 
 if __name__ == "__main__":

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -230,14 +230,17 @@ class ControllerTests(unittest.TestCase):
             )
             with patch(
                 "inky_bird_frame.controller.discover_species",
-                return_value=(location, []),
+                return_value=(location, [species]),
             ):
                 result = run_controller_cycle(config)
 
             published = (config.controller.catalog_dir / "species/9083-northern-cardinal").is_dir()
+            active = json.loads((config.controller.state_dir / "active-catalog.json").read_text())
 
         self.assertTrue(published)
         self.assertEqual(result["approved_count"], 1)
+        self.assertEqual(result["active_approved_count"], 1)
+        self.assertEqual([item["taxon_id"] for item in active["species"]], [9083])
         published_pending = result["published_pending"]
         self.assertIsInstance(published_pending, list)
         if isinstance(published_pending, list):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -131,6 +131,44 @@ class ControllerTests(unittest.TestCase):
         self.assertNotIn("zip_code", active)
         self.assertEqual(len(snapshot["species"]), 2)
 
+    def test_refresh_preserves_approved_catalog_order(self) -> None:
+        first = BirdSpecies(1, "Alpha Bird", "Alpha avis", 2, "iNaturalist")
+        second = BirdSpecies(2, "Beta Bird", "Beta avis", 9, "iNaturalist")
+        location = ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        approved = [
+            CatalogEntry(
+                species.taxon_id,
+                species.common_name,
+                species.scientific_name,
+                species.common_name.lower().replace(" ", "-"),
+                f"species/{species.taxon_id}/portrait.png",
+                "a" * 64,
+                f"species/{species.taxon_id}/display.png",
+                "b" * 64,
+                "2026-07-09T00:00:00+00:00",
+            )
+            for species in (first, second)
+        ]
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            with (
+                patch(
+                    "inky_bird_frame.controller.discover_species",
+                    return_value=(location, [second, first]),
+                ),
+                patch(
+                    "inky_bird_frame.controller.rebuild_catalog_index",
+                    return_value=approved,
+                ),
+            ):
+                run_refresh_cycle(config)
+            active = json.loads((config.controller.state_dir / "active-catalog.json").read_text())
+
+        self.assertEqual([item["taxon_id"] for item in active["species"]], [1, 2])
+        self.assertEqual([item["observation_count"] for item in active["species"]], [2, 9])
+
     def test_transient_source_failure_remains_eligible(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
         location = ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import unittest
+from datetime import UTC, datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -10,6 +11,7 @@ from inky_bird_frame.birds import BirdSpecies
 from inky_bird_frame.catalog import CatalogEntry, candidate_directory, write_candidate_manifest
 from inky_bird_frame.config import load_config
 from inky_bird_frame.controller import (
+    DiscoverySnapshot,
     generate_candidate,
     run_controller_cycle,
     run_generation_cycle,
@@ -67,6 +69,62 @@ state_dir = "display"
 
 
 class ControllerTests(unittest.TestCase):
+    def test_generation_recovers_pending_before_requiring_discovery(self) -> None:
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            recovered: list[str] = []
+
+            def approve(_config: object) -> list[dict[str, object]]:
+                recovered.append("approved")
+                return []
+
+            with (
+                patch(
+                    "inky_bird_frame.controller.approve_passing_candidates",
+                    side_effect=approve,
+                ),
+                patch(
+                    "inky_bird_frame.controller._read_discovery_snapshot",
+                    side_effect=DataSourceError("missing"),
+                ),
+                self.assertRaisesRegex(DataSourceError, "missing"),
+            ):
+                run_generation_cycle(config)
+
+        self.assertEqual(recovered, ["approved"])
+
+    def test_generation_rebuilds_active_catalog_from_latest_snapshot(self) -> None:
+        initial = DiscoverySnapshot(
+            datetime.now(UTC),
+            "Exampleville",
+            "XY",
+            [BirdSpecies(1, "Alpha Bird", "Alpha avis", 1, "iNaturalist")],
+        )
+        latest = DiscoverySnapshot(
+            datetime.now(UTC),
+            "Exampleville",
+            "XY",
+            [BirdSpecies(2, "Beta Bird", "Beta avis", 4, "iNaturalist")],
+        )
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            with (
+                patch("inky_bird_frame.controller.approve_passing_candidates", return_value=[]),
+                patch(
+                    "inky_bird_frame.controller._read_discovery_snapshot",
+                    side_effect=[initial, latest],
+                ),
+                patch("inky_bird_frame.controller._has_terminal_state", return_value=True),
+                patch("inky_bird_frame.controller._write_active_catalog", return_value=0) as write,
+            ):
+                run_generation_cycle(config)
+
+        write.assert_called_once_with(config, latest.species)
+
     def test_generation_rejects_a_stale_discovery_snapshot(self) -> None:
         with TemporaryDirectory() as temporary:
             config_path = Path(temporary) / "config.toml"
@@ -345,7 +403,7 @@ class ControllerTests(unittest.TestCase):
             def review_plate(self, *_args: object) -> QualityReview:
                 return next(self.reviews)
 
-        def prepare(_source: Path, portrait: Path, display: Path, *, config: object) -> None:
+        def prepare(_source: Path, portrait: Path, display: Path) -> None:
             portrait.write_bytes(b"portrait")
             display.write_bytes(b"display")
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -12,6 +12,7 @@ from inky_bird_frame.catalog import CatalogEntry, candidate_directory, write_can
 from inky_bird_frame.config import load_config
 from inky_bird_frame.controller import (
     DiscoverySnapshot,
+    exclusive_refresh_lock,
     generate_candidate,
     run_controller_cycle,
     run_generation_cycle,
@@ -69,6 +70,20 @@ state_dir = "display"
 
 
 class ControllerTests(unittest.TestCase):
+    def test_overlapping_refresh_is_rejected_before_discovery(self) -> None:
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            with (
+                exclusive_refresh_lock(config.controller.state_dir),
+                patch("inky_bird_frame.controller.discover_species") as discover,
+                self.assertRaisesRegex(DataSourceError, "already running"),
+            ):
+                run_refresh_cycle(config)
+
+        discover.assert_not_called()
+
     def test_generation_recovers_pending_before_requiring_discovery(self) -> None:
         with TemporaryDirectory() as temporary:
             config_path = Path(temporary) / "config.toml"

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -7,9 +7,14 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from inky_bird_frame.birds import BirdSpecies
-from inky_bird_frame.catalog import candidate_directory, write_candidate_manifest
+from inky_bird_frame.catalog import CatalogEntry, candidate_directory, write_candidate_manifest
 from inky_bird_frame.config import load_config
-from inky_bird_frame.controller import generate_candidate, run_controller_cycle
+from inky_bird_frame.controller import (
+    generate_candidate,
+    run_controller_cycle,
+    run_generation_cycle,
+    run_refresh_cycle,
+)
 from inky_bird_frame.errors import (
     CatalogError,
     DataSourceError,
@@ -62,6 +67,70 @@ state_dir = "display"
 
 
 class ControllerTests(unittest.TestCase):
+    def test_generation_rejects_a_stale_discovery_snapshot(self) -> None:
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            (config.controller.state_dir / "discovery.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "refreshed_at": "2000-01-01T00:00:00+00:00",
+                        "place_name": "Exampleville",
+                        "state": "XY",
+                        "species": [],
+                    }
+                )
+            )
+
+            with self.assertRaisesRegex(DataSourceError, "stale"):
+                run_generation_cycle(config)
+
+    def test_refresh_writes_only_observed_approved_species_to_private_active_catalog(
+        self,
+    ) -> None:
+        observed = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 9, "iNaturalist")
+        unapproved = BirdSpecies(
+            7513, "Carolina Wren", "Thryothorus ludovicianus", 4, "iNaturalist"
+        )
+        location = ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        approved = CatalogEntry(
+            12942,
+            "Eastern Bluebird",
+            "Sialia sialis",
+            "eastern-bluebird",
+            "species/12942/portrait.png",
+            "a" * 64,
+            "species/12942/display.png",
+            "b" * 64,
+            "2026-07-09T00:00:00+00:00",
+        )
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            with (
+                patch(
+                    "inky_bird_frame.controller.discover_species",
+                    return_value=(location, [observed, unapproved]),
+                ),
+                patch(
+                    "inky_bird_frame.controller.rebuild_catalog_index",
+                    return_value=[approved],
+                ),
+            ):
+                result = run_refresh_cycle(config)
+            active = json.loads((config.controller.state_dir / "active-catalog.json").read_text())
+            snapshot = json.loads((config.controller.state_dir / "discovery.json").read_text())
+
+        self.assertEqual(result["active_approved_count"], 1)
+        self.assertEqual(active["species"][0]["taxon_id"], 12942)
+        self.assertEqual(active["species"][0]["observation_count"], 9)
+        self.assertNotIn("zip_code", active)
+        self.assertEqual(len(snapshot["species"]), 2)
+
     def test_transient_source_failure_remains_eligible(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
         location = ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0)
@@ -235,7 +304,7 @@ class ControllerTests(unittest.TestCase):
             def review_plate(self, *_args: object) -> QualityReview:
                 return next(self.reviews)
 
-        def prepare(_source: Path, portrait: Path, display: Path) -> None:
+        def prepare(_source: Path, portrait: Path, display: Path, *, config: object) -> None:
             portrait.write_bytes(b"portrait")
             display.write_bytes(b"display")
 

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import unittest
 
-from inky_bird_frame.config import DisplayConfig
-from inky_bird_frame.images import slugify
+from inky_bird_frame.images import HARDWARE_SIZE, PORTRAIT_SIZE, ROTATION_DEGREES, slugify
 
 
 class ImageHelperTests(unittest.TestCase):
@@ -11,12 +10,10 @@ class ImageHelperTests(unittest.TestCase):
         self.assertEqual(slugify("Eastern Bluebird"), "eastern-bluebird")
         self.assertEqual(slugify("Sialia sialis!"), "sialia-sialis")
 
-    def test_display_config_matches_inky_panel(self) -> None:
-        config = DisplayConfig()
-
-        self.assertEqual(config.portrait_size, (1200, 1600))
-        self.assertEqual(config.hardware_size, (1600, 1200))
-        self.assertEqual(config.rotation_degrees, 90)
+    def test_canonical_assets_match_inky_panel(self) -> None:
+        self.assertEqual(PORTRAIT_SIZE, (1200, 1600))
+        self.assertEqual(HARDWARE_SIZE, (1600, 1200))
+        self.assertEqual(ROTATION_DEGREES, 90)
 
 
 if __name__ == "__main__":

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,9 +1,27 @@
 from __future__ import annotations
 
+import random
 import unittest
 
 from inky_bird_frame.birds import BirdSpecies
-from inky_bird_frame.selection import select_rotating_species
+from inky_bird_frame.catalog import CatalogEntry
+from inky_bird_frame.config import RotationMode
+from inky_bird_frame.selection import select_catalog_entry, select_rotating_species
+
+
+def catalog_entry(taxon_id: int, count: int) -> CatalogEntry:
+    return CatalogEntry(
+        taxon_id=taxon_id,
+        common_name=f"Bird {taxon_id}",
+        scientific_name=f"Species {taxon_id}",
+        slug=f"bird-{taxon_id}",
+        portrait_path=f"{taxon_id}/portrait.png",
+        portrait_sha256="a" * 64,
+        display_path=f"{taxon_id}/display.png",
+        display_sha256="b" * 64,
+        approved_at="2026-07-09T00:00:00+00:00",
+        observation_count=count,
+    )
 
 
 class SelectionTests(unittest.TestCase):
@@ -22,6 +40,40 @@ class SelectionTests(unittest.TestCase):
             select_rotating_species([])
         with self.assertRaises(ValueError):
             select_rotating_species([BirdSpecies(1, "A", "B", 1, "test")], -1)
+
+    def test_shuffle_visits_each_entry_before_repeating(self) -> None:
+        entries = [catalog_entry(1, 10), catalog_entry(2, 5), catalog_entry(3, 1)]
+        rng = random.Random(7)
+        remaining: list[int] = []
+        selected_ids: list[int] = []
+        last_taxon_id: int | None = None
+        for _ in entries:
+            selected, _, remaining = select_catalog_entry(
+                entries,
+                RotationMode.SHUFFLE,
+                next_index=0,
+                last_taxon_id=last_taxon_id,
+                shuffle_remaining=remaining,
+                rng=rng,
+            )
+            selected_ids.append(selected.taxon_id)
+            last_taxon_id = selected.taxon_id
+
+        self.assertEqual(set(selected_ids), {1, 2, 3})
+        self.assertEqual(remaining, [])
+
+    def test_weighted_selection_uses_observation_counts_and_avoids_repeat(self) -> None:
+        entries = [catalog_entry(1, 10), catalog_entry(2, 3)]
+        selected, _, _ = select_catalog_entry(
+            entries,
+            RotationMode.WEIGHTED,
+            next_index=0,
+            last_taxon_id=1,
+            shuffle_remaining=[],
+            rng=random.Random(2),
+        )
+
+        self.assertEqual(selected.taxon_id, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -62,6 +62,30 @@ class SelectionTests(unittest.TestCase):
         self.assertEqual(set(selected_ids), {1, 2, 3})
         self.assertEqual(remaining, [])
 
+    def test_shuffle_refill_includes_every_entry_without_immediate_repeat(self) -> None:
+        entries = [catalog_entry(1, 10), catalog_entry(2, 5), catalog_entry(3, 1)]
+        rng = random.Random(7)
+        remaining: list[int] = []
+        selected_ids: list[int] = []
+        last_taxon_id: int | None = None
+        for _ in range(len(entries) * 2):
+            selected, _, remaining = select_catalog_entry(
+                entries,
+                RotationMode.SHUFFLE,
+                next_index=0,
+                last_taxon_id=last_taxon_id,
+                shuffle_remaining=remaining,
+                rng=rng,
+            )
+            selected_ids.append(selected.taxon_id)
+            last_taxon_id = selected.taxon_id
+
+        self.assertEqual(set(selected_ids[:3]), {1, 2, 3})
+        self.assertEqual(set(selected_ids[3:]), {1, 2, 3})
+        self.assertTrue(
+            all(left != right for left, right in zip(selected_ids, selected_ids[1:], strict=False))
+        )
+
     def test_weighted_selection_uses_observation_counts_and_avoids_repeat(self) -> None:
         entries = [catalog_entry(1, 10), catalog_entry(2, 3)]
         selected, _, _ = select_catalog_entry(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import threading
+import unittest
+from http.client import HTTPConnection
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from inky_bird_frame.server import CatalogRequestHandler
+
+
+class ServerTests(unittest.TestCase):
+    def test_active_catalog_is_not_cached_as_an_immutable_asset(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            catalog_dir = root / "catalog"
+            catalog_dir.mkdir()
+            active_catalog_path = root / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps({"schema_version": 1, "species": []}))
+            handler = type(
+                "TestCatalogRequestHandler",
+                (CatalogRequestHandler,),
+                {
+                    "catalog_dir": catalog_dir,
+                    "active_catalog_path": active_catalog_path,
+                },
+            )
+            server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+            thread = threading.Thread(target=server.serve_forever)
+            thread.start()
+            try:
+                connection = HTTPConnection("127.0.0.1", server.server_port, timeout=5)
+                connection.request("GET", "/v1/catalog")
+                response = connection.getresponse()
+                response.read()
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join()
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.getheader("Cache-Control"), "no-store")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- separate observation refresh, image generation, and display rotation schedules
- add sequential, shuffle, and observation-weighted rotation policies
- publish only approved species active in the private observation window
- make display geometry and service timing configurable

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest` (74 passed)
- `shellcheck deploy/*.sh`
- `actionlint`
- `git diff --check`