### PR TITLE
Fix controller deployment job race

### DIFF
--- a/deploy/install-controller.sh
+++ b/deploy/install-controller.sh
@@ -21,6 +21,30 @@ catalog_publish_plist="${agents_dir}/com.inky-bird-frame.catalog-publish.plist"
 notifications_plist="${agents_dir}/com.inky-bird-frame.notifications.plist"
 legacy_cycle_plist="${agents_dir}/com.inky-bird-frame.controller-cycle.plist"
 
+restore_catalog_publisher_schedule() {
+  local uid=$1
+  local recovery_dir
+  local recovery_plist
+  recovery_dir=$(mktemp -d "${support_dir}/catalog-publish-recovery.XXXXXX")
+  recovery_plist="${recovery_dir}/catalog-publish.plist"
+  if ! cp "${catalog_publish_plist}" "${recovery_plist}"; then
+    rmdir "${recovery_dir}"
+    return 1
+  fi
+  if ! /usr/bin/plutil -replace RunAtLoad -bool false "${recovery_plist}"; then
+    rm -f "${recovery_plist}"
+    rmdir "${recovery_dir}"
+    return 1
+  fi
+  if ! launchctl bootstrap "gui/${uid}" "${recovery_plist}"; then
+    rm -f "${recovery_plist}"
+    rmdir "${recovery_dir}"
+    return 1
+  fi
+  rm -f "${recovery_plist}"
+  rmdir "${recovery_dir}"
+}
+
 if [ ! -f "${config_path}" ]; then
   echo "Controller configuration is missing: ${config_path}" >&2
   exit 1
@@ -163,10 +187,16 @@ PY
 
 uid=$(id -u)
 if [ -f "${catalog_publish_plist}" ]; then
-  launchctl bootout "gui/${uid}/com.inky-bird-frame.catalog-publish" 2>/dev/null || true
+  publisher_was_loaded=false
+  if launchctl print "gui/${uid}/com.inky-bird-frame.catalog-publish" >/dev/null 2>&1; then
+    launchctl bootout "gui/${uid}/com.inky-bird-frame.catalog-publish"
+    publisher_was_loaded=true
+  fi
   if ! "${app_dir}/.venv/bin/inky-bird-frame" catalog-publish \
     --config "${config_path}" --dry-run; then
-    echo "Catalog publication validation failed; publisher remains unloaded." >&2
+    if [ "${publisher_was_loaded}" = true ]; then
+      restore_catalog_publisher_schedule "${uid}"
+    fi
     exit 1
   fi
 fi

--- a/deploy/install-controller.sh
+++ b/deploy/install-controller.sh
@@ -163,16 +163,10 @@ PY
 
 uid=$(id -u)
 if [ -f "${catalog_publish_plist}" ]; then
-  publisher_was_loaded=false
-  if launchctl print "gui/${uid}/com.inky-bird-frame.catalog-publish" >/dev/null 2>&1; then
-    launchctl bootout "gui/${uid}/com.inky-bird-frame.catalog-publish"
-    publisher_was_loaded=true
-  fi
+  launchctl bootout "gui/${uid}/com.inky-bird-frame.catalog-publish" 2>/dev/null || true
   if ! "${app_dir}/.venv/bin/inky-bird-frame" catalog-publish \
     --config "${config_path}" --dry-run; then
-    if [ "${publisher_was_loaded}" = true ]; then
-      launchctl bootstrap "gui/${uid}" "${catalog_publish_plist}" 2>/dev/null || true
-    fi
+    echo "Catalog publication validation failed; publisher remains unloaded." >&2
     exit 1
   fi
 fi

--- a/deploy/install-controller.sh
+++ b/deploy/install-controller.sh
@@ -163,10 +163,16 @@ PY
 
 uid=$(id -u)
 if [ -f "${catalog_publish_plist}" ]; then
-  launchctl bootout "gui/${uid}/com.inky-bird-frame.catalog-publish" 2>/dev/null || true
+  publisher_was_loaded=false
+  if launchctl print "gui/${uid}/com.inky-bird-frame.catalog-publish" >/dev/null 2>&1; then
+    launchctl bootout "gui/${uid}/com.inky-bird-frame.catalog-publish"
+    publisher_was_loaded=true
+  fi
   if ! "${app_dir}/.venv/bin/inky-bird-frame" catalog-publish \
     --config "${config_path}" --dry-run; then
-    launchctl bootstrap "gui/${uid}" "${catalog_publish_plist}" 2>/dev/null || true
+    if [ "${publisher_was_loaded}" = true ]; then
+      launchctl bootstrap "gui/${uid}" "${catalog_publish_plist}" 2>/dev/null || true
+    fi
     exit 1
   fi
 fi

--- a/deploy/install-controller.sh
+++ b/deploy/install-controller.sh
@@ -161,12 +161,16 @@ else:
     notifications_path.unlink(missing_ok=True)
 PY
 
+uid=$(id -u)
 if [ -f "${catalog_publish_plist}" ]; then
-  "${app_dir}/.venv/bin/inky-bird-frame" catalog-publish \
-    --config "${config_path}" --dry-run
+  launchctl bootout "gui/${uid}/com.inky-bird-frame.catalog-publish" 2>/dev/null || true
+  if ! "${app_dir}/.venv/bin/inky-bird-frame" catalog-publish \
+    --config "${config_path}" --dry-run; then
+    launchctl bootstrap "gui/${uid}" "${catalog_publish_plist}" 2>/dev/null || true
+    exit 1
+  fi
 fi
 
