### PR TITLE
Automate trusted public catalog publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ flowchart LR
     B --> C["Facts + licensed references"]
     C --> D["Field-journal plate"]
     D --> E{"Independent AI review"}
-    E -->|pass| F["Immutable public catalog"]
+    E -->|pass| F["Approved local catalog"]
     E -->|revise| D
     F --> G["Active local rotation"]
     G --> H["E-paper display"]
+    F --> I["Validated asynchronous publish"]
+    I --> J["Reusable public catalog"]
 ```
 
 The system has two deliberately small roles:
@@ -124,6 +126,10 @@ uv run inky-bird-frame status --config config.toml
 # Serve the catalog and rotate the next approved plate.
 uv run inky-bird-frame serve --config config.toml
 uv run inky-bird-frame display-cycle --config config.toml
+
+# Preview or run asynchronous publication to a dedicated public catalog.
+uv run inky-bird-frame catalog-publish --config config.toml --dry-run
+uv run inky-bird-frame catalog-publish --config config.toml
 ```
 
 Observation windows are `last-day`, `last-week`, `last-30-days`, and
@@ -147,6 +153,12 @@ Every approved species lives under `catalog/species/<taxon-id>-<slug>/`:
 Downloaded source photographs, run logs, pending work, rejected work, and
 display state stay under ignored runtime storage. Reference licenses and source
 URLs remain recorded without redistributing the source bitmaps.
+
+Public catalog publication is optional and independent of the live display.
+The publisher accepts only new immutable taxa whose manifests, reviews,
+checksums, image dimensions, and privacy constraints validate. It pushes them
+to a separately configured Git repository without routing generated content
+through the application's code-review gates.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ flowchart LR
     E -->|revise| D
     F --> G["Active local rotation"]
     G --> H["E-paper display"]
-    F --> I["Validated asynchronous publish"]
-    I --> J["Reusable public catalog"]
+    F --> I["Validated catalog-only PR"]
+    I --> J["Reusable project catalog"]
 ```
 
 The system has two deliberately small roles:
@@ -120,6 +120,9 @@ uv run inky-bird-frame refresh --config config.toml
 # Generate and AI-review missing plates from the latest refresh.
 uv run inky-bird-frame generate --config config.toml
 
+# Queue a broader one-time set without changing the active display window.
+uv run inky-bird-frame seed --config config.toml --window last-year --species-limit 500
+
 # Inspect approved, pending, and failed work.
 uv run inky-bird-frame status --config config.toml
 
@@ -127,13 +130,13 @@ uv run inky-bird-frame status --config config.toml
 uv run inky-bird-frame serve --config config.toml
 uv run inky-bird-frame display-cycle --config config.toml
 
-# Preview or run asynchronous publication to a dedicated public catalog.
+# Preview or run owner-only publication into this repository's catalog.
 uv run inky-bird-frame catalog-publish --config config.toml --dry-run
 uv run inky-bird-frame catalog-publish --config config.toml
 ```
 
-Observation windows are `last-day`, `last-week`, `last-30-days`, and
-`all-time`. Discovery distance is configured in kilometers with `radius_km`.
+Observation windows are `last-day`, `last-week`, `last-30-days`, `last-year`,
+and `all-time`. Discovery distance is configured in kilometers with `radius_km`.
 Rotation modes are `sequential`, `shuffle`, and `weighted`. Shuffle visits every
 active bird before repeating; weighted selection uses local observation counts
 and avoids displaying the same bird twice in succession when alternatives are
@@ -154,11 +157,12 @@ Downloaded source photographs, run logs, pending work, rejected work, and
 display state stay under ignored runtime storage. Reference licenses and source
 URLs remain recorded without redistributing the source bitmaps.
 
-Public catalog publication is optional and independent of the live display.
-The publisher accepts only new immutable taxa whose manifests, reviews,
-checksums, image dimensions, and privacy constraints validate. It pushes them
-to a separately configured Git repository without routing generated content
-through the application's code-review gates.
+Catalog publication is optional and independent of the live display. The
+publisher accepts only new immutable taxa whose manifests, reviews, checksums,
+image dimensions, and privacy constraints validate. A trusted controller opens
+a catalog-only PR in this repository, verifies the exact staged paths, and uses
+the authenticated repository owner's ruleset bypass to merge it. External PRs
+and GitHub-hosted workflows never receive that credential.
 
 ## Development
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -25,6 +25,17 @@ state_dir = "var/display-node"
 # repeating, and weighted uses local observation counts as selection weights.
 rotation_mode = "shuffle"
 
+[public_catalog]
+# Publishing is independent of generation and never delays the display.
+enabled = false
+# Clone a dedicated public catalog repository here, then enable publishing.
+# checkout_dir = "var/public-catalog"
+remote = "origin"
+branch = "main"
+# Git commit identity only; authentication belongs in the checkout's Git configuration.
+commit_name = "Inky Bird Frame Catalog"
+commit_email = "inky-bird-frame@users.noreply.github.com"
+
 [schedule]
 refresh_minutes = 15
 # Generation can consume substantial Codex usage. Start conservatively.
@@ -32,3 +43,4 @@ generation_minutes = 360
 rotation_minutes = 30
 rotation_jitter_seconds = 0
 display_startup_delay_seconds = 120
+catalog_publish_minutes = 5

--- a/config.example.toml
+++ b/config.example.toml
@@ -26,12 +26,15 @@ state_dir = "var/display-node"
 rotation_mode = "shuffle"
 
 [public_catalog]
+# The trusted controller opens and owner-merges catalog-only PRs in this repository.
 # Publishing is independent of generation and never delays the display.
 enabled = false
-# Clone a dedicated public catalog repository here, then enable publishing.
-# checkout_dir = "var/public-catalog"
+# Clone this project repository into a writable controller-only checkout.
+# checkout_dir = "var/source-repository"
+# repository = "owner/inky-bird-frame"
+gh_path = "gh"
 remote = "origin"
-branch = "main"
+base_branch = "main"
 # Git commit identity only; authentication belongs in the checkout's Git configuration.
 commit_name = "Inky Bird Frame Catalog"
 commit_email = "inky-bird-frame@users.noreply.github.com"

--- a/deploy/install-controller.sh
+++ b/deploy/install-controller.sh
@@ -17,6 +17,7 @@ agents_dir="${HOME}/Library/LaunchAgents"
 serve_plist="${agents_dir}/com.inky-bird-frame.serve.plist"
 refresh_plist="${agents_dir}/com.inky-bird-frame.refresh.plist"
 generation_plist="${agents_dir}/com.inky-bird-frame.generate.plist"
+catalog_publish_plist="${agents_dir}/com.inky-bird-frame.catalog-publish.plist"
 legacy_cycle_plist="${agents_dir}/com.inky-bird-frame.controller-cycle.plist"
 
 if [ ! -f "${config_path}" ]; then
@@ -38,7 +39,7 @@ done
 "${uv_bin}" sync --project "${app_dir}" --python "${python_version}" --locked
 
 "${app_dir}/.venv/bin/python" - \
-  "${serve_plist}" "${refresh_plist}" "${generation_plist}" \
+  "${serve_plist}" "${refresh_plist}" "${generation_plist}" "${catalog_publish_plist}" \
   "${app_dir}" "${config_path}" "${log_dir}" <<'PY'
 import plistlib
 import sys
@@ -46,11 +47,12 @@ from pathlib import Path
 
 from inky_bird_frame.config import load_config
 
-serve_path, refresh_path, generation_path, app_dir, config_path, log_dir = map(
+serve_path, refresh_path, generation_path, catalog_publish_path, app_dir, config_path, log_dir = map(
     Path, sys.argv[1:]
 )
 executable = app_dir / ".venv/bin/inky-bird-frame"
-schedule = load_config(config_path).schedule
+config = load_config(config_path)
+schedule = config.schedule
 
 common = {
     "WorkingDirectory": str(app_dir),
@@ -84,6 +86,20 @@ generation = {
     "StandardOutPath": str(log_dir / "generate.log"),
     "StandardErrorPath": str(log_dir / "generate.error.log"),
 }
+catalog_publish = {
+    **common,
+    "Label": "com.inky-bird-frame.catalog-publish",
+    "ProgramArguments": [
+        str(executable),
+        "catalog-publish",
+        "--config",
+        str(config_path),
+    ],
+    "RunAtLoad": True,
+    "StartInterval": schedule.catalog_publish_minutes * 60,
+    "StandardOutPath": str(log_dir / "catalog-publish.log"),
+    "StandardErrorPath": str(log_dir / "catalog-publish.error.log"),
+}
 for path, payload in (
     (serve_path, serve),
     (refresh_path, refresh),
@@ -91,20 +107,37 @@ for path, payload in (
 ):
     with path.open("wb") as handle:
         plistlib.dump(payload, handle, sort_keys=True)
+if config.public_catalog.enabled:
+    with catalog_publish_path.open("wb") as handle:
+        plistlib.dump(catalog_publish, handle, sort_keys=True)
+else:
+    catalog_publish_path.unlink(missing_ok=True)
 PY
+
+if [ -f "${catalog_publish_plist}" ]; then
+  "${app_dir}/.venv/bin/inky-bird-frame" catalog-publish \
+    --config "${config_path}" --dry-run >/dev/null
+fi
 
 uid=$(id -u)
 launchctl bootout "gui/${uid}/com.inky-bird-frame.serve" 2>/dev/null || true
 launchctl bootout "gui/${uid}/com.inky-bird-frame.controller-cycle" 2>/dev/null || true
 launchctl bootout "gui/${uid}/com.inky-bird-frame.refresh" 2>/dev/null || true
 launchctl bootout "gui/${uid}/com.inky-bird-frame.generate" 2>/dev/null || true
+launchctl bootout "gui/${uid}/com.inky-bird-frame.catalog-publish" 2>/dev/null || true
 rm -f "${legacy_cycle_plist}"
 launchctl bootstrap "gui/${uid}" "${serve_plist}"
 launchctl bootstrap "gui/${uid}" "${refresh_plist}"
 launchctl bootstrap "gui/${uid}" "${generation_plist}"
+if [ -f "${catalog_publish_plist}" ]; then
+  launchctl bootstrap "gui/${uid}" "${catalog_publish_plist}"
+fi
 launchctl print "gui/${uid}/com.inky-bird-frame.serve" >/dev/null
 launchctl print "gui/${uid}/com.inky-bird-frame.refresh" >/dev/null
 launchctl print "gui/${uid}/com.inky-bird-frame.generate" >/dev/null
+if [ -f "${catalog_publish_plist}" ]; then
+  launchctl print "gui/${uid}/com.inky-bird-frame.catalog-publish" >/dev/null
+fi
 
 echo "Controller installed from ${root} into ${app_dir}."
 echo "Configuration: ${config_path}"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,9 @@ A locked generation cycle reads the latest non-stale snapshot, then:
 6. runs an independent, sourced Codex factual and visual review;
 7. regenerates failed reviews with corrective findings, within a configured
    attempt limit; and
-8. atomically publishes passing output through the pending queue.
+8. atomically publishes passing output through the pending queue; and
+9. immediately rebuilds the private active catalog from the latest observation
+   snapshot.
 
 The controller also exposes a read-only HTTP catalog:
 
@@ -46,6 +48,28 @@ The display node does not discover birds or generate art. Each timer cycle:
 This pull model keeps display addressing out of controller state and limits the
 node to a read-only catalog relationship. If refresh, generation, or controller
 access fails, the current e-paper image remains visible.
+
+### Public catalog publisher
+
+Public archival is an independent scheduled role. It never runs in the
+generation transaction and cannot delay local approval or display rotation. A
+publication cycle:
+
+1. fetches the configured branch of a dedicated catalog Git repository;
+2. creates a disposable detached worktree from that exact remote revision;
+3. validates every local and public species directory;
+4. copies only taxa that do not yet exist publicly;
+5. rebuilds and validates the public index;
+6. commits the new immutable directories; and
+7. pushes a fast-forward update to the configured branch.
+
+Validation fails closed on review scores, missing verification sources,
+unbounded current-generation output, unexpected files, image dimensions or
+metadata, checksums, private configuration fields, local paths, and any attempt
+to change an existing public taxon. Explicitly recognized seed and version-one
+catalog entries remain publishable for backward compatibility. A failed fetch,
+validation, commit, or push leaves the local catalog and active display
+unchanged. The next scheduled cycle retries from the current remote branch.
 
 ## State model
 
@@ -76,10 +100,17 @@ state and are not redistributed in the catalog.
 
 Deterministic code handles discovery parameters, terminal-state selection,
 license filtering, reference checksums, prompt assembly, image dimensions,
-rotation, catalog checksums, publication, serving, downloading, and display
-rotation.
+rotation, catalog checksums, local approval, public publication, serving,
+downloading, and display rotation.
 
 Codex handles factual synthesis, image generation, and independent factual and
 visual review. Those steps are bounded by structured schemas, attached
 references, sourced verification, versioned prompts, configurable attempts,
 and a terminal failure state. Human approval is not required for normal flow.
+
+Application code and documentation continue through protected pull requests.
+Generated species are content artifacts: after runtime review and deterministic
+validation, the trusted controller writes them directly to the dedicated public
+catalog. This keeps external contributors and untrusted GitHub-hosted workflows
+out of the publication credential path without making human review a content
+bottleneck.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,9 @@ An observation refresh:
 4. publishes a private active catalog containing only observed taxa that
    already have approved plates.
 
-A locked generation cycle reads the latest non-stale snapshot, then:
+A locked generation cycle reads the latest non-stale snapshot and the durable
+seed queue. Current observations take priority over queued seed taxa. The cycle
+then:
 
 1. selects taxa without a terminal local state;
 2. acquires and verifies licensed references;
@@ -49,26 +51,29 @@ This pull model keeps display addressing out of controller state and limits the
 node to a read-only catalog relationship. If refresh, generation, or controller
 access fails, the current e-paper image remains visible.
 
-### Public catalog publisher
+### Catalog publisher
 
-Public archival is an independent scheduled role. It never runs in the
+Catalog archival is an independent scheduled role. It never runs in the
 generation transaction and cannot delay local approval or display rotation. A
 publication cycle:
 
-1. fetches the configured branch of a dedicated catalog Git repository;
-2. creates a disposable detached worktree from that exact remote revision;
-3. validates every local and public species directory;
-4. copies only taxa that do not yet exist publicly;
-5. rebuilds and validates the public index;
-6. commits the new immutable directories; and
-7. pushes a fast-forward update to the configured branch.
+1. verifies that GitHub CLI is authenticated as the configured repository owner;
+2. fetches the configured base branch of this project repository;
+3. creates a disposable detached worktree from that exact remote revision;
+4. validates every local and repository species directory;
+5. copies only taxa that do not yet exist in `catalog/`;
+6. rebuilds and validates the catalog index;
+7. verifies that the staged diff contains only the index and new species files;
+8. pushes a content-addressed publication branch;
+9. opens a catalog-only pull request; and
+10. owner-merges it with `gh pr merge --admin` and an exact head-SHA guard.
 
 Validation fails closed on review scores, missing verification sources,
 unbounded current-generation output, unexpected files, image dimensions or
 metadata, checksums, private configuration fields, local paths, and any attempt
-to change an existing public taxon. Explicitly recognized seed and version-one
+to change an existing catalog taxon. Explicitly recognized seed and version-one
 catalog entries remain publishable for backward compatibility. A failed fetch,
-validation, commit, or push leaves the local catalog and active display
+validation, commit, PR, or merge leaves the local catalog and active display
 unchanged. The next scheduled cycle retries from the current remote branch.
 
 ## State model
@@ -79,6 +84,7 @@ unchanged. The next scheduled cycle retries from the current remote branch.
 | pending | Passing candidate awaiting atomic publication or crash recovery | No |
 | rejected | Operator override rejected a candidate | No |
 | failed | Generation exhausted its bounded attempts | No |
+| queued | Broader seed discovery awaits generation | Yes |
 | eligible | No terminal state exists | Yes |
 
 `retry TAXON_ID` archives rejected or failed state and makes that taxon
@@ -88,7 +94,7 @@ eligible. There is deliberately no implicit replacement path for approved art.
 
 The private ZIP code and observation window influence the generation queue and
 active rotation. They are not passed to image generation and are not stored in
-public catalog manifests. Observation snapshots and counts stay in ignored
+catalog manifests. Observation snapshots and counts stay in ignored
 controller state.
 
 Reference acquisition accepts only iNaturalist research-grade photos marked
@@ -98,9 +104,10 @@ state and are not redistributed in the catalog.
 
 ## Deterministic and generative work
 
-Deterministic code handles discovery parameters, terminal-state selection,
-license filtering, reference checksums, prompt assembly, image dimensions,
-rotation, catalog checksums, local approval, public publication, serving,
+Deterministic code handles discovery parameters, the persistent seed queue,
+terminal-state selection, license filtering, reference checksums, prompt
+assembly, image dimensions, rotation, catalog checksums, local approval,
+catalog publication, serving,
 downloading, and display rotation.
 
 Codex handles factual synthesis, image generation, and independent factual and
@@ -110,7 +117,7 @@ and a terminal failure state. Human approval is not required for normal flow.
 
 Application code and documentation continue through protected pull requests.
 Generated species are content artifacts: after runtime review and deterministic
-validation, the trusted controller writes them directly to the dedicated public
-catalog. This keeps external contributors and untrusted GitHub-hosted workflows
-out of the publication credential path without making human review a content
-bottleneck.
+validation, the trusted controller submits and owner-merges a catalog-only PR in
+this repository. This keeps external contributors and untrusted GitHub-hosted
+workflows out of the publication credential path without making human review a
+content bottleneck.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -15,6 +15,7 @@ Schedules are configured in `[schedule]`. Conservative starting values are:
 - controller HTTP service: always running;
 - observation refresh: every 15 minutes;
 - generation cycle: every six hours, one candidate per cycle;
+- public catalog publication: every five minutes when enabled; and
 - display cycle: every 30 minutes.
 
 The refresh command does not invoke Codex. `generation_minutes`,
@@ -37,6 +38,45 @@ portable across installations using the supported panel. Controller and display
 state paths remain TOML configuration. Installer bootstrap paths, including the
 TOML path itself, remain environment variables because the installer must find
 the configuration before it can load it.
+
+## Public catalog publication
+
+Use a dedicated Git repository for generated catalog content. Initialize its
+default branch with a README and license, then clone it on the trusted
+controller. Configure unattended authentication on that checkout with a
+repository-scoped deploy key or credential helper. Credentials and remote URLs
+do not belong in application configuration.
+
+```toml
+[public_catalog]
+enabled = true
+checkout_dir = "/path/to/public-catalog-checkout"
+remote = "origin"
+branch = "main"
+commit_name = "Inky Bird Frame Catalog"
+commit_email = "inky-bird-frame@users.noreply.github.com"
+
+[schedule]
+catalog_publish_minutes = 5
+```
+
+Validate the complete local and remote catalog without committing or pushing:
+
+```bash
+inky-bird-frame catalog-publish --config /path/to/config.toml --dry-run
+```
+
+Run an immediate publication cycle:
+
+```bash
+inky-bird-frame catalog-publish --config /path/to/config.toml
+```
+
+The publisher copies only new approved taxa. Existing public taxa must be
+byte-for-byte identical to their local approved versions. It never publishes
+the private discovery snapshot, downloaded reference bitmaps, run logs, failed
+attempts, or display state. The macOS installer creates the publication
+LaunchAgent only when `[public_catalog].enabled` is true.
 
 ## Maintainer deployment on macOS
 
@@ -71,9 +111,8 @@ inky-bird-frame approve --config /path/to/config.toml TAXON_ID
 inky-bird-frame reject --config /path/to/config.toml TAXON_ID --reason "specific issue"
 ```
 
-Commit the complete catalog directory for every published taxon. This preserves
-the accepted bitmap for other installations and prevents them from spending
-generation quota on it.
+Enable public catalog publication to preserve accepted plates for other
+installations without routing each generated image through an application PR.
 
 ## Failure recovery
 
@@ -88,3 +127,7 @@ generation quota on it.
 - Controller unavailable: the current e-paper image remains visible. Display
   state is not advanced.
 - Checksum mismatch: the display refuses the asset and preserves current state.
+- Public catalog failure: inspect `catalog-publish.error.log`. Fix repository
+  authentication, remote divergence, or the reported validation problem, then
+  rerun `catalog-publish`. Local approval and display rotation continue while
+  public publication is unavailable.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -15,7 +15,7 @@ Schedules are configured in `[schedule]`. Conservative starting values are:
 - controller HTTP service: always running;
 - observation refresh: every 15 minutes;
 - generation cycle: every six hours, one candidate per cycle;
-- public catalog publication: every five minutes when enabled; and
+- catalog publication: every five minutes when enabled; and
 - display cycle: every 30 minutes.
 
 The refresh command does not invoke Codex. `generation_minutes`,
@@ -39,20 +39,39 @@ state paths remain TOML configuration. Installer bootstrap paths, including the
 TOML path itself, remain environment variables because the installer must find
 the configuration before it can load it.
 
-## Public catalog publication
+## Seed a broader catalog
 
-Use a dedicated Git repository for generated catalog content. Initialize its
-default branch with a README and license, then clone it on the trusted
-controller. Configure unattended authentication on that checkout with a
-repository-scoped deploy key or credential helper. Credentials and remote URLs
-do not belong in application configuration.
+The active display window and the generation backlog are separate. Use `seed`
+to enqueue distinct taxa from a broader period without changing which birds are
+currently active on the display:
+
+```bash
+inky-bird-frame seed --config /path/to/config.toml \
+  --window last-year --species-limit 500 --dry-run
+inky-bird-frame seed --config /path/to/config.toml \
+  --window last-year --species-limit 500
+```
+
+The configured radius is used unless `--radius-km` is provided. Repeating a seed
+is idempotent: approved, terminal, and already queued taxa are not added again.
+Current observations remain ahead of seed-only taxa during generation.
+
+## Catalog publication
+
+Clone this project repository into a controller-only checkout. Install GitHub
+CLI and authenticate it as the repository owner. The owner must have pull
+request bypass permission on the base-branch ruleset. GitHub CLI stores its
+credential outside application configuration; do not use a deploy key because a
+deploy key cannot exercise the owner's pull request bypass.
 
 ```toml
 [public_catalog]
 enabled = true
-checkout_dir = "/path/to/public-catalog-checkout"
+checkout_dir = "/path/to/inky-bird-frame-source"
+repository = "owner/inky-bird-frame"
+gh_path = "/path/to/gh"
 remote = "origin"
-branch = "main"
+base_branch = "main"
 commit_name = "Inky Bird Frame Catalog"
 commit_email = "inky-bird-frame@users.noreply.github.com"
 
@@ -72,7 +91,7 @@ Run an immediate publication cycle:
 inky-bird-frame catalog-publish --config /path/to/config.toml
 ```
 
-The publisher copies only new approved taxa. Existing public taxa must be
+The publisher copies only new approved taxa. Existing repository taxa must be
 byte-for-byte identical to their local approved versions. It never publishes
 the private discovery snapshot, downloaded reference bitmaps, run logs, failed
 attempts, or display state. The macOS installer creates the publication
@@ -111,8 +130,9 @@ inky-bird-frame approve --config /path/to/config.toml TAXON_ID
 inky-bird-frame reject --config /path/to/config.toml TAXON_ID --reason "specific issue"
 ```
 
-Enable public catalog publication to preserve accepted plates for other
-installations without routing each generated image through an application PR.
+Enable catalog publication to preserve accepted plates for other installations.
+Each generated image receives an auditable catalog-only PR, while application
+code continues through the full review and CI policy.
 
 ## Failure recovery
 
@@ -127,7 +147,7 @@ installations without routing each generated image through an application PR.
 - Controller unavailable: the current e-paper image remains visible. Display
   state is not advanced.
 - Checksum mismatch: the display refuses the asset and preserves current state.
-- Public catalog failure: inspect `catalog-publish.error.log`. Fix repository
+- Catalog publication failure: inspect `catalog-publish.error.log`. Fix repository
   authentication, remote divergence, or the reported validation problem, then
   rerun `catalog-publish`. Local approval and display rotation continue while
   public publication is unavailable.

--- a/src/inky_bird_frame/birds.py
+++ b/src/inky_bird_frame/birds.py
@@ -34,6 +34,7 @@ class ObservationWindow(StrEnum):
     LAST_DAY = "last-day"
     LAST_WEEK = "last-week"
     LAST_30_DAYS = "last-30-days"
+    LAST_YEAR = "last-year"
     ALL_TIME = "all-time"
 
 
@@ -61,6 +62,8 @@ def date_range_for_window(window: ObservationWindow, today: date | None = None) 
         return DateRange(start=current - timedelta(days=7), end=current)
     if window is ObservationWindow.LAST_30_DAYS:
         return DateRange(start=current - timedelta(days=30), end=current)
+    if window is ObservationWindow.LAST_YEAR:
+        return DateRange(start=current - timedelta(days=365), end=current)
     raise ValueError(f"Unsupported observation window: {window}")
 
 

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
 import shutil
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -17,6 +20,17 @@ from .images import slugify
 from .models import QualityReview, ReferencePhoto, SpeciesProfileData
 
 SCHEMA_VERSION = 1
+
+
+@contextmanager
+def catalog_state_lock(state_dir: Path) -> Iterator[None]:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    with (state_dir / "catalog-state.lock").open("a+") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 @dataclass(frozen=True)
@@ -215,6 +229,55 @@ def rebuild_catalog_index(catalog_dir: Path) -> list[CatalogEntry]:
 def approved_taxon_ids(catalog_dir: Path) -> set[int]:
     entries = rebuild_catalog_index(catalog_dir)
     return {entry.taxon_id for entry in entries}
+
+
+def has_passing_sourced_review(review: object) -> bool:
+    if not isinstance(review, dict):
+        return False
+    score_fields = (
+        "species_accuracy",
+        "anatomy_accuracy",
+        "text_accuracy",
+        "composition_quality",
+    )
+    if (
+        review.get("passed") is not True
+        or review.get("location_free") is not True
+        or any(
+            not isinstance(review.get(field), int)
+            or isinstance(review.get(field), bool)
+            or cast(int, review[field]) < 4
+            for field in score_fields
+        )
+    ):
+        return False
+    sources = review.get("verification_sources")
+    if not isinstance(sources, list):
+        return False
+    urls = {
+        source.get("url")
+        for source in sources
+        if isinstance(source, dict)
+        and isinstance(source.get("title"), str)
+        and bool(source["title"].strip())
+        and isinstance(source.get("url"), str)
+        and source["url"].startswith("https://")
+    }
+    return len(urls) >= 2
+
+
+def is_bounded_generation(generation: object) -> bool:
+    if not isinstance(generation, dict):
+        return False
+    attempt = generation.get("attempt")
+    max_attempts = generation.get("max_attempts")
+    return (
+        isinstance(attempt, int)
+        and not isinstance(attempt, bool)
+        and isinstance(max_attempts, int)
+        and not isinstance(max_attempts, bool)
+        and 1 <= attempt <= max_attempts
+    )
 
 
 def approve_candidate(state_dir: Path, catalog_dir: Path, taxon_id: int) -> CatalogEntry:

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -209,25 +209,34 @@ def _manifest_entry(manifest_path: Path, catalog_dir: Path) -> CatalogEntry:
     )
 
 
-def rebuild_catalog_index(catalog_dir: Path) -> list[CatalogEntry]:
+def read_catalog_entries(catalog_dir: Path) -> list[CatalogEntry]:
     species_dir = catalog_dir / "species"
     entries = [
         _manifest_entry(path, catalog_dir) for path in sorted(species_dir.glob("*/manifest.json"))
     ]
     entries.sort(key=lambda item: (item.common_name.casefold(), item.taxon_id))
+    return entries
+
+
+def catalog_index_data(entries: list[CatalogEntry]) -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": max((entry.approved_at for entry in entries), default=None),
+        "species": [entry.as_dict() for entry in entries],
+    }
+
+
+def rebuild_catalog_index(catalog_dir: Path) -> list[CatalogEntry]:
+    entries = read_catalog_entries(catalog_dir)
     write_json_atomic(
         catalog_dir / "index.json",
-        {
-            "schema_version": SCHEMA_VERSION,
-            "generated_at": max((entry.approved_at for entry in entries), default=None),
-            "species": [entry.as_dict() for entry in entries],
-        },
+        catalog_index_data(entries),
     )
     return entries
 
 
 def approved_taxon_ids(catalog_dir: Path) -> set[int]:
-    entries = rebuild_catalog_index(catalog_dir)
+    entries = read_catalog_entries(catalog_dir)
     return {entry.taxon_id for entry in entries}
 
 

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -8,7 +8,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from .birds import BirdSpecies
+from .birds import BirdSpecies, ObservationWindow, parse_observation_window
 from .catalog import (
     approve_candidate,
     find_taxon_directory,
@@ -19,6 +19,8 @@ from .catalog import (
 from .config import AppConfig, load_config
 from .controller import (
     discover_species,
+    enqueue_seed_species,
+    read_generation_queue,
     run_controller_cycle,
     run_generation_cycle,
     run_refresh_cycle,
@@ -96,6 +98,19 @@ def generate_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def seed_command(args: argparse.Namespace) -> int:
+    print_result(
+        enqueue_seed_species(
+            _config(args),
+            window=parse_observation_window(args.window),
+            radius_km=args.radius_km,
+            species_limit=args.species_limit,
+            dry_run=args.dry_run,
+        )
+    )
+    return 0
+
+
 def approve_command(args: argparse.Namespace) -> int:
     config = _config(args)
     entry = approve_candidate(
@@ -158,6 +173,7 @@ def status_command(args: argparse.Namespace) -> int:
         {
             "approved": [entry.as_dict() for entry in entries],
             "pending": pending,
+            "queued": [species_to_dict(item) for item in read_generation_queue(config)],
             "failed": [
                 str(path) for path in sorted((config.controller.state_dir / "failed").glob("*"))
             ],
@@ -244,6 +260,21 @@ def build_parser() -> argparse.ArgumentParser:
     add_config_argument(generate_parser)
     generate_parser.set_defaults(func=generate_command)
 
+    seed_parser = subparsers.add_parser(
+        "seed",
+        help="Queue distinct species from a broader observation window for generation",
+    )
+    add_config_argument(seed_parser)
+    seed_parser.add_argument(
+        "--window",
+        required=True,
+        choices=[window.value for window in ObservationWindow],
+    )
+    seed_parser.add_argument("--radius-km", type=int)
+    seed_parser.add_argument("--species-limit", type=int)
+    seed_parser.add_argument("--dry-run", action="store_true")
+    seed_parser.set_defaults(func=seed_command)
+
     approve_parser = subparsers.add_parser("approve", help="Publish a pending candidate")
     add_config_argument(approve_parser)
     approve_parser.add_argument("taxon_id", type=int)
@@ -281,7 +312,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     catalog_publish_parser = subparsers.add_parser(
         "catalog-publish",
-        help="Validate and publish newly approved plates to a dedicated catalog repository",
+        help="Validate and owner-merge approved plates into this repository's catalog",
     )
     add_config_argument(catalog_publish_parser)
     catalog_publish_parser.add_argument("--dry-run", action="store_true")

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -27,6 +27,7 @@ from .display import show_on_inky
 from .display_node import run_display_cycle
 from .errors import InkyBirdFrameError
 from .images import prepare_uploaded_image
+from .publisher import run_catalog_publish
 from .server import serve_catalog
 
 
@@ -176,6 +177,11 @@ def display_cycle_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def catalog_publish_command(args: argparse.Namespace) -> int:
+    print_result(run_catalog_publish(_config(args), dry_run=args.dry_run))
+    return 0
+
+
 def prepare_image_command(args: argparse.Namespace) -> int:
     portrait, display = prepare_uploaded_image(args.image, args.output_dir)
     if args.display:
@@ -272,6 +278,14 @@ def build_parser() -> argparse.ArgumentParser:
     add_config_argument(display_cycle_parser)
     display_cycle_parser.add_argument("--force", action="store_true")
     display_cycle_parser.set_defaults(func=display_cycle_command)
+
+    catalog_publish_parser = subparsers.add_parser(
+        "catalog-publish",
+        help="Validate and publish newly approved plates to a dedicated catalog repository",
+    )
+    add_config_argument(catalog_publish_parser)
+    catalog_publish_parser.add_argument("--dry-run", action="store_true")
+    catalog_publish_parser.set_defaults(func=catalog_publish_command)
 
     prepare_parser = subparsers.add_parser(
         "prepare-image", help="Prepare a portrait image for Inky"

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -58,8 +58,10 @@ class DisplayNodeConfig:
 class PublicCatalogConfig:
     enabled: bool = False
     checkout_dir: Path | None = None
+    repository: str | None = None
+    gh_path: Path = Path("gh")
     remote: str = "origin"
-    branch: str = "main"
+    base_branch: str = "main"
     commit_name: str = "Inky Bird Frame Catalog"
     commit_email: str = "inky-bird-frame@users.noreply.github.com"
 
@@ -195,9 +197,14 @@ def load_config(path: Path) -> AppConfig:
         else None
     )
     if public_catalog_enabled and checkout_dir is None:
-        raise ConfigurationError(
-            "checkout_dir is required when public catalog publishing is enabled"
-        )
+        raise ConfigurationError("checkout_dir is required when catalog publishing is enabled")
+    repository = _string(public_catalog, "repository") if "repository" in public_catalog else None
+    if public_catalog_enabled and repository is None:
+        raise ConfigurationError("repository is required when catalog publishing is enabled")
+    if repository is not None:
+        parts = repository.split("/")
+        if len(parts) != 2 or any(not part or part in {".", ".."} for part in parts):
+            raise ConfigurationError("repository must use the owner/name format")
 
     return AppConfig(
         discovery=DiscoveryConfig(
@@ -227,8 +234,12 @@ def load_config(path: Path) -> AppConfig:
         public_catalog=PublicCatalogConfig(
             enabled=public_catalog_enabled,
             checkout_dir=checkout_dir,
+            repository=repository,
+            gh_path=_executable_path(
+                _optional_string(public_catalog, "gh_path", default="gh"), base_dir
+            ),
             remote=_optional_string(public_catalog, "remote", default="origin"),
-            branch=_optional_string(public_catalog, "branch", default="main"),
+            base_branch=_optional_string(public_catalog, "base_branch", default="main"),
             commit_name=_optional_string(
                 public_catalog, "commit_name", default="Inky Bird Frame Catalog"
             ),

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -55,12 +55,23 @@ class DisplayNodeConfig:
 
 
 @dataclass(frozen=True)
+class PublicCatalogConfig:
+    enabled: bool = False
+    checkout_dir: Path | None = None
+    remote: str = "origin"
+    branch: str = "main"
+    commit_name: str = "Inky Bird Frame Catalog"
+    commit_email: str = "inky-bird-frame@users.noreply.github.com"
+
+
+@dataclass(frozen=True)
 class ScheduleConfig:
     refresh_minutes: int = 15
     generation_minutes: int = 360
     rotation_minutes: int = 30
     rotation_jitter_seconds: int = 0
     display_startup_delay_seconds: int = 120
+    catalog_publish_minutes: int = 5
 
 
 @dataclass(frozen=True)
@@ -68,6 +79,7 @@ class AppConfig:
     discovery: DiscoveryConfig
     controller: ControllerConfig
     display_node: DisplayNodeConfig
+    public_catalog: PublicCatalogConfig = PublicCatalogConfig()
     schedule: ScheduleConfig = ScheduleConfig()
 
 
@@ -117,6 +129,15 @@ def _optional_string(section: dict[str, object], name: str, *, default: str) -> 
     return _string(section, name)
 
 
+def _optional_boolean(section: dict[str, object], name: str, *, default: bool) -> bool:
+    if name not in section:
+        return default
+    value = section[name]
+    if not isinstance(value, bool):
+        raise ConfigurationError(f"{name} must be a boolean")
+    return value
+
+
 def _path(value: str, base_dir: Path) -> Path:
     path = Path(value).expanduser()
     return path if path.is_absolute() else (base_dir / path).resolve()
@@ -141,6 +162,7 @@ def load_config(path: Path) -> AppConfig:
     discovery = _section(raw, "discovery")
     controller = _section(raw, "controller")
     display_node = _section(raw, "display_node")
+    public_catalog = _optional_section(raw, "public_catalog")
     schedule = _optional_section(raw, "schedule")
     base_dir = path.parent.resolve()
 
@@ -165,6 +187,17 @@ def load_config(path: Path) -> AppConfig:
         rotation_mode = parse_rotation_mode(rotation_mode_value)
     except ValueError as exc:
         raise ConfigurationError(str(exc)) from exc
+
+    public_catalog_enabled = _optional_boolean(public_catalog, "enabled", default=False)
+    checkout_dir = (
+        _path(_string(public_catalog, "checkout_dir"), base_dir)
+        if "checkout_dir" in public_catalog
+        else None
+    )
+    if public_catalog_enabled and checkout_dir is None:
+        raise ConfigurationError(
+            "checkout_dir is required when public catalog publishing is enabled"
+        )
 
     return AppConfig(
         discovery=DiscoveryConfig(
@@ -191,6 +224,20 @@ def load_config(path: Path) -> AppConfig:
             state_dir=_path(_string(display_node, "state_dir"), base_dir),
             rotation_mode=rotation_mode,
         ),
+        public_catalog=PublicCatalogConfig(
+            enabled=public_catalog_enabled,
+            checkout_dir=checkout_dir,
+            remote=_optional_string(public_catalog, "remote", default="origin"),
+            branch=_optional_string(public_catalog, "branch", default="main"),
+            commit_name=_optional_string(
+                public_catalog, "commit_name", default="Inky Bird Frame Catalog"
+            ),
+            commit_email=_optional_string(
+                public_catalog,
+                "commit_email",
+                default="inky-bird-frame@users.noreply.github.com",
+            ),
+        ),
         schedule=ScheduleConfig(
             refresh_minutes=_optional_integer(schedule, "refresh_minutes", default=15),
             generation_minutes=_optional_integer(schedule, "generation_minutes", default=360),
@@ -200,6 +247,9 @@ def load_config(path: Path) -> AppConfig:
             ),
             display_startup_delay_seconds=_optional_integer(
                 schedule, "display_startup_delay_seconds", default=120, minimum=0
+            ),
+            catalog_publish_minutes=_optional_integer(
+                schedule, "catalog_publish_minutes", default=5
             ),
         ),
     )

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import cast
 
-from .birds import BirdSpecies, fetch_inaturalist_birds, fetch_taxon_context
+from .birds import BirdSpecies, ObservationWindow, fetch_inaturalist_birds, fetch_taxon_context
 from .catalog import (
     approve_candidate,
     approved_taxon_ids,
@@ -100,6 +100,10 @@ def _active_catalog_path(config: AppConfig) -> Path:
     return config.controller.state_dir / "active-catalog.json"
 
 
+def _generation_queue_path(config: AppConfig) -> Path:
+    return config.controller.state_dir / "generation-queue.json"
+
+
 def _species_payload(species: BirdSpecies) -> dict[str, object]:
     return {
         "taxon_id": species.taxon_id,
@@ -107,6 +111,124 @@ def _species_payload(species: BirdSpecies) -> dict[str, object]:
         "scientific_name": species.scientific_name,
         "observation_count": species.observation_count,
         "source": species.source,
+    }
+
+
+def _parse_species_list(raw: object, source: Path) -> list[BirdSpecies]:
+    if not isinstance(raw, list):
+        raise CatalogError(f"Invalid species list in {source}")
+    species: list[BirdSpecies] = []
+    seen: set[int] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            raise CatalogError(f"Invalid species in {source}")
+        taxon_id = item.get("taxon_id")
+        observation_count = item.get("observation_count")
+        strings = [item.get(name) for name in ("common_name", "scientific_name", "source")]
+        if (
+            not isinstance(taxon_id, int)
+            or isinstance(taxon_id, bool)
+            or taxon_id <= 0
+            or taxon_id in seen
+            or not isinstance(observation_count, int)
+            or isinstance(observation_count, bool)
+            or observation_count < 0
+            or any(not isinstance(value, str) or not value for value in strings)
+        ):
+            raise CatalogError(f"Invalid species in {source}")
+        seen.add(taxon_id)
+        species.append(
+            BirdSpecies(
+                taxon_id=taxon_id,
+                common_name=cast(str, strings[0]),
+                scientific_name=cast(str, strings[1]),
+                observation_count=observation_count,
+                source=cast(str, strings[2]),
+            )
+        )
+    return species
+
+
+def read_generation_queue(config: AppConfig) -> list[BirdSpecies]:
+    path = _generation_queue_path(config)
+    if not path.exists():
+        return []
+    try:
+        raw = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise CatalogError(f"Invalid generation queue: {path}") from exc
+    if not isinstance(raw, dict) or raw.get("schema_version") != 1:
+        raise CatalogError(f"Unsupported generation queue: {path}")
+    return _parse_species_list(raw.get("species"), path)
+
+
+def _write_generation_queue(config: AppConfig, species: list[BirdSpecies]) -> None:
+    write_json_atomic(
+        _generation_queue_path(config),
+        {
+            "schema_version": 1,
+            "updated_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+            "species": [_species_payload(item) for item in species],
+        },
+    )
+
+
+def enqueue_seed_species(
+    config: AppConfig,
+    *,
+    window: ObservationWindow,
+    radius_km: int | None = None,
+    species_limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, object]:
+    radius = radius_km if radius_km is not None else config.discovery.radius_km
+    limit = species_limit if species_limit is not None else config.discovery.species_limit
+    if radius <= 0:
+        raise ValueError("radius_km must be greater than zero")
+    if limit <= 0:
+        raise ValueError("species_limit must be greater than zero")
+
+    with exclusive_cycle_lock(config.controller.state_dir):
+        location = lookup_us_zip(config.discovery.zip_code)
+        discovered = fetch_inaturalist_birds(
+            latitude=location.latitude,
+            longitude=location.longitude,
+            radius_km=radius,
+            limit=limit,
+            window=window,
+        )
+        approved = approved_taxon_ids(config.controller.catalog_dir)
+        existing = [
+            species for species in read_generation_queue(config) if species.taxon_id not in approved
+        ]
+        eligible = [
+            species
+            for species in discovered
+            if species.taxon_id not in approved
+            and not _has_terminal_state(config.controller.state_dir, species.taxon_id)
+        ]
+        queued_by_taxon = {species.taxon_id: species for species in existing}
+        added: list[BirdSpecies] = []
+        for species in eligible:
+            if species.taxon_id in queued_by_taxon:
+                continue
+            queued_by_taxon[species.taxon_id] = species
+            added.append(species)
+        queued = list(queued_by_taxon.values())
+        if not dry_run:
+            _write_generation_queue(config, queued)
+
+    return {
+        "window": window.value,
+        "radius_km": radius,
+        "species_limit": limit,
+        "discovered_count": len(discovered),
+        "already_approved_count": sum(species.taxon_id in approved for species in discovered),
+        "eligible_count": len(eligible),
+        "added_count": len(added),
+        "queued_count": len(queued),
+        "dry_run": dry_run,
+        "added": [_species_payload(species) for species in added],
     }
 
 
@@ -187,31 +309,7 @@ def _read_discovery_snapshot(config: AppConfig) -> DiscoverySnapshot:
     if refreshed.tzinfo is None:
         raise CatalogError(f"Discovery timestamp has no timezone: {path}")
 
-    species: list[BirdSpecies] = []
-    for item in species_raw:
-        if not isinstance(item, dict):
-            raise CatalogError(f"Invalid species in discovery state: {path}")
-        taxon_id = item.get("taxon_id")
-        observation_count = item.get("observation_count")
-        strings = [item.get(name) for name in ("common_name", "scientific_name", "source")]
-        if (
-            not isinstance(taxon_id, int)
-            or isinstance(taxon_id, bool)
-            or not isinstance(observation_count, int)
-            or isinstance(observation_count, bool)
-            or observation_count < 0
-            or any(not isinstance(value, str) or not value for value in strings)
-        ):
-            raise CatalogError(f"Invalid species in discovery state: {path}")
-        species.append(
-            BirdSpecies(
-                taxon_id=taxon_id,
-                common_name=cast(str, strings[0]),
-                scientific_name=cast(str, strings[1]),
-                observation_count=observation_count,
-                source=cast(str, strings[2]),
-            )
-        )
+    species = _parse_species_list(species_raw, path)
     return DiscoverySnapshot(refreshed, place_name, state, species)
 
 
@@ -440,10 +538,16 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 "Discovery state is stale; a successful refresh is required before generation"
             )
         species_list = snapshot.species
+        queued_species = read_generation_queue(config)
+        generation_species = list(species_list)
+        observed_taxa = {species.taxon_id for species in species_list}
+        generation_species.extend(
+            species for species in queued_species if species.taxon_id not in observed_taxa
+        )
         approved = approved_taxon_ids(config.controller.catalog_dir)
         eligible = [
             species
-            for species in species_list
+            for species in generation_species
             if species.taxon_id not in approved
             and not _has_terminal_state(config.controller.state_dir, species.taxon_id)
         ]
@@ -511,6 +615,11 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
         with catalog_state_lock(config.controller.state_dir):
             latest_snapshot = _read_discovery_snapshot(config)
             active_count = _write_active_catalog(config, latest_snapshot.species)
+            approved_after = approved_taxon_ids(config.controller.catalog_dir)
+            remaining_queue = [
+                species for species in queued_species if species.taxon_id not in approved_after
+            ]
+            _write_generation_queue(config, remaining_queue)
         return {
             "discovery": {
                 "refreshed_at": snapshot.refreshed_at.isoformat(),
@@ -524,6 +633,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
             "active_approved_count": active_count,
             "published_pending": published,
             "eligible_count": len(eligible),
+            "queued_count": len(remaining_queue),
             "generated": generated,
             "failures": failures,
         }

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -18,7 +18,10 @@ from .catalog import (
     approve_candidate,
     approved_taxon_ids,
     candidate_directory,
+    catalog_state_lock,
     find_taxon_directory,
+    has_passing_sourced_review,
+    is_bounded_generation,
     rebuild_catalog_index,
     write_candidate_manifest,
     write_json_atomic,
@@ -57,17 +60,6 @@ def exclusive_cycle_lock(state_dir: Path) -> Iterator[None]:
             fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         except BlockingIOError as exc:
             raise GenerationError("Another controller cycle is already running") from exc
-        try:
-            yield
-        finally:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
-
-
-@contextmanager
-def catalog_state_lock(state_dir: Path) -> Iterator[None]:
-    state_dir.mkdir(parents=True, exist_ok=True)
-    with (state_dir / "catalog-state.lock").open("a+") as handle:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
         try:
             yield
         finally:
@@ -426,11 +418,7 @@ def approve_passing_candidates(config: AppConfig) -> list[dict[str, object]]:
             raise CatalogError(f"Pending manifest has no taxon ID: {manifest_path}")
         review = manifest.get("quality_review")
         generation = manifest.get("generation")
-        if (
-            not isinstance(review, dict)
-            or not _has_passing_sourced_review(review)
-            or not _is_bounded_generation(generation)
-        ):
+        if not has_passing_sourced_review(review) or not is_bounded_generation(generation):
             continue
         entry = approve_candidate(
             config.controller.state_dir,
@@ -439,53 +427,6 @@ def approve_passing_candidates(config: AppConfig) -> list[dict[str, object]]:
         )
         published.append(entry.as_dict())
     return published
-
-
-def _has_passing_sourced_review(review: dict[str, object]) -> bool:
-    score_fields = (
-        "species_accuracy",
-        "anatomy_accuracy",
-        "text_accuracy",
-        "composition_quality",
-    )
-    if (
-        review.get("passed") is not True
-        or review.get("location_free") is not True
-        or any(
-            not isinstance(review.get(field), int)
-            or isinstance(review.get(field), bool)
-            or cast(int, review[field]) < 4
-            for field in score_fields
-        )
-    ):
-        return False
-    sources = review.get("verification_sources")
-    if not isinstance(sources, list):
-        return False
-    urls = {
-        source.get("url")
-        for source in sources
-        if isinstance(source, dict)
-        and isinstance(source.get("title"), str)
-        and bool(source["title"].strip())
-        and isinstance(source.get("url"), str)
-        and source["url"].startswith("https://")
-    }
-    return len(urls) >= 2
-
-
-def _is_bounded_generation(generation: object) -> bool:
-    if not isinstance(generation, dict):
-        return False
-    attempt = generation.get("attempt")
-    max_attempts = generation.get("max_attempts")
-    return (
-        isinstance(attempt, int)
-        and not isinstance(attempt, bool)
-        and isinstance(max_attempts, int)
-        and not isinstance(max_attempts, bool)
-        and 1 <= attempt <= max_attempts
-    )
 
 
 def run_generation_cycle(config: AppConfig) -> dict[str, object]:

--- a/src/inky_bird_frame/errors.py
+++ b/src/inky_bird_frame/errors.py
@@ -29,6 +29,10 @@ class CatalogError(InkyBirdFrameError):
     """Raised when catalog data is missing, invalid, or inconsistent."""
 
 
+class CatalogPublishError(InkyBirdFrameError):
+    """Raised when an approved catalog cannot be published safely."""
+
+
 class GenerationError(InkyBirdFrameError):
     """Raised when Codex cannot produce or validate an artifact."""
 

--- a/src/inky_bird_frame/publisher.py
+++ b/src/inky_bird_frame/publisher.py
@@ -1,8 +1,10 @@
-"""Validate and publish immutable approved plates to a dedicated Git repository."""
+"""Validate approved plates and publish them through owner-bypassed catalog PRs."""
 
 from __future__ import annotations
 
 import fcntl
+import hashlib
+import json
 import re
 import shutil
 import subprocess
@@ -16,11 +18,14 @@ from PIL import Image
 
 from .catalog import (
     CatalogEntry,
+    catalog_index_data,
     catalog_state_lock,
     has_passing_sourced_review,
     is_bounded_generation,
+    read_catalog_entries,
     read_json,
     rebuild_catalog_index,
+    sha256_file,
 )
 from .config import AppConfig, PublicCatalogConfig
 from .errors import CatalogPublishError
@@ -51,9 +56,16 @@ _PRIVATE_KEYS = frozenset(
     }
 )
 _WINDOWS_ABSOLUTE_PATH = re.compile(r"^[A-Za-z]:[\\/]")
+_WINDOWS_UNC_PATH = re.compile(r"^(?:\\\\|//)[^\\/]")
 _CREDENTIALS_IN_URL = re.compile(r"(https?://)[^/@\s]+@")
 _GIT_REMOTE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_GITHUB_REMOTE = re.compile(
+    r"^(?:https://github\.com/|git@github\.com:|ssh://git@github\.com/)"
+    r"(?P<repository>[^/\s]+/[^/\s]+?)(?:\.git)?/?$",
+    re.IGNORECASE,
+)
 _IMAGE_DIMENSIONS = {"portrait.png": (1200, 1600), "display.png": (1600, 1200)}
+_COMMAND_TIMEOUT_SECONDS = 180
 
 
 @contextmanager
@@ -63,7 +75,7 @@ def exclusive_publish_lock(state_dir: Path) -> Iterator[None]:
         try:
             fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         except BlockingIOError as exc:
-            raise CatalogPublishError("Another public catalog publication is running") from exc
+            raise CatalogPublishError("Another catalog publication is running") from exc
         try:
             yield
         finally:
@@ -87,8 +99,9 @@ def _check_json_privacy(value: object, source: Path) -> None:
         value.startswith("file://")
         or Path(value).is_absolute()
         or _WINDOWS_ABSOLUTE_PATH.match(value) is not None
+        or _WINDOWS_UNC_PATH.match(value) is not None
     ):
-        raise CatalogPublishError(f"Local path found in public catalog JSON: {source}")
+        raise CatalogPublishError(f"Local path found in catalog JSON: {source}")
 
 
 def _validate_image(path: Path, expected_size: tuple[int, int]) -> None:
@@ -105,7 +118,7 @@ def _validate_image(path: Path, expected_size: tuple[int, int]) -> None:
     except CatalogPublishError:
         raise
     except (OSError, RuntimeError, SyntaxError) as exc:
-        raise CatalogPublishError(f"Invalid public catalog image: {path}") from exc
+        raise CatalogPublishError(f"Invalid catalog image: {path}") from exc
 
 
 def _legacy_seed_review_passed(review: object, generation: object) -> bool:
@@ -138,7 +151,29 @@ def _legacy_sourced_review_passed(review: object, generation: object) -> bool:
     )
 
 
-def _validate_species_directory(directory: Path) -> None:
+def _validate_catalog_root(catalog_dir: Path, *, allow_create: bool) -> None:
+    if catalog_dir.exists():
+        if catalog_dir.is_symlink() or not catalog_dir.is_dir():
+            raise CatalogPublishError(f"Catalog root must be a directory: {catalog_dir}")
+    elif allow_create:
+        parent = catalog_dir.parent
+        if parent.is_symlink() or not parent.is_dir():
+            raise CatalogPublishError(f"Catalog parent must be a directory: {parent}")
+        catalog_dir.mkdir()
+    else:
+        raise CatalogPublishError(f"Catalog root does not exist: {catalog_dir}")
+
+    species_root = catalog_dir / "species"
+    if species_root.exists():
+        if species_root.is_symlink() or not species_root.is_dir():
+            raise CatalogPublishError(f"Species root must be a directory: {species_root}")
+    elif allow_create:
+        species_root.mkdir()
+    else:
+        raise CatalogPublishError(f"Species root does not exist: {species_root}")
+
+
+def _validate_species_directory(directory: Path) -> tuple[int, str]:
     if directory.is_symlink() or not directory.is_dir():
         raise CatalogPublishError(f"Species path must be a directory, not a symlink: {directory}")
     files = {path.name for path in directory.iterdir()}
@@ -146,19 +181,19 @@ def _validate_species_directory(directory: Path) -> None:
     missing = {"manifest.json", "portrait.png", "display.png"} - files
     if unexpected:
         raise CatalogPublishError(
-            f"Unexpected public catalog files in {directory}: {', '.join(sorted(unexpected))}"
+            f"Unexpected catalog files in {directory}: {', '.join(sorted(unexpected))}"
         )
     if missing:
         raise CatalogPublishError(
-            f"Required public catalog files missing from {directory}: {', '.join(sorted(missing))}"
+            f"Required catalog files missing from {directory}: {', '.join(sorted(missing))}"
         )
     for path in directory.iterdir():
         if path.is_symlink() or not path.is_file():
-            raise CatalogPublishError(f"Public catalog entries must be regular files: {path}")
+            raise CatalogPublishError(f"Catalog entries must be regular files: {path}")
 
     manifest = read_json(directory / "manifest.json")
     if not isinstance(manifest, dict) or manifest.get("schema_version") != 1:
-        raise CatalogPublishError(f"Unsupported public manifest: {directory / 'manifest.json'}")
+        raise CatalogPublishError(f"Unsupported catalog manifest: {directory / 'manifest.json'}")
     taxon_id = manifest.get("taxon_id")
     slug = manifest.get("slug")
     if (
@@ -184,6 +219,15 @@ def _validate_species_directory(directory: Path) -> None:
             raise CatalogPublishError(
                 f"Manifest {asset_name} asset must use {expected_filename}: {directory}"
             )
+        checksum = asset.get("sha256")
+        if (
+            not isinstance(checksum, str)
+            or re.fullmatch(r"[0-9a-f]{64}", checksum) is None
+            or sha256_file(directory / expected_filename) != checksum
+        ):
+            raise CatalogPublishError(
+                f"Manifest {asset_name} checksum does not match {expected_filename}: {directory}"
+            )
     automated = has_passing_sourced_review(review) and is_bounded_generation(generation)
     legacy = _legacy_seed_review_passed(review, generation) or _legacy_sourced_review_passed(
         review, generation
@@ -200,20 +244,26 @@ def _validate_species_directory(directory: Path) -> None:
             raise CatalogPublishError(f"Quality review does not match the manifest: {directory}")
     for filename, dimensions in _IMAGE_DIMENSIONS.items():
         _validate_image(directory / filename, dimensions)
+    return taxon_id, slug
 
 
 def validate_public_catalog(catalog_dir: Path) -> list[CatalogEntry]:
+    _validate_catalog_root(catalog_dir, allow_create=False)
     species_root = catalog_dir / "species"
-    directories = sorted(path for path in species_root.glob("*") if path.name != ".DS_Store")
+    directories = sorted(path for path in species_root.iterdir() if path.name != ".DS_Store")
+    seen_taxa: set[int] = set()
     for directory in directories:
-        _validate_species_directory(directory)
-    entries = rebuild_catalog_index(catalog_dir)
+        taxon_id, _ = _validate_species_directory(directory)
+        if taxon_id in seen_taxa:
+            raise CatalogPublishError(f"Catalog contains duplicate taxon ID {taxon_id}")
+        seen_taxa.add(taxon_id)
+    entries = read_catalog_entries(catalog_dir)
     if len(entries) != len(directories):
-        raise CatalogPublishError(
-            f"Every public species directory needs one manifest: {species_root}"
-        )
+        raise CatalogPublishError(f"Every species directory needs one manifest: {species_root}")
     index = read_json(catalog_dir / "index.json")
     _check_json_privacy(index, catalog_dir / "index.json")
+    if index != catalog_index_data(entries):
+        raise CatalogPublishError(f"Catalog index does not match species manifests: {catalog_dir}")
     return entries
 
 
@@ -227,9 +277,14 @@ def _trees_match(left: Path, right: Path) -> bool:
 
 def sync_public_catalog(source_catalog: Path, destination_catalog: Path) -> dict[str, object]:
     source_entries = validate_public_catalog(source_catalog)
+    _validate_catalog_root(destination_catalog, allow_create=True)
+    if (destination_catalog / "index.json").exists():
+        validate_public_catalog(destination_catalog)
+    elif any((destination_catalog / "species").iterdir()):
+        raise CatalogPublishError("Catalog with species entries must include index.json")
+
     source_by_taxon = {entry.taxon_id: entry for entry in source_entries}
     destination_species = destination_catalog / "species"
-    destination_species.mkdir(parents=True, exist_ok=True)
     published: list[dict[str, object]] = []
     existing: list[int] = []
 
@@ -237,13 +292,11 @@ def sync_public_catalog(source_catalog: Path, destination_catalog: Path) -> dict
         source = source_catalog / "species" / f"{taxon_id}-{entry.slug}"
         matches = sorted(destination_species.glob(f"{taxon_id}-*"))
         if len(matches) > 1:
-            raise CatalogPublishError(
-                f"Public catalog contains multiple directories for taxon {taxon_id}"
-            )
+            raise CatalogPublishError(f"Catalog contains multiple directories for taxon {taxon_id}")
         if matches:
             if matches[0].name != source.name or not _trees_match(source, matches[0]):
                 raise CatalogPublishError(
-                    f"Public catalog taxon {taxon_id} conflicts with immutable local approval"
+                    f"Catalog taxon {taxon_id} conflicts with immutable local approval"
                 )
             existing.append(taxon_id)
             continue
@@ -253,44 +306,83 @@ def sync_public_catalog(source_catalog: Path, destination_catalog: Path) -> dict
                 "taxon_id": entry.taxon_id,
                 "common_name": entry.common_name,
                 "scientific_name": entry.scientific_name,
+                "slug": entry.slug,
             }
         )
 
+    rebuild_catalog_index(destination_catalog)
     validate_public_catalog(destination_catalog)
     return {"published": published, "already_present": existing}
 
 
-def _redact_git_output(value: str) -> str:
+def _redact_command_output(value: str) -> str:
     return _CREDENTIALS_IN_URL.sub(r"\1[REDACTED]@", value.strip())
 
 
-def _git(repository: Path, *arguments: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+def _run(
+    arguments: list[str],
+    *,
+    input_text: str | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
     try:
         result = subprocess.run(
-            ["git", "-C", str(repository), *arguments],
+            arguments,
             check=False,
             capture_output=True,
             text=True,
-            timeout=180,
+            input=input_text,
+            timeout=_COMMAND_TIMEOUT_SECONDS,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
-        raise CatalogPublishError(f"Unable to run git {arguments[0]}") from exc
+        raise CatalogPublishError(f"Unable to run {Path(arguments[0]).name}") from exc
     if check and result.returncode != 0:
-        detail = _redact_git_output(result.stderr or result.stdout)
-        raise CatalogPublishError(f"git {arguments[0]} failed: {detail or 'unknown error'}")
+        detail = _redact_command_output(result.stderr or result.stdout)
+        raise CatalogPublishError(
+            f"{Path(arguments[0]).name} {arguments[1]} failed: {detail or 'unknown error'}"
+        )
     return result
 
 
-def _validate_checkout(checkout: Path, publication: PublicCatalogConfig) -> None:
-    if not checkout.is_dir():
-        raise CatalogPublishError(f"Public catalog checkout does not exist: {checkout}")
+def _git(repository: Path, *arguments: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return _run(["git", "-C", str(repository), *arguments], check=check)
+
+
+def _gh(
+    publication: PublicCatalogConfig,
+    *arguments: str,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return _run([str(publication.gh_path), *arguments], input_text=input_text)
+
+
+def _remote_repository(remote_url: str) -> str | None:
+    match = _GITHUB_REMOTE.fullmatch(remote_url.strip())
+    return match.group("repository") if match is not None else None
+
+
+def _validate_checkout(checkout: Path, publication: PublicCatalogConfig) -> str:
+    if checkout.is_symlink() or not checkout.is_dir():
+        raise CatalogPublishError(f"Repository checkout does not exist: {checkout}")
+    repository = publication.repository
+    if repository is None:
+        raise CatalogPublishError("Catalog repository is not configured")
     top_level = _git(checkout, "rev-parse", "--show-toplevel").stdout.strip()
     if Path(top_level).resolve() != checkout.resolve():
-        raise CatalogPublishError("Public catalog checkout_dir must be the Git repository root")
+        raise CatalogPublishError("checkout_dir must be the Git repository root")
     if _GIT_REMOTE_NAME.fullmatch(publication.remote) is None:
-        raise CatalogPublishError("Public catalog remote has an invalid Git remote name")
-    _git(checkout, "check-ref-format", "--branch", publication.branch)
-    _git(checkout, "remote", "get-url", publication.remote)
+        raise CatalogPublishError("Catalog remote has an invalid Git remote name")
+    _git(checkout, "check-ref-format", "--branch", publication.base_branch)
+    remote_url = _git(checkout, "remote", "get-url", publication.remote).stdout.strip()
+    remote_repository = _remote_repository(remote_url)
+    if remote_repository is None or remote_repository.casefold() != repository.casefold():
+        raise CatalogPublishError("Catalog remote does not match the configured repository")
+
+    owner = repository.split("/", maxsplit=1)[0]
+    authenticated = _gh(publication, "api", "user", "--jq", ".login").stdout.strip()
+    if authenticated.casefold() != owner.casefold():
+        raise CatalogPublishError(f"GitHub CLI must be authenticated as repository owner {owner!r}")
+    return repository
 
 
 def _commit_message(published: list[dict[str, object]]) -> str:
@@ -301,23 +393,133 @@ def _commit_message(published: list[dict[str, object]]) -> str:
     return "Rebuild catalog index"
 
 
+def _catalog_digest(catalog_dir: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(item for item in catalog_dir.rglob("*") if item.is_file()):
+        relative = path.relative_to(catalog_dir).as_posix()
+        digest.update(relative.encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _validate_staged_catalog(
+    worktree: Path,
+    published: list[dict[str, object]],
+) -> list[str]:
+    expected_directories = {
+        f"catalog/species/{item['taxon_id']}-{item['slug']}/"
+        for item in published
+        if isinstance(item.get("taxon_id"), int) and isinstance(item.get("slug"), str)
+    }
+    output = _git(
+        worktree,
+        "diff",
+        "--cached",
+        "--name-status",
+        "--no-renames",
+    ).stdout
+    paths: list[str] = []
+    for line in output.splitlines():
+        try:
+            status, path = line.split("\t", maxsplit=1)
+        except ValueError as exc:
+            raise CatalogPublishError("Unable to parse staged catalog changes") from exc
+        paths.append(path)
+        if path == "catalog/index.json":
+            if status not in {"A", "M"}:
+                raise CatalogPublishError("Catalog index may only be added or modified")
+            continue
+        if status != "A" or not any(path.startswith(prefix) for prefix in expected_directories):
+            raise CatalogPublishError(f"Publication attempted an unexpected change: {path}")
+        if Path(path).name not in _ALLOWED_SPECIES_FILES:
+            raise CatalogPublishError(f"Publication attempted an unexpected species file: {path}")
+    if published and "catalog/index.json" not in paths:
+        raise CatalogPublishError("Catalog publication did not update catalog/index.json")
+    return paths
+
+
+def _pull_request(
+    publication: PublicCatalogConfig,
+    repository: str,
+    branch: str,
+) -> dict[str, object] | None:
+    raw = _gh(
+        publication,
+        "pr",
+        "list",
+        "--repo",
+        repository,
+        "--head",
+        branch,
+        "--state",
+        "all",
+        "--limit",
+        "1",
+        "--json",
+        "number,url,state,headRefOid",
+    ).stdout
+    try:
+        pull_requests = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise CatalogPublishError("GitHub CLI returned invalid pull request data") from exc
+    if not isinstance(pull_requests, list) or any(
+        not isinstance(item, dict) for item in pull_requests
+    ):
+        raise CatalogPublishError("GitHub CLI returned invalid pull request data")
+    return cast(dict[str, object], pull_requests[0]) if pull_requests else None
+
+
+def _create_pull_request(
+    publication: PublicCatalogConfig,
+    repository: str,
+    branch: str,
+    title: str,
+    published: list[dict[str, object]],
+) -> str:
+    birds = "\n".join(f"- {item['common_name']} ({item['scientific_name']})" for item in published)
+    body = (
+        "Automated catalog publication from the trusted controller.\n\n"
+        "Validated additions:\n"
+        f"{birds}\n\n"
+        "Only immutable, location-neutral files under `catalog/` are included.\n"
+    )
+    return _gh(
+        publication,
+        "pr",
+        "create",
+        "--repo",
+        repository,
+        "--base",
+        publication.base_branch,
+        "--head",
+        branch,
+        "--title",
+        title,
+        "--body-file",
+        "-",
+        input_text=body,
+    ).stdout.strip()
+
+
 def run_catalog_publish(config: AppConfig, *, dry_run: bool = False) -> dict[str, object]:
     publication = config.public_catalog
     if not publication.enabled:
-        raise CatalogPublishError("Public catalog publishing is disabled")
+        raise CatalogPublishError("Catalog publishing is disabled")
     checkout = publication.checkout_dir
     if checkout is None:
-        raise CatalogPublishError("Public catalog checkout_dir is not configured")
+        raise CatalogPublishError("Catalog checkout_dir is not configured")
 
     with exclusive_publish_lock(config.controller.state_dir):
-        _validate_checkout(checkout, publication)
-        remote_ref = f"refs/remotes/{publication.remote}/{publication.branch}"
+        repository = _validate_checkout(checkout, publication)
+        remote_ref = f"refs/remotes/{publication.remote}/{publication.base_branch}"
         _git(
             checkout,
             "fetch",
             "--prune",
             publication.remote,
-            f"+refs/heads/{publication.branch}:{remote_ref}",
+            f"+refs/heads/{publication.base_branch}:{remote_ref}",
         )
         _git(checkout, "worktree", "prune")
         work_parent = config.controller.state_dir / "catalog-publish-work"
@@ -326,59 +528,150 @@ def run_catalog_publish(config: AppConfig, *, dry_run: bool = False) -> dict[str
             source_snapshot = Path(temporary) / "source-catalog"
             with catalog_state_lock(config.controller.state_dir):
                 try:
-                    shutil.copytree(config.controller.catalog_dir, source_snapshot)
+                    shutil.copytree(
+                        config.controller.catalog_dir,
+                        source_snapshot,
+                        symlinks=True,
+                    )
                 except FileNotFoundError as exc:
                     raise CatalogPublishError("Approved local catalog does not exist") from exc
+            validate_public_catalog(source_snapshot)
+
             worktree = Path(temporary) / "checkout"
             _git(checkout, "worktree", "add", "--detach", str(worktree), remote_ref)
             try:
-                sync = sync_public_catalog(
-                    source_snapshot,
-                    worktree / "catalog",
+                sync = sync_public_catalog(source_snapshot, worktree / "catalog")
+                published = sync["published"]
+                if not isinstance(published, list) or any(
+                    not isinstance(item, dict) for item in published
+                ):
+                    raise CatalogPublishError("Publisher produced an invalid change summary")
+                typed_published = cast(list[dict[str, object]], published)
+                changed = bool(
+                    _git(
+                        worktree,
+                        "status",
+                        "--porcelain",
+                        "--untracked-files=all",
+                        "--",
+                        "catalog",
+                    ).stdout.strip()
                 )
-                status = _git(
-                    worktree,
-                    "status",
-                    "--porcelain",
-                    "--untracked-files=all",
-                    "--",
-                    "catalog",
-                ).stdout
-                changed = bool(status.strip())
-                result = {
+                result: dict[str, object] = {
                     **sync,
                     "changed": changed,
                     "dry_run": dry_run,
                     "pushed": False,
+                    "merged": False,
                     "commit": None,
+                    "pull_request": None,
                 }
-                if dry_run or not changed:
+                if not changed:
                     return result
+                if not typed_published:
+                    raise CatalogPublishError("Catalog changed without adding an approved species")
 
-                published = sync["published"]
-                if not isinstance(published, list):
-                    raise CatalogPublishError("Publisher produced an invalid change summary")
                 _git(worktree, "add", "--", "catalog")
                 _git(worktree, "diff", "--cached", "--check")
-                _git(
-                    worktree,
-                    "-c",
-                    f"user.name={publication.commit_name}",
-                    "-c",
-                    f"user.email={publication.commit_email}",
-                    "commit",
-                    "-m",
-                    _commit_message(cast(list[dict[str, object]], published)),
-                )
-                commit = _git(worktree, "rev-parse", "HEAD").stdout.strip()
-                _git(
-                    worktree,
-                    "push",
+                result["paths"] = _validate_staged_catalog(worktree, typed_published)
+                if dry_run:
+                    return result
+
+                base_commit = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+                branch = f"catalog/publish-{_catalog_digest(source_snapshot)[:8]}-{base_commit[:8]}"
+                remote_branch = _git(
+                    checkout,
+                    "ls-remote",
+                    "--heads",
                     publication.remote,
-                    f"HEAD:refs/heads/{publication.branch}",
-                )
+                    f"refs/heads/{branch}",
+                ).stdout.strip()
+                if remote_branch:
+                    remote_commit = remote_branch.split(maxsplit=1)[0]
+                    branch_ref = f"refs/remotes/{publication.remote}/catalog-publication"
+                    _git(
+                        checkout,
+                        "fetch",
+                        publication.remote,
+                        f"+refs/heads/{branch}:{branch_ref}",
+                    )
+                    staged_tree = _git(worktree, "write-tree").stdout.strip()
+                    remote_tree = _git(
+                        checkout, "rev-parse", f"{branch_ref}^{{tree}}"
+                    ).stdout.strip()
+                    if remote_tree != staged_tree:
+                        raise CatalogPublishError(
+                            f"Existing publication branch {branch!r} has unexpected content"
+                        )
+                    commit = remote_commit
+                else:
+                    _git(
+                        worktree,
+                        "-c",
+                        f"user.name={publication.commit_name}",
+                        "-c",
+                        f"user.email={publication.commit_email}",
+                        "commit",
+                        "-m",
+                        _commit_message(typed_published),
+                    )
+                    commit = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+                    _git(worktree, "push", publication.remote, f"HEAD:refs/heads/{branch}")
                 result["pushed"] = True
                 result["commit"] = commit
+                result["branch"] = branch
+
+                pull_request = _pull_request(publication, repository, branch)
+                if pull_request is None:
+                    pull_request_url = _create_pull_request(
+                        publication,
+                        repository,
+                        branch,
+                        _commit_message(typed_published),
+                        typed_published,
+                    )
+                else:
+                    existing_url = pull_request.get("url")
+                    if not isinstance(existing_url, str):
+                        raise CatalogPublishError("Existing publication PR has no URL")
+                    pull_request_url = existing_url
+                    if pull_request.get("state") == "CLOSED":
+                        raise CatalogPublishError(
+                            "Existing publication PR was closed without merge"
+                        )
+                    head_sha = pull_request.get("headRefOid")
+                    if head_sha != commit:
+                        raise CatalogPublishError("Existing publication PR has an unexpected head")
+                result["pull_request"] = pull_request_url
+
+                _gh(
+                    publication,
+                    "pr",
+                    "merge",
+                    pull_request_url,
+                    "--repo",
+                    repository,
+                    "--admin",
+                    "--squash",
+                    "--delete-branch",
+                    "--match-head-commit",
+                    commit,
+                )
+                state = _gh(
+                    publication,
+                    "pr",
+                    "view",
+                    pull_request_url,
+                    "--repo",
+                    repository,
+                    "--json",
+                    "state",
+                    "--jq",
+                    ".state",
+                ).stdout.strip()
+                if state != "MERGED":
+                    raise CatalogPublishError(f"Catalog pull request did not merge: {state}")
+                result["merged"] = True
                 return result
             finally:
                 _git(checkout, "worktree", "remove", "--force", str(worktree), check=False)

--- a/src/inky_bird_frame/publisher.py
+++ b/src/inky_bird_frame/publisher.py
@@ -1,0 +1,385 @@
+"""Validate and publish immutable approved plates to a dedicated Git repository."""
+
+from __future__ import annotations
+
+import fcntl
+import re
+import shutil
+import subprocess
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import cast
+
+from PIL import Image
+
+from .catalog import (
+    CatalogEntry,
+    catalog_state_lock,
+    has_passing_sourced_review,
+    is_bounded_generation,
+    read_json,
+    rebuild_catalog_index,
+)
+from .config import AppConfig, PublicCatalogConfig
+from .errors import CatalogPublishError
+
+_ALLOWED_SPECIES_FILES = frozenset(
+    {
+        "display.png",
+        "manifest.json",
+        "portrait.png",
+        "profile.json",
+        "quality-review.json",
+    }
+)
+_PRIVATE_KEYS = frozenset(
+    {
+        "catalog_dir",
+        "checkout_dir",
+        "controller_url",
+        "coordinates",
+        "latitude",
+        "longitude",
+        "observation_count",
+        "place_name",
+        "radius_km",
+        "state_dir",
+        "workspace_dir",
+        "zip_code",
+    }
+)
+_WINDOWS_ABSOLUTE_PATH = re.compile(r"^[A-Za-z]:[\\/]")
+_CREDENTIALS_IN_URL = re.compile(r"(https?://)[^/@\s]+@")
+_GIT_REMOTE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_IMAGE_DIMENSIONS = {"portrait.png": (1200, 1600), "display.png": (1600, 1200)}
+
+
+@contextmanager
+def exclusive_publish_lock(state_dir: Path) -> Iterator[None]:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    with (state_dir / "catalog-publish.lock").open("a+") as handle:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise CatalogPublishError("Another public catalog publication is running") from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _check_json_privacy(value: object, source: Path) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if not isinstance(key, str):
+                raise CatalogPublishError(f"JSON object has a non-string key: {source}")
+            if key.casefold() in _PRIVATE_KEYS:
+                raise CatalogPublishError(f"Private field {key!r} found in {source}")
+            _check_json_privacy(child, source)
+        return
+    if isinstance(value, list):
+        for child in value:
+            _check_json_privacy(child, source)
+        return
+    if isinstance(value, str) and (
+        value.startswith("file://")
+        or Path(value).is_absolute()
+        or _WINDOWS_ABSOLUTE_PATH.match(value) is not None
+    ):
+        raise CatalogPublishError(f"Local path found in public catalog JSON: {source}")
+
+
+def _validate_image(path: Path, expected_size: tuple[int, int]) -> None:
+    try:
+        with Image.open(path) as image:
+            if image.format != "PNG" or image.size != expected_size:
+                raise CatalogPublishError(
+                    f"{path} must be a {expected_size[0]}x{expected_size[1]} PNG"
+                )
+            image.verify()
+        with Image.open(path) as image:
+            if image.info or image.getexif():
+                raise CatalogPublishError(f"Image metadata is not allowed in {path}")
+    except CatalogPublishError:
+        raise
+    except (OSError, RuntimeError, SyntaxError) as exc:
+        raise CatalogPublishError(f"Invalid public catalog image: {path}") from exc
+
+
+def _legacy_seed_review_passed(review: object, generation: object) -> bool:
+    if not isinstance(review, dict) or not isinstance(generation, dict):
+        return False
+    score_fields = (
+        "species_accuracy",
+        "anatomy_accuracy",
+        "text_accuracy",
+        "composition_quality",
+    )
+    return (
+        generation.get("generator") == "User-approved seed image"
+        and review.get("passed") is True
+        and review.get("location_free") is True
+        and all(
+            isinstance(review.get(field), int)
+            and not isinstance(review.get(field), bool)
+            and cast(int, review[field]) >= 4
+            for field in score_fields
+        )
+    )
+
+
+def _legacy_sourced_review_passed(review: object, generation: object) -> bool:
+    if not isinstance(generation, dict):
+        return False
+    return generation.get("prompt_version") == "field-journal-v1" and has_passing_sourced_review(
+        review
+    )
+
+
+def _validate_species_directory(directory: Path) -> None:
+    if directory.is_symlink() or not directory.is_dir():
+        raise CatalogPublishError(f"Species path must be a directory, not a symlink: {directory}")
+    files = {path.name for path in directory.iterdir()}
+    unexpected = files - _ALLOWED_SPECIES_FILES
+    missing = {"manifest.json", "portrait.png", "display.png"} - files
+    if unexpected:
+        raise CatalogPublishError(
+            f"Unexpected public catalog files in {directory}: {', '.join(sorted(unexpected))}"
+        )
+    if missing:
+        raise CatalogPublishError(
+            f"Required public catalog files missing from {directory}: {', '.join(sorted(missing))}"
+        )
+    for path in directory.iterdir():
+        if path.is_symlink() or not path.is_file():
+            raise CatalogPublishError(f"Public catalog entries must be regular files: {path}")
+
+    manifest = read_json(directory / "manifest.json")
+    if not isinstance(manifest, dict) or manifest.get("schema_version") != 1:
+        raise CatalogPublishError(f"Unsupported public manifest: {directory / 'manifest.json'}")
+    taxon_id = manifest.get("taxon_id")
+    slug = manifest.get("slug")
+    if (
+        manifest.get("status") != "approved"
+        or not isinstance(taxon_id, int)
+        or isinstance(taxon_id, bool)
+        or not isinstance(slug, str)
+        or directory.name != f"{taxon_id}-{slug}"
+    ):
+        raise CatalogPublishError(f"Manifest identity does not match {directory}")
+
+    review = manifest.get("quality_review")
+    generation = manifest.get("generation")
+    assets = manifest.get("assets")
+    if not isinstance(assets, dict):
+        raise CatalogPublishError(f"Manifest has no asset map: {directory}")
+    for asset_name, expected_filename in (
+        ("portrait", "portrait.png"),
+        ("display", "display.png"),
+    ):
+        asset = assets.get(asset_name)
+        if not isinstance(asset, dict) or asset.get("filename") != expected_filename:
+            raise CatalogPublishError(
+                f"Manifest {asset_name} asset must use {expected_filename}: {directory}"
+            )
+    automated = has_passing_sourced_review(review) and is_bounded_generation(generation)
+    legacy = _legacy_seed_review_passed(review, generation) or _legacy_sourced_review_passed(
+        review, generation
+    )
+    if not automated and not legacy:
+        raise CatalogPublishError(f"Manifest lacks a publishable quality review: {directory}")
+
+    for path in directory.glob("*.json"):
+        payload = read_json(path)
+        _check_json_privacy(payload, path)
+        if path.name == "profile.json" and payload != manifest.get("profile"):
+            raise CatalogPublishError(f"Profile does not match the manifest: {directory}")
+        if path.name == "quality-review.json" and payload != review:
+            raise CatalogPublishError(f"Quality review does not match the manifest: {directory}")
+    for filename, dimensions in _IMAGE_DIMENSIONS.items():
+        _validate_image(directory / filename, dimensions)
+
+
+def validate_public_catalog(catalog_dir: Path) -> list[CatalogEntry]:
+    species_root = catalog_dir / "species"
+    directories = sorted(path for path in species_root.glob("*") if path.name != ".DS_Store")
+    for directory in directories:
+        _validate_species_directory(directory)
+    entries = rebuild_catalog_index(catalog_dir)
+    if len(entries) != len(directories):
+        raise CatalogPublishError(
+            f"Every public species directory needs one manifest: {species_root}"
+        )
+    index = read_json(catalog_dir / "index.json")
+    _check_json_privacy(index, catalog_dir / "index.json")
+    return entries
+
+
+def _trees_match(left: Path, right: Path) -> bool:
+    left_files = sorted(path.relative_to(left) for path in left.rglob("*") if path.is_file())
+    right_files = sorted(path.relative_to(right) for path in right.rglob("*") if path.is_file())
+    return left_files == right_files and all(
+        (left / relative).read_bytes() == (right / relative).read_bytes() for relative in left_files
+    )
+
+
+def sync_public_catalog(source_catalog: Path, destination_catalog: Path) -> dict[str, object]:
+    source_entries = validate_public_catalog(source_catalog)
+    source_by_taxon = {entry.taxon_id: entry for entry in source_entries}
+    destination_species = destination_catalog / "species"
+    destination_species.mkdir(parents=True, exist_ok=True)
+    published: list[dict[str, object]] = []
+    existing: list[int] = []
+
+    for taxon_id, entry in sorted(source_by_taxon.items()):
+        source = source_catalog / "species" / f"{taxon_id}-{entry.slug}"
+        matches = sorted(destination_species.glob(f"{taxon_id}-*"))
+        if len(matches) > 1:
+            raise CatalogPublishError(
+                f"Public catalog contains multiple directories for taxon {taxon_id}"
+            )
+        if matches:
+            if matches[0].name != source.name or not _trees_match(source, matches[0]):
+                raise CatalogPublishError(
+                    f"Public catalog taxon {taxon_id} conflicts with immutable local approval"
+                )
+            existing.append(taxon_id)
+            continue
+        shutil.copytree(source, destination_species / source.name)
+        published.append(
+            {
+                "taxon_id": entry.taxon_id,
+                "common_name": entry.common_name,
+                "scientific_name": entry.scientific_name,
+            }
+        )
+
+    validate_public_catalog(destination_catalog)
+    return {"published": published, "already_present": existing}
+
+
+def _redact_git_output(value: str) -> str:
+    return _CREDENTIALS_IN_URL.sub(r"\1[REDACTED]@", value.strip())
+
+
+def _git(repository: Path, *arguments: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repository), *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise CatalogPublishError(f"Unable to run git {arguments[0]}") from exc
+    if check and result.returncode != 0:
+        detail = _redact_git_output(result.stderr or result.stdout)
+        raise CatalogPublishError(f"git {arguments[0]} failed: {detail or 'unknown error'}")
+    return result
+
+
+def _validate_checkout(checkout: Path, publication: PublicCatalogConfig) -> None:
+    if not checkout.is_dir():
+        raise CatalogPublishError(f"Public catalog checkout does not exist: {checkout}")
+    top_level = _git(checkout, "rev-parse", "--show-toplevel").stdout.strip()
+    if Path(top_level).resolve() != checkout.resolve():
+        raise CatalogPublishError("Public catalog checkout_dir must be the Git repository root")
+    if _GIT_REMOTE_NAME.fullmatch(publication.remote) is None:
+        raise CatalogPublishError("Public catalog remote has an invalid Git remote name")
+    _git(checkout, "check-ref-format", "--branch", publication.branch)
+    _git(checkout, "remote", "get-url", publication.remote)
+
+
+def _commit_message(published: list[dict[str, object]]) -> str:
+    if len(published) == 1:
+        return f"Publish {published[0]['common_name']}"
+    if published:
+        return f"Publish {len(published)} bird plates"
+    return "Rebuild catalog index"
+
+
+def run_catalog_publish(config: AppConfig, *, dry_run: bool = False) -> dict[str, object]:
+    publication = config.public_catalog
+    if not publication.enabled:
+        raise CatalogPublishError("Public catalog publishing is disabled")
+    checkout = publication.checkout_dir
+    if checkout is None:
+        raise CatalogPublishError("Public catalog checkout_dir is not configured")
+
+    with exclusive_publish_lock(config.controller.state_dir):
+        _validate_checkout(checkout, publication)
+        remote_ref = f"refs/remotes/{publication.remote}/{publication.branch}"
+        _git(
+            checkout,
+            "fetch",
+            "--prune",
+            publication.remote,
+            f"+refs/heads/{publication.branch}:{remote_ref}",
+        )
+        _git(checkout, "worktree", "prune")
+        work_parent = config.controller.state_dir / "catalog-publish-work"
+        work_parent.mkdir(parents=True, exist_ok=True)
+        with TemporaryDirectory(prefix="publish-", dir=work_parent) as temporary:
+            source_snapshot = Path(temporary) / "source-catalog"
+            with catalog_state_lock(config.controller.state_dir):
+                try:
+                    shutil.copytree(config.controller.catalog_dir, source_snapshot)
+                except FileNotFoundError as exc:
+                    raise CatalogPublishError("Approved local catalog does not exist") from exc
+            worktree = Path(temporary) / "checkout"
+            _git(checkout, "worktree", "add", "--detach", str(worktree), remote_ref)
+            try:
+                sync = sync_public_catalog(
+                    source_snapshot,
+                    worktree / "catalog",
+                )
+                status = _git(
+                    worktree,
+                    "status",
+                    "--porcelain",
+                    "--untracked-files=all",
+                    "--",
+                    "catalog",
+                ).stdout
+                changed = bool(status.strip())
+                result = {
+                    **sync,
+                    "changed": changed,
+                    "dry_run": dry_run,
+                    "pushed": False,
+                    "commit": None,
+                }
+                if dry_run or not changed:
+                    return result
+
+                published = sync["published"]
+                if not isinstance(published, list):
+                    raise CatalogPublishError("Publisher produced an invalid change summary")
+                _git(worktree, "add", "--", "catalog")
+                _git(worktree, "diff", "--cached", "--check")
+                _git(
+                    worktree,
+                    "-c",
+                    f"user.name={publication.commit_name}",
+                    "-c",
+                    f"user.email={publication.commit_email}",
+                    "commit",
+                    "-m",
+                    _commit_message(cast(list[dict[str, object]], published)),
+                )
+                commit = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+                _git(
+                    worktree,
+                    "push",
+                    publication.remote,
+                    f"HEAD:refs/heads/{publication.branch}",
+                )
+                result["pushed"] = True
+                result["commit"] = commit
+                return result
+            finally:
+                _git(checkout, "worktree", "remove", "--force", str(worktree), check=False)
+                _git(checkout, "worktree", "prune", check=False)

--- a/tests/test_birds.py
+++ b/tests/test_birds.py
@@ -62,6 +62,10 @@ class InaturalistParsingTests(unittest.TestCase):
             {"d1": "2026-06-09", "d2": "2026-07-09"},
         )
         self.assertEqual(
+            date_range_for_window(ObservationWindow.LAST_YEAR, today).as_query_params(),
+            {"d1": "2025-07-09", "d2": "2026-07-09"},
+        )
+        self.assertEqual(
             date_range_for_window(ObservationWindow.ALL_TIME, today).as_query_params(),
             {},
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,27 @@ class CliTests(unittest.TestCase):
         self.assertEqual(str(args.config), "instance.toml")
         self.assertTrue(args.dry_run)
 
+    def test_seed_supports_year_window_and_overrides(self) -> None:
+        args = build_parser().parse_args(
+            [
+                "seed",
+                "--config",
+                "instance.toml",
+                "--window",
+                "last-year",
+                "--radius-km",
+                "16",
+                "--species-limit",
+                "500",
+                "--dry-run",
+            ]
+        )
+
+        self.assertEqual(args.window, "last-year")
+        self.assertEqual(args.radius_km, 16)
+        self.assertEqual(args.species_limit, 500)
+        self.assertTrue(args.dry_run)
+
     def test_expected_error_uses_json_envelope(self) -> None:
         output = io.StringIO()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,14 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(str(args.config), "instance.toml")
 
+    def test_catalog_publish_supports_dry_run(self) -> None:
+        args = build_parser().parse_args(
+            ["catalog-publish", "--config", "instance.toml", "--dry-run"]
+        )
+
+        self.assertEqual(str(args.config), "instance.toml")
+        self.assertTrue(args.dry_run)
+
     def test_expected_error_uses_json_envelope(self) -> None:
         output = io.StringIO()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,12 +32,21 @@ controller_url = "http://controller.test:8793/"
 state_dir = "var/display"
 rotation_mode = "weighted"
 
+[public_catalog]
+enabled = true
+checkout_dir = "var/public-catalog"
+remote = "public"
+branch = "catalog"
+commit_name = "Catalog Publisher"
+commit_email = "catalog@example.test"
+
 [schedule]
 refresh_minutes = 15
 generation_minutes = 5
 rotation_minutes = 3
 rotation_jitter_seconds = 7
 display_startup_delay_seconds = 30
+catalog_publish_minutes = 4
 """
 
 
@@ -55,11 +64,21 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(config.controller.max_generation_attempts, 3)
         self.assertEqual(config.display_node.controller_url, "http://controller.test:8793")
         self.assertEqual(config.display_node.rotation_mode, RotationMode.WEIGHTED)
+        self.assertTrue(config.public_catalog.enabled)
+        self.assertEqual(
+            config.public_catalog.checkout_dir,
+            (Path(temporary) / "var/public-catalog").resolve(),
+        )
+        self.assertEqual(config.public_catalog.remote, "public")
+        self.assertEqual(config.public_catalog.branch, "catalog")
+        self.assertEqual(config.public_catalog.commit_name, "Catalog Publisher")
+        self.assertEqual(config.public_catalog.commit_email, "catalog@example.test")
         self.assertEqual(config.schedule.refresh_minutes, 15)
         self.assertEqual(config.schedule.generation_minutes, 5)
         self.assertEqual(config.schedule.rotation_minutes, 3)
         self.assertEqual(config.schedule.rotation_jitter_seconds, 7)
         self.assertEqual(config.schedule.display_startup_delay_seconds, 30)
+        self.assertEqual(config.schedule.catalog_publish_minutes, 4)
 
     def test_rejects_invalid_zip(self) -> None:
         with TemporaryDirectory() as temporary:
@@ -98,7 +117,7 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(config.controller.codex_path, (Path(temporary) / "codex").resolve())
 
     def test_uses_backward_compatible_schedule_defaults(self) -> None:
-        legacy = CONFIG.split("\n[schedule]\n", maxsplit=1)[0].replace(
+        legacy = CONFIG.split("\n[public_catalog]\n", maxsplit=1)[0].replace(
             'rotation_mode = "weighted"\n', ""
         )
         with TemporaryDirectory() as temporary:
@@ -108,9 +127,21 @@ class ConfigTests(unittest.TestCase):
             config = load_config(path)
 
         self.assertEqual(config.display_node.rotation_mode, RotationMode.SEQUENTIAL)
+        self.assertFalse(config.public_catalog.enabled)
+        self.assertIsNone(config.public_catalog.checkout_dir)
         self.assertEqual(config.schedule.refresh_minutes, 15)
         self.assertEqual(config.schedule.generation_minutes, 360)
         self.assertEqual(config.schedule.rotation_minutes, 30)
+        self.assertEqual(config.schedule.catalog_publish_minutes, 5)
+
+    def test_enabled_public_catalog_requires_checkout(self) -> None:
+        invalid = CONFIG.replace('checkout_dir = "var/public-catalog"\n', "")
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(invalid)
+
+            with self.assertRaisesRegex(ConfigurationError, "checkout_dir is required"):
+                load_config(path)
 
     def test_rejects_invalid_rotation_policy(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,8 +35,10 @@ rotation_mode = "weighted"
 [public_catalog]
 enabled = true
 checkout_dir = "var/public-catalog"
+repository = "example/inky-bird-frame"
+gh_path = "/opt/homebrew/bin/gh"
 remote = "public"
-branch = "catalog"
+base_branch = "main"
 commit_name = "Catalog Publisher"
 commit_email = "catalog@example.test"
 
@@ -70,7 +72,9 @@ class ConfigTests(unittest.TestCase):
             (Path(temporary) / "var/public-catalog").resolve(),
         )
         self.assertEqual(config.public_catalog.remote, "public")
-        self.assertEqual(config.public_catalog.branch, "catalog")
+        self.assertEqual(config.public_catalog.repository, "example/inky-bird-frame")
+        self.assertEqual(config.public_catalog.gh_path, Path("/opt/homebrew/bin/gh"))
+        self.assertEqual(config.public_catalog.base_branch, "main")
         self.assertEqual(config.public_catalog.commit_name, "Catalog Publisher")
         self.assertEqual(config.public_catalog.commit_email, "catalog@example.test")
         self.assertEqual(config.schedule.refresh_minutes, 15)
@@ -141,6 +145,15 @@ class ConfigTests(unittest.TestCase):
             path.write_text(invalid)
 
             with self.assertRaisesRegex(ConfigurationError, "checkout_dir is required"):
+                load_config(path)
+
+    def test_enabled_public_catalog_requires_repository(self) -> None:
+        invalid = CONFIG.replace('repository = "example/inky-bird-frame"\n', "")
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(invalid)
+
+            with self.assertRaisesRegex(ConfigurationError, "repository is required"):
                 load_config(path)
 
     def test_rejects_invalid_rotation_policy(self) -> None:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -7,11 +7,12 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
-from inky_bird_frame.birds import BirdSpecies
+from inky_bird_frame.birds import BirdSpecies, ObservationWindow
 from inky_bird_frame.catalog import CatalogEntry, candidate_directory, write_candidate_manifest
 from inky_bird_frame.config import load_config
 from inky_bird_frame.controller import (
     DiscoverySnapshot,
+    enqueue_seed_species,
     exclusive_refresh_lock,
     generate_candidate,
     run_controller_cycle,
@@ -70,6 +71,97 @@ state_dir = "display"
 
 
 class ControllerTests(unittest.TestCase):
+    def test_seed_queues_distinct_unapproved_species_without_changing_discovery(self) -> None:
+        approved = BirdSpecies(1, "Approved Bird", "Avis approved", 4, "iNaturalist")
+        queued = BirdSpecies(2, "Queued Bird", "Avis queued", 3, "iNaturalist")
+        location = ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            with (
+                patch("inky_bird_frame.controller.lookup_us_zip", return_value=location),
+                patch(
+                    "inky_bird_frame.controller.fetch_inaturalist_birds",
+                    return_value=[approved, queued],
+                ),
+                patch("inky_bird_frame.controller.approved_taxon_ids", return_value={1}),
+            ):
+                result = enqueue_seed_species(
+                    config,
+                    window=ObservationWindow.LAST_YEAR,
+                    species_limit=500,
+                )
+
+            queue = json.loads((config.controller.state_dir / "generation-queue.json").read_text())
+
+        self.assertEqual(result["discovered_count"], 2)
+        self.assertEqual(result["already_approved_count"], 1)
+        self.assertEqual(result["added_count"], 1)
+        self.assertEqual(queue["species"][0]["taxon_id"], 2)
+        self.assertNotIn("zip_code", queue)
+
+    def test_generation_prioritizes_current_species_before_seed_queue(self) -> None:
+        current = BirdSpecies(1, "Current Bird", "Avis current", 4, "iNaturalist")
+        queued = BirdSpecies(2, "Queued Bird", "Avis queued", 3, "iNaturalist")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            (config.controller.state_dir / "discovery.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "refreshed_at": datetime.now(UTC).isoformat(),
+                        "place_name": "Exampleville",
+                        "state": "XY",
+                        "species": [
+                            {
+                                "taxon_id": current.taxon_id,
+                                "common_name": current.common_name,
+                                "scientific_name": current.scientific_name,
+                                "observation_count": current.observation_count,
+                                "source": current.source,
+                            }
+                        ],
+                    }
+                )
+            )
+            (config.controller.state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "updated_at": datetime.now(UTC).isoformat(),
+                        "species": [
+                            {
+                                "taxon_id": queued.taxon_id,
+                                "common_name": queued.common_name,
+                                "scientific_name": queued.scientific_name,
+                                "observation_count": queued.observation_count,
+                                "source": queued.source,
+                            }
+                        ],
+                    }
+                )
+            )
+            attempted: list[int] = []
+
+            def fail_generation(_config: object, species: BirdSpecies, _workspace: object) -> Path:
+                attempted.append(species.taxon_id)
+                raise DataSourceError("temporary")
+
+            with (
+                patch("inky_bird_frame.controller.approved_taxon_ids", return_value=set()),
+                patch("inky_bird_frame.controller.generate_candidate", side_effect=fail_generation),
+                patch("inky_bird_frame.controller.rebuild_catalog_index", return_value=[]),
+            ):
+                result = run_generation_cycle(config)
+
+        self.assertEqual(attempted, [current.taxon_id])
+        self.assertEqual(result["eligible_count"], 2)
+        self.assertEqual(result["queued_count"], 1)
+
     def test_overlapping_refresh_is_rejected_before_discovery(self) -> None:
         with TemporaryDirectory() as temporary:
             config_path = Path(temporary) / "config.toml"

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -5,13 +5,16 @@ import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from PIL import Image, PngImagePlugin
 
 from inky_bird_frame.catalog import rebuild_catalog_index, sha256_file, write_json_atomic
-from inky_bird_frame.config import load_config
+from inky_bird_frame.config import PublicCatalogConfig, load_config
 from inky_bird_frame.errors import CatalogPublishError
 from inky_bird_frame.publisher import (
+    _remote_repository,
+    _validate_checkout,
     run_catalog_publish,
     sync_public_catalog,
     validate_public_catalog,
@@ -128,8 +131,10 @@ state_dir = "display"
 [public_catalog]
 enabled = true
 checkout_dir = "{checkout}"
+repository = "example/inky-bird-frame"
+gh_path = "/usr/bin/false"
 remote = "origin"
-branch = "main"
+base_branch = "main"
 commit_name = "Test Publisher"
 commit_email = "publisher@example.test"
 """
@@ -160,6 +165,45 @@ def _initialize_remote(root: Path) -> tuple[Path, Path]:
 
 
 class PublisherTests(unittest.TestCase):
+    def test_parses_only_supported_github_repository_remotes(self) -> None:
+        self.assertEqual(
+            _remote_repository("https://github.com/example/inky-bird-frame.git"),
+            "example/inky-bird-frame",
+        )
+        self.assertEqual(
+            _remote_repository("git@github.com:example/inky-bird-frame.git"),
+            "example/inky-bird-frame",
+        )
+        self.assertIsNone(_remote_repository("https://example.test/example/inky-bird-frame"))
+        self.assertIsNone(
+            _remote_repository("https://token@github.com/example/inky-bird-frame.git")
+        )
+
+    def test_checkout_requires_github_cli_owner_identity(self) -> None:
+        with TemporaryDirectory() as temporary:
+            checkout = Path(temporary) / "checkout"
+            subprocess.run(["git", "init", str(checkout)], check=True, capture_output=True)
+            _run_git(
+                checkout,
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/example/inky-bird-frame.git",
+            )
+            publication = PublicCatalogConfig(
+                enabled=True,
+                checkout_dir=checkout,
+                repository="example/inky-bird-frame",
+                gh_path=Path("/usr/bin/false"),
+            )
+            gh_result = subprocess.CompletedProcess(["gh"], 0, "intruder\n", "")
+
+            with (
+                patch("inky_bird_frame.publisher._gh", return_value=gh_result),
+                self.assertRaisesRegex(CatalogPublishError, "repository owner 'example'"),
+            ):
+                _validate_checkout(checkout, publication)
+
     def test_repository_seed_catalog_is_publishable(self) -> None:
         catalog = Path(__file__).parents[1] / "catalog"
 
@@ -184,6 +228,7 @@ class PublisherTests(unittest.TestCase):
                         "taxon_id": 1,
                         "common_name": "Example Bird",
                         "scientific_name": "Avis exemplaris",
+                        "slug": "example-bird",
                     }
                 ],
             )
@@ -206,6 +251,51 @@ class PublisherTests(unittest.TestCase):
             with self.assertRaisesRegex(CatalogPublishError, "Private field"):
                 validate_public_catalog(catalog)
 
+    def test_rejects_windows_unc_paths(self) -> None:
+        with TemporaryDirectory() as temporary:
+            catalog = Path(temporary) / "catalog"
+            directory = _create_species(catalog, 1, "Example Bird")
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text())
+            manifest["source_path"] = r"\\server\share\bird.png"
+            write_json_atomic(manifest_path, manifest)
+
+            with self.assertRaisesRegex(CatalogPublishError, "Local path"):
+                validate_public_catalog(catalog)
+
+    def test_rejects_duplicate_taxon_ids(self) -> None:
+        with TemporaryDirectory() as temporary:
+            catalog = Path(temporary) / "catalog"
+            _create_species(catalog, 1, "Example Bird")
+            _create_species(catalog, 1, "Second Bird")
+
+            with self.assertRaisesRegex(CatalogPublishError, "duplicate taxon ID 1"):
+                validate_public_catalog(catalog)
+
+    def test_rejects_symlinks_in_catalog_entries(self) -> None:
+        with TemporaryDirectory() as temporary:
+            catalog = Path(temporary) / "catalog"
+            directory = _create_species(catalog, 1, "Example Bird")
+            profile = directory / "profile.json"
+            profile.unlink()
+            profile.symlink_to(directory / "manifest.json")
+
+            with self.assertRaisesRegex(CatalogPublishError, "regular files"):
+                validate_public_catalog(catalog)
+
+    def test_rejects_symlinked_destination_root_before_writing(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            target = root / "target"
+            target.mkdir()
+            destination = root / "destination"
+            destination.symlink_to(target, target_is_directory=True)
+            _create_species(source, 1, "Example Bird")
+
+            with self.assertRaisesRegex(CatalogPublishError, "Catalog root"):
+                sync_public_catalog(source, destination)
+
     def test_rejects_image_metadata(self) -> None:
         with TemporaryDirectory() as temporary:
             catalog = Path(temporary) / "catalog"
@@ -220,6 +310,30 @@ class PublisherTests(unittest.TestCase):
             write_json_atomic(manifest_path, manifest)
 
             with self.assertRaisesRegex(CatalogPublishError, "metadata is not allowed"):
+                validate_public_catalog(catalog)
+
+    def test_rejects_asset_checksum_mismatch(self) -> None:
+        with TemporaryDirectory() as temporary:
+            catalog = Path(temporary) / "catalog"
+            directory = _create_species(catalog, 1, "Example Bird")
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text())
+            manifest["assets"]["portrait"]["sha256"] = "0" * 64
+            write_json_atomic(manifest_path, manifest)
+
+            with self.assertRaisesRegex(CatalogPublishError, "checksum does not match"):
+                validate_public_catalog(catalog)
+
+    def test_rejects_index_that_does_not_match_manifests(self) -> None:
+        with TemporaryDirectory() as temporary:
+            catalog = Path(temporary) / "catalog"
+            _create_species(catalog, 1, "Example Bird")
+            index_path = catalog / "index.json"
+            index = json.loads(index_path.read_text())
+            index["species"] = []
+            write_json_atomic(index_path, index)
+
+            with self.assertRaisesRegex(CatalogPublishError, "index does not match"):
                 validate_public_catalog(catalog)
 
     def test_rejects_an_automated_review_below_threshold(self) -> None:
@@ -256,7 +370,7 @@ class PublisherTests(unittest.TestCase):
             public_portrait = destination / "species/1-example-bird/portrait.png"
             public_portrait.write_bytes(b"changed")
 
-            with self.assertRaisesRegex(CatalogPublishError, "conflicts with immutable"):
+            with self.assertRaisesRegex(CatalogPublishError, "checksum does not match"):
                 sync_public_catalog(source, destination)
 
     def test_publishes_through_a_real_git_remote_and_supports_dry_run(self) -> None:
@@ -266,9 +380,45 @@ class PublisherTests(unittest.TestCase):
             config = load_config(_write_config(root, checkout))
             _create_species(config.controller.catalog_dir, 1, "Example Bird")
 
-            first = run_catalog_publish(config)
+            def fake_gh(
+                _publication: object,
+                *arguments: str,
+                input_text: str | None = None,
+            ) -> subprocess.CompletedProcess[str]:
+                del input_text
+                if arguments[:2] == ("pr", "list"):
+                    stdout = "[]\n"
+                elif arguments[:2] == ("pr", "create"):
+                    stdout = "https://github.com/example/inky-bird-frame/pull/1\n"
+                elif arguments[:2] == ("pr", "merge"):
+                    refs = _run_git(
+                        remote,
+                        "for-each-ref",
+                        "--format=%(refname)",
+                        "refs/heads/catalog/publish-*",
+                    ).splitlines()
+                    self.assertEqual(len(refs), 1)
+                    commit = _run_git(remote, "rev-parse", refs[0])
+                    _run_git(remote, "update-ref", "refs/heads/main", commit)
+                    _run_git(remote, "update-ref", "-d", refs[0])
+                    stdout = ""
+                elif arguments[:2] == ("pr", "view"):
+                    stdout = "MERGED\n"
+                else:
+                    self.fail(f"Unexpected gh call: {arguments}")
+                return subprocess.CompletedProcess(["gh", *arguments], 0, stdout, "")
+
+            with (
+                patch(
+                    "inky_bird_frame.publisher._validate_checkout",
+                    return_value="example/inky-bird-frame",
+                ),
+                patch("inky_bird_frame.publisher._gh", side_effect=fake_gh),
+            ):
+                first = run_catalog_publish(config)
 
             self.assertTrue(first["pushed"])
+            self.assertTrue(first["merged"])
             self.assertTrue(first["changed"])
             self.assertIsInstance(first["commit"], str)
             self.assertIn(
@@ -276,13 +426,21 @@ class PublisherTests(unittest.TestCase):
                 _run_git(remote, "ls-tree", "-r", "--name-only", "main"),
             )
 
-            second = run_catalog_publish(config)
+            with patch(
+                "inky_bird_frame.publisher._validate_checkout",
+                return_value="example/inky-bird-frame",
+            ):
+                second = run_catalog_publish(config)
 
             self.assertFalse(second["pushed"])
             self.assertFalse(second["changed"])
 
             _create_species(config.controller.catalog_dir, 2, "Second Bird")
-            dry_run = run_catalog_publish(config, dry_run=True)
+            with patch(
+                "inky_bird_frame.publisher._validate_checkout",
+                return_value="example/inky-bird-frame",
+            ):
+                dry_run = run_catalog_publish(config, dry_run=True)
 
             self.assertTrue(dry_run["changed"])
             self.assertFalse(dry_run["pushed"])
@@ -290,7 +448,14 @@ class PublisherTests(unittest.TestCase):
                 "2-second-bird", _run_git(remote, "ls-tree", "-r", "--name-only", "main")
             )
 
-            final = run_catalog_publish(config)
+            with (
+                patch(
+                    "inky_bird_frame.publisher._validate_checkout",
+                    return_value="example/inky-bird-frame",
+                ),
+                patch("inky_bird_frame.publisher._gh", side_effect=fake_gh),
+            ):
+                final = run_catalog_publish(config)
 
             self.assertTrue(final["pushed"])
             self.assertIn(

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from PIL import Image, PngImagePlugin
+
+from inky_bird_frame.catalog import rebuild_catalog_index, sha256_file, write_json_atomic
+from inky_bird_frame.config import load_config
+from inky_bird_frame.errors import CatalogPublishError
+from inky_bird_frame.publisher import (
+    run_catalog_publish,
+    sync_public_catalog,
+    validate_public_catalog,
+)
+
+
+def _run_git(repository: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _create_species(catalog: Path, taxon_id: int, common_name: str) -> Path:
+    slug = common_name.casefold().replace(" ", "-")
+    directory = catalog / "species" / f"{taxon_id}-{slug}"
+    directory.mkdir(parents=True)
+    Image.new("RGB", (1200, 1600), "white").save(directory / "portrait.png")
+    Image.new("RGB", (1600, 1200), "white").save(directory / "display.png")
+    profile = {
+        "taxon_id": taxon_id,
+        "common_name": common_name,
+        "scientific_name": "Avis exemplaris",
+        "family": "Exemplaridae",
+        "measurements": {"length": "10 cm", "wingspan": "20 cm", "weight": "10 g"},
+        "field_marks": ["example field mark"],
+        "habitat": "Woodland",
+        "behavior": "Forages",
+        "palette": ["white"],
+        "sources": [
+            {"title": "Source one", "url": "https://example.test/one"},
+            {"title": "Source two", "url": "https://example.test/two"},
+        ],
+    }
+    review = {
+        "passed": True,
+        "species_accuracy": 5,
+        "anatomy_accuracy": 5,
+        "text_accuracy": 5,
+        "composition_quality": 5,
+        "location_free": True,
+        "findings": [],
+        "verification_sources": [
+            {"title": "Source one", "url": "https://example.test/one"},
+            {"title": "Source two", "url": "https://example.test/two"},
+        ],
+    }
+    write_json_atomic(directory / "profile.json", profile)
+    write_json_atomic(directory / "quality-review.json", review)
+    write_json_atomic(
+        directory / "manifest.json",
+        {
+            "schema_version": 1,
+            "status": "approved",
+            "taxon_id": taxon_id,
+            "common_name": common_name,
+            "scientific_name": "Avis exemplaris",
+            "slug": slug,
+            "approved_at": "2026-07-09T00:00:00+00:00",
+            "profile": profile,
+            "references": [],
+            "generation": {
+                "generator": "test",
+                "prompt_version": "test-v1",
+                "generated_at": "2026-07-09T00:00:00+00:00",
+                "attempt": 1,
+                "max_attempts": 3,
+            },
+            "quality_review": review,
+            "assets": {
+                "portrait": {
+                    "filename": "portrait.png",
+                    "sha256": sha256_file(directory / "portrait.png"),
+                },
+                "display": {
+                    "filename": "display.png",
+                    "sha256": sha256_file(directory / "display.png"),
+                },
+            },
+        },
+    )
+    rebuild_catalog_index(catalog)
+    return directory
+
+
+def _write_config(root: Path, checkout: Path) -> Path:
+    path = root / "config.toml"
+    path.write_text(
+        f"""
+[discovery]
+zip_code = "12345"
+radius_km = 8
+species_limit = 12
+window = "last-week"
+
+[controller]
+workspace_dir = "."
+catalog_dir = "catalog"
+state_dir = "state"
+codex_path = "/usr/bin/false"
+bind_host = "127.0.0.1"
+port = 8793
+references_per_species = 4
+generations_per_cycle = 1
+max_generation_attempts = 3
+
+[display_node]
+controller_url = "http://controller.test:8793"
+state_dir = "display"
+
+[public_catalog]
+enabled = true
+checkout_dir = "{checkout}"
+remote = "origin"
+branch = "main"
+commit_name = "Test Publisher"
+commit_email = "publisher@example.test"
+"""
+    )
+    return path
+
+
+def _initialize_remote(root: Path) -> tuple[Path, Path]:
+    remote = root / "remote.git"
+    checkout = root / "checkout"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    subprocess.run(["git", "clone", str(remote), str(checkout)], check=True, capture_output=True)
+    _run_git(checkout, "switch", "-c", "main")
+    (checkout / "README.md").write_text("# Test catalog\n")
+    _run_git(checkout, "add", "README.md")
+    _run_git(
+        checkout,
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.test",
+        "commit",
+        "-m",
+        "Initialize catalog",
+    )
+    _run_git(checkout, "push", "-u", "origin", "main")
+    return remote, checkout
+
+
+class PublisherTests(unittest.TestCase):
+    def test_repository_seed_catalog_is_publishable(self) -> None:
+        catalog = Path(__file__).parents[1] / "catalog"
+
+        entries = validate_public_catalog(catalog)
+
+        self.assertEqual({entry.taxon_id for entry in entries}, {7562, 9083, 11935, 12942})
+
+    def test_validates_and_syncs_an_approved_catalog(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            _create_species(source, 1, "Example Bird")
+
+            result = sync_public_catalog(source, destination)
+
+            self.assertEqual(result["already_present"], [])
+            self.assertEqual(
+                result["published"],
+                [
+                    {
+                        "taxon_id": 1,
+                        "common_name": "Example Bird",
+                        "scientific_name": "Avis exemplaris",
+                    }
+                ],
+            )
+            self.assertEqual(len(validate_public_catalog(destination)), 1)
+
+            repeated = sync_public_catalog(source, destination)
+
+            self.assertEqual(repeated["published"], [])
+            self.assertEqual(repeated["already_present"], [1])
+
+    def test_rejects_private_manifest_fields(self) -> None:
+        with TemporaryDirectory() as temporary:
+            catalog = Path(temporary) / "catalog"
+            directory = _create_species(catalog, 1, "Example Bird")
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text())
+            manifest["zip_code"] = "12345"
+            write_json_atomic(manifest_path, manifest)
+
+            with self.assertRaisesRegex(CatalogPublishError, "Private field"):
+                validate_public_catalog(catalog)
+
+    def test_rejects_image_metadata(self) -> None:
+        with TemporaryDirectory() as temporary:
+            catalog = Path(temporary) / "catalog"
+            directory = _create_species(catalog, 1, "Example Bird")
+            portrait = directory / "portrait.png"
+            metadata = PngImagePlugin.PngInfo()
+            metadata.add_text("location", "private")
+            Image.new("RGB", (1200, 1600), "white").save(portrait, pnginfo=metadata)
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text())
+            manifest["assets"]["portrait"]["sha256"] = sha256_file(portrait)
+            write_json_atomic(manifest_path, manifest)
+
+            with self.assertRaisesRegex(CatalogPublishError, "metadata is not allowed"):
+                validate_public_catalog(catalog)
+
+    def test_rejects_an_automated_review_below_threshold(self) -> None:
+        with TemporaryDirectory() as temporary:
+            catalog = Path(temporary) / "catalog"
+            directory = _create_species(catalog, 1, "Example Bird")
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text())
+            manifest["quality_review"]["species_accuracy"] = 3
+            write_json_atomic(manifest_path, manifest)
+
+            with self.assertRaisesRegex(CatalogPublishError, "lacks a publishable quality review"):
+                validate_public_catalog(catalog)
+
+    def test_rejects_manifest_asset_path_traversal_before_reading_it(self) -> None:
+        with TemporaryDirectory() as temporary:
+            catalog = Path(temporary) / "catalog"
+            directory = _create_species(catalog, 1, "Example Bird")
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text())
+            manifest["assets"]["portrait"]["filename"] = "../../private.png"
+            write_json_atomic(manifest_path, manifest)
+
+            with self.assertRaisesRegex(CatalogPublishError, "must use portrait.png"):
+                validate_public_catalog(catalog)
+
+    def test_rejects_changes_to_an_existing_public_taxon(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            _create_species(source, 1, "Example Bird")
+            sync_public_catalog(source, destination)
+            public_portrait = destination / "species/1-example-bird/portrait.png"
+            public_portrait.write_bytes(b"changed")
+
+            with self.assertRaisesRegex(CatalogPublishError, "conflicts with immutable"):
+                sync_public_catalog(source, destination)
+
+    def test_publishes_through_a_real_git_remote_and_supports_dry_run(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            remote, checkout = _initialize_remote(root)
+            config = load_config(_write_config(root, checkout))
+            _create_species(config.controller.catalog_dir, 1, "Example Bird")
+
+            first = run_catalog_publish(config)
+
+            self.assertTrue(first["pushed"])
+            self.assertTrue(first["changed"])
+            self.assertIsInstance(first["commit"], str)
+            self.assertIn(
+                "catalog/species/1-example-bird/manifest.json",
+                _run_git(remote, "ls-tree", "-r", "--name-only", "main"),
+            )
+
+            second = run_catalog_publish(config)
+
+            self.assertFalse(second["pushed"])
+            self.assertFalse(second["changed"])
+
+            _create_species(config.controller.catalog_dir, 2, "Second Bird")
+            dry_run = run_catalog_publish(config, dry_run=True)
+
+            self.assertTrue(dry_run["changed"])
+            self.assertFalse(dry_run["pushed"])
+            self.assertNotIn(
+                "2-second-bird", _run_git(remote, "ls-tree", "-r", "--name-only", "main")
+            )
+
+            final = run_catalog_publish(config)
+
+            self.assertTrue(final["pushed"])
+            self.assertIn(
+                "catalog/species/2-second-bird/manifest.json",
+                _run_git(remote, "ls-tree", "-r", "--name-only", "main"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an opt-in scheduled publisher for a dedicated public catalog repository
- validate review thresholds, provenance, privacy fields, paths, checksums, dimensions, metadata, and immutable taxon identity before publication
- publish from a locked local catalog snapshot through a disposable Git worktree
- keep fetch, commit, and push failures outside the live generation and display path
- install the macOS publication LaunchAgent only when configured and preflight it before replacing services
- document the code-review/content-publication trust boundary

The separate public catalog is initialized at https://github.com/veteranbv/inky-bird-catalog with the four existing approved species.

## Validation

- `uv sync --extra dev --locked`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest` (91 passed)
- `shellcheck deploy/install-controller.sh deploy/install-display-node.sh`
- `actionlint`
- `bash -n deploy/install-controller.sh deploy/install-display-node.sh`
- `git diff --check`

The publisher integration test uses a real temporary bare Git remote and verifies initial publish, idempotence, dry-run behavior, and a later incremental publish.