-uid=$(id -u)
 launchctl bootout "gui/${uid}/com.inky-bird-frame.serve" 2>/dev/null || true
 launchctl bootout "gui/${uid}/com.inky-bird-frame.controller-cycle" 2>/dev/null || true
 launchctl bootout "gui/${uid}/com.inky-bird-frame.refresh" 2>/dev/null || true

--- a/tests/test_deployment_scripts.py
+++ b/tests/test_deployment_scripts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def test_controller_installer_unloads_publisher_until_publish_validation_succeeds() -> None:
+def test_controller_installer_restores_schedule_without_run_at_load_on_failure() -> None:
     script = (Path(__file__).resolve().parents[1] / "deploy" / "install-controller.sh").read_text()
 
     validation = script.index('"${app_dir}/.venv/bin/inky-bird-frame" catalog-publish')
@@ -12,11 +12,11 @@ def test_controller_installer_unloads_publisher_until_publish_validation_succeed
         0,
         validation,
     )
-    reload_after_validation = script.index(
-        'launchctl bootstrap "gui/${uid}" "${catalog_publish_plist}"',
-        validation,
-    )
+    restore_guard = script.index('if [ "${publisher_was_loaded}" = true ]; then', validation)
+    restore = script.index('restore_catalog_publisher_schedule "${uid}"', restore_guard)
     runtime_update = script.index('rsync -a --delete "${root}/src/"')
 
-    assert runtime_update < unload < validation < reload_after_validation
-    assert "publisher remains unloaded" in script[validation:reload_after_validation]
+    assert runtime_update < unload < validation < restore_guard < restore
+    assert "publisher_was_loaded=false" in script[unload - 250 : unload]
+    assert "publisher_was_loaded=true" in script[unload:validation]
+    assert "/usr/bin/plutil -replace RunAtLoad -bool false" in script

--- a/tests/test_deployment_scripts.py
+++ b/tests/test_deployment_scripts.py
@@ -16,6 +16,9 @@ def test_controller_installer_unloads_publisher_before_publish_validation() -> N
         'launchctl bootstrap "gui/${uid}" "${catalog_publish_plist}"',
         validation,
     )
+    restore_guard = script.index('if [ "${publisher_was_loaded}" = true ]; then', validation)
     runtime_update = script.index('rsync -a --delete "${root}/src/"')
 
-    assert runtime_update < unload < validation < restore
+    assert runtime_update < unload < validation < restore_guard < restore
+    assert "publisher_was_loaded=false" in script[unload - 250 : unload]
+    assert "publisher_was_loaded=true" in script[unload:validation]

--- a/tests/test_deployment_scripts.py
+++ b/tests/test_deployment_scripts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def test_controller_installer_unloads_publisher_before_publish_validation() -> None:
+def test_controller_installer_unloads_publisher_until_publish_validation_succeeds() -> None:
     script = (Path(__file__).resolve().parents[1] / "deploy" / "install-controller.sh").read_text()
 
     validation = script.index('"${app_dir}/.venv/bin/inky-bird-frame" catalog-publish')
@@ -12,13 +12,11 @@ def test_controller_installer_unloads_publisher_before_publish_validation() -> N
         0,
         validation,
     )
-    restore = script.index(
+    reload_after_validation = script.index(
         'launchctl bootstrap "gui/${uid}" "${catalog_publish_plist}"',
         validation,
     )
-    restore_guard = script.index('if [ "${publisher_was_loaded}" = true ]; then', validation)
     runtime_update = script.index('rsync -a --delete "${root}/src/"')
 
-    assert runtime_update < unload < validation < restore_guard < restore
-    assert "publisher_was_loaded=false" in script[unload - 250 : unload]
-    assert "publisher_was_loaded=true" in script[unload:validation]
+    assert runtime_update < unload < validation < reload_after_validation
+    assert "publisher remains unloaded" in script[validation:reload_after_validation]

--- a/tests/test_deployment_scripts.py
+++ b/tests/test_deployment_scripts.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_controller_installer_unloads_publisher_before_publish_validation() -> None:
+    script = (Path(__file__).resolve().parents[1] / "deploy" / "install-controller.sh").read_text()
+
+    validation = script.index('"${app_dir}/.venv/bin/inky-bird-frame" catalog-publish')
+    unload = script.rindex(
+        'launchctl bootout "gui/${uid}/com.inky-bird-frame.catalog-publish"',
+        0,
+        validation,
+    )
+    restore = script.index(
+        'launchctl bootstrap "gui/${uid}" "${catalog_publish_plist}"',
+        validation,
+    )
+    runtime_update = script.index('rsync -a --delete "${root}/src/"')
+
+    assert runtime_update < unload < validation < restore


### PR DESCRIPTION
## Summary

- unload the scheduled catalog publisher before the installer's lock-taking dry run
- restore the publisher if validation fails so a failed deploy does not leave publication offline
- add a regression test for the required deployment ordering

## Validation

- `uv run pytest` (139 passed)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `bash -n deploy/install-controller.sh`
- `shellcheck deploy/install-controller.sh`

## Production evidence

A deployment of `408106f` failed because the existing LaunchAgent held the nonblocking catalog publication lock. Unloading that agent before retrying allowed the same revision to deploy successfully.
