### PR TITLE
Add durable shuffle bag rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,13 @@ uv run inky-bird-frame catalog-publish --config config.toml
 
 Observation windows are `last-day`, `last-week`, `last-30-days`, `last-year`,
 and `all-time`. Discovery distance is configured in kilometers with `radius_km`.
-Rotation modes are `sequential`, `shuffle`, and `weighted`. Shuffle visits every
-active bird before repeating; weighted selection uses local observation counts
-and avoids displaying the same bird twice in succession when alternatives are
-available.
+Rotation modes are `sequential`, `shuffle`, `shuffle_bag`, and `weighted`.
+`shuffle` keeps its existing shuffled-round behavior. `shuffle_bag` persists a
+separate bag: it displays each currently active bird at most once before a
+refill, adds newly active birds to the current bag immediately, prunes inactive
+birds, and avoids a repeat at the refill boundary when alternatives exist.
+`weighted` uses local observation counts and avoids displaying the same bird
+twice in succession when alternatives are available.
 Recovery and operator-override commands are documented in
 [`docs/operations.md`](docs/operations.md).
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -44,8 +44,9 @@ allowed_domains = [
 [display_node]
 controller_url = "http://controller.example:8793"
 state_dir = "var/display-node"
-# sequential visits the sorted active catalog, shuffle visits every active bird before
-# repeating, and weighted uses local observation counts as selection weights.
+# sequential visits the sorted active catalog. shuffle preserves its existing shuffled
+# round behavior. shuffle_bag immediately adds new active birds to its durable bag and
+# visits each active bird at most once before refill. weighted uses observation counts.
 rotation_mode = "shuffle"
 
 [public_catalog]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,12 +49,18 @@ The controller also exposes a read-only HTTP catalog:
 The display node does not discover birds or generate art. Each timer cycle:
 
 1. fetches the private active catalog;
-2. selects an entry using the configured sequential, shuffle, or
-   observation-weighted policy and durable local state;
+2. selects an entry using the configured sequential, shuffle, `shuffle_bag`, or
+   observation-weighted policy and durable local state. `shuffle_bag` has its
+   own persisted remaining/shown state, so catalog additions join the active bag
+   without restoring species already shown in that bag;
 3. downloads the display asset;
 4. verifies its SHA-256 checksum;
 5. writes it to a local cache atomically; and
 6. updates the Inky panel before advancing state.
+
+Display cycles use a nonblocking local process lock. A cycle that cannot obtain
+the lock fails without changing state, and failed panel updates also leave the
+prior selection state intact.
 
 This pull model keeps display addressing out of controller state and limits the
 node to a read-only catalog relationship. If refresh, generation, or controller

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -48,7 +48,12 @@ facts rather than trusting the profile's citations.
 `rotation_mode` is configured under `[display_node]`:
 
 - `sequential`: stable round-robin order;
-- `shuffle`: every active species once per shuffled round; or
+- `shuffle`: existing shuffled-round behavior; removed species are pruned, while
+  new species join on the next refill;
+- `shuffle_bag`: a separately persisted bag that shows each active species at
+  most once per refill, admits new active species immediately in randomized
+  order, prunes inactive species, and avoids repeating the prior species across
+  a refill when another species is active; or
 - `weighted`: random selection weighted by current observation count, without
   immediate repeats when another species is active.
 

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -18,6 +18,7 @@ from .errors import ConfigurationError
 class RotationMode(StrEnum):
     SEQUENTIAL = "sequential"
     SHUFFLE = "shuffle"
+    SHUFFLE_BAG = "shuffle_bag"
     WEIGHTED = "weighted"
 
 

--- a/src/inky_bird_frame/display_node.py
+++ b/src/inky_bird_frame/display_node.py
@@ -2,20 +2,25 @@
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
 import random
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 from urllib.parse import quote
 
 from .catalog import CatalogEntry, write_json_atomic
-from .config import DisplayNodeConfig
+from .config import DisplayNodeConfig, RotationMode
 from .display import show_on_inky
 from .errors import CatalogError
 from .http import get_bytes, get_json, write_bytes_atomic
-from .selection import select_catalog_entry
+from .selection import select_catalog_entry, select_shuffle_bag_entry
+
+DISPLAY_STATE_SCHEMA_VERSION = 2
 
 
 @dataclass(frozen=True)
@@ -24,6 +29,22 @@ class DisplayState:
     last_sha256: str = ""
     last_taxon_id: int | None = None
     shuffle_remaining: tuple[int, ...] = ()
+    shuffle_bag_remaining: tuple[int, ...] = ()
+    shuffle_bag_seen: tuple[int, ...] = ()
+
+
+@contextmanager
+def exclusive_display_cycle_lock(state_dir: Path) -> Iterator[None]:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    with (state_dir / "display-cycle.lock").open("a+") as handle:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise CatalogError("Another display cycle is already running") from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 def parse_catalog_entries(payload: object) -> list[CatalogEntry]:
@@ -33,6 +54,7 @@ def parse_catalog_entries(payload: object) -> list[CatalogEntry]:
     if not isinstance(species, list):
         raise CatalogError("Controller catalog has no species list")
     entries: list[CatalogEntry] = []
+    taxon_ids: set[int] = set()
     for raw in species:
         if not isinstance(raw, dict):
             raise CatalogError("Controller catalog entry must be an object")
@@ -50,10 +72,16 @@ def parse_catalog_entries(payload: object) -> list[CatalogEntry]:
                 "approved_at",
             )
         }
-        if not isinstance(taxon_id, int) or any(
-            not isinstance(value, str) for value in strings.values()
+        if (
+            not isinstance(taxon_id, int)
+            or isinstance(taxon_id, bool)
+            or taxon_id <= 0
+            or any(not isinstance(value, str) for value in strings.values())
         ):
             raise CatalogError("Controller catalog entry has invalid fields")
+        if taxon_id in taxon_ids:
+            raise CatalogError(f"Controller catalog has duplicate taxon ID: {taxon_id}")
+        taxon_ids.add(taxon_id)
         observation_count = raw.get("observation_count", 1)
         if (
             not isinstance(observation_count, int)
@@ -80,19 +108,50 @@ def parse_catalog_entries(payload: object) -> list[CatalogEntry]:
     return entries
 
 
+def _state_taxon_ids(raw: object, path: Path) -> tuple[int, ...]:
+    if (
+        not isinstance(raw, list)
+        or any(not isinstance(item, int) or isinstance(item, bool) or item <= 0 for item in raw)
+        or len(raw) != len(set(raw))
+    ):
+        raise CatalogError(f"Invalid display-node state: {path}")
+    return tuple(raw)
+
+
 def _read_state(path: Path) -> DisplayState:
     if not path.is_file():
         return DisplayState()
     try:
-        raw = json.loads(path.read_text())
-    except json.JSONDecodeError as exc:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise CatalogError(f"Invalid display-node state: {path}") from exc
     if not isinstance(raw, dict):
+        raise CatalogError(f"Invalid display-node state: {path}")
+    schema_version = raw.get("schema_version", 1)
+    if (
+        not isinstance(schema_version, int)
+        or isinstance(schema_version, bool)
+        or schema_version not in {1, DISPLAY_STATE_SCHEMA_VERSION}
+    ):
+        raise CatalogError(f"Invalid display-node state: {path}")
+    if schema_version == DISPLAY_STATE_SCHEMA_VERSION and any(
+        name not in raw
+        for name in (
+            "next_index",
+            "last_sha256",
+            "last_taxon_id",
+            "shuffle_remaining",
+            "shuffle_bag_remaining",
+            "shuffle_bag_seen",
+        )
+    ):
         raise CatalogError(f"Invalid display-node state: {path}")
     next_index = raw.get("next_index", 0)
     last_sha256 = raw.get("last_sha256", "")
     last_taxon_id = raw.get("last_taxon_id")
-    shuffle_remaining = raw.get("shuffle_remaining", [])
+    shuffle_remaining = _state_taxon_ids(raw.get("shuffle_remaining", []), path)
+    shuffle_bag_remaining = _state_taxon_ids(raw.get("shuffle_bag_remaining", []), path)
+    shuffle_bag_seen = _state_taxon_ids(raw.get("shuffle_bag_seen", []), path)
     if (
         not isinstance(next_index, int)
         or isinstance(next_index, bool)
@@ -100,17 +159,22 @@ def _read_state(path: Path) -> DisplayState:
         or not isinstance(last_sha256, str)
         or (
             last_taxon_id is not None
-            and (not isinstance(last_taxon_id, int) or isinstance(last_taxon_id, bool))
+            and (
+                not isinstance(last_taxon_id, int)
+                or isinstance(last_taxon_id, bool)
+                or last_taxon_id <= 0
+            )
         )
-        or not isinstance(shuffle_remaining, list)
-        or any(not isinstance(item, int) or isinstance(item, bool) for item in shuffle_remaining)
+        or set(shuffle_bag_remaining) & set(shuffle_bag_seen)
     ):
         raise CatalogError(f"Invalid display-node state: {path}")
     return DisplayState(
         next_index=next_index,
         last_sha256=last_sha256,
         last_taxon_id=last_taxon_id,
-        shuffle_remaining=tuple(shuffle_remaining),
+        shuffle_remaining=shuffle_remaining,
+        shuffle_bag_remaining=shuffle_bag_remaining,
+        shuffle_bag_seen=shuffle_bag_seen,
     )
 
 
@@ -120,16 +184,20 @@ def _write_state(
     selected: CatalogEntry,
     next_index: int,
     shuffle_remaining: list[int],
+    shuffle_bag_remaining: list[int],
+    shuffle_bag_seen: list[int],
     last_sha256: str,
 ) -> None:
     write_json_atomic(
         path,
         {
-            "schema_version": 1,
+            "schema_version": DISPLAY_STATE_SCHEMA_VERSION,
             "next_index": next_index,
             "last_sha256": last_sha256,
             "last_taxon_id": selected.taxon_id,
             "shuffle_remaining": shuffle_remaining,
+            "shuffle_bag_remaining": shuffle_bag_remaining,
+            "shuffle_bag_seen": shuffle_bag_seen,
         },
     )
 
@@ -140,53 +208,71 @@ def run_display_cycle(
     force: bool = False,
     rng: random.Random | random.SystemRandom | None = None,
 ) -> dict[str, object]:
-    catalog_payload = get_json(f"{config.controller_url}/v1/catalog", 20.0)
-    entries = parse_catalog_entries(catalog_payload)
-    state_path = config.state_dir / "state.json"
-    state = _read_state(state_path)
-    selected, following_index, shuffle_remaining = select_catalog_entry(
-        entries,
-        config.rotation_mode,
-        next_index=state.next_index,
-        last_taxon_id=state.last_taxon_id,
-        shuffle_remaining=list(state.shuffle_remaining),
-        rng=rng,
-    )
-    if selected.display_sha256 == state.last_sha256 and not force:
+    with exclusive_display_cycle_lock(config.state_dir):
+        catalog_payload = get_json(f"{config.controller_url}/v1/catalog", 20.0)
+        entries = parse_catalog_entries(catalog_payload)
+        state_path = config.state_dir / "state.json"
+        state = _read_state(state_path)
+        shuffle_remaining = list(state.shuffle_remaining)
+        shuffle_bag_remaining = list(state.shuffle_bag_remaining)
+        shuffle_bag_seen = list(state.shuffle_bag_seen)
+        if config.rotation_mode is RotationMode.SHUFFLE_BAG:
+            selected, shuffle_bag_remaining, shuffle_bag_seen = select_shuffle_bag_entry(
+                entries,
+                last_taxon_id=state.last_taxon_id,
+                shuffle_bag_remaining=shuffle_bag_remaining,
+                shuffle_bag_seen=shuffle_bag_seen,
+                rng=rng,
+            )
+            following_index = state.next_index
+        else:
+            selected, following_index, shuffle_remaining = select_catalog_entry(
+                entries,
+                config.rotation_mode,
+                next_index=state.next_index,
+                last_taxon_id=state.last_taxon_id,
+                shuffle_remaining=shuffle_remaining,
+                rng=rng,
+            )
+        if selected.display_sha256 == state.last_sha256 and not force:
+            _write_state(
+                state_path,
+                selected=selected,
+                next_index=following_index,
+                shuffle_remaining=shuffle_remaining,
+                shuffle_bag_remaining=shuffle_bag_remaining,
+                shuffle_bag_seen=shuffle_bag_seen,
+                last_sha256=state.last_sha256,
+            )
+            return {
+                "display_update": "unchanged",
+                "taxon_id": selected.taxon_id,
+                "common_name": selected.common_name,
+            }
+
+        encoded_path = quote(selected.display_path, safe="/")
+        image_bytes = get_bytes(f"{config.controller_url}/v1/assets/{encoded_path}", 60.0)
+        actual_hash = hashlib.sha256(image_bytes).hexdigest()
+        if actual_hash != selected.display_sha256:
+            raise CatalogError(
+                f"Downloaded asset checksum mismatch for {selected.common_name}: {actual_hash}"
+            )
+        image_path = config.state_dir / "cache" / f"{selected.taxon_id}-{actual_hash[:12]}.png"
+        write_bytes_atomic(image_path, image_bytes)
+        display_size = show_on_inky(image_path)
         _write_state(
             state_path,
             selected=selected,
             next_index=following_index,
             shuffle_remaining=shuffle_remaining,
-            last_sha256=state.last_sha256,
+            shuffle_bag_remaining=shuffle_bag_remaining,
+            shuffle_bag_seen=shuffle_bag_seen,
+            last_sha256=actual_hash,
         )
         return {
-            "display_update": "unchanged",
+            "display_update": "sent",
             "taxon_id": selected.taxon_id,
             "common_name": selected.common_name,
+            "display_size": display_size,
+            "sha256": actual_hash,
         }
-
-    encoded_path = quote(selected.display_path, safe="/")
-    image_bytes = get_bytes(f"{config.controller_url}/v1/assets/{encoded_path}", 60.0)
-    actual_hash = hashlib.sha256(image_bytes).hexdigest()
-    if actual_hash != selected.display_sha256:
-        raise CatalogError(
-            f"Downloaded asset checksum mismatch for {selected.common_name}: {actual_hash}"
-        )
-    image_path = config.state_dir / "cache" / f"{selected.taxon_id}-{actual_hash[:12]}.png"
-    write_bytes_atomic(image_path, image_bytes)
-    display_size = show_on_inky(image_path)
-    _write_state(
-        state_path,
-        selected=selected,
-        next_index=following_index,
-        shuffle_remaining=shuffle_remaining,
-        last_sha256=actual_hash,
-    )
-    return {
-        "display_update": "sent",
-        "taxon_id": selected.taxon_id,
-        "common_name": selected.common_name,
-        "display_size": display_size,
-        "sha256": actual_hash,
-    }

--- a/src/inky_bird_frame/selection.py
+++ b/src/inky_bird_frame/selection.py
@@ -36,7 +36,7 @@ def select_catalog_entry(
         return selected, (next_index + 1) % len(entries), []
 
     random_source = rng or random.SystemRandom()
-    by_taxon = {entry.taxon_id: entry for entry in entries}
+    by_taxon = _entries_by_taxon(entries)
     candidates = [entry for entry in entries if entry.taxon_id != last_taxon_id] or entries
 
     if mode is RotationMode.WEIGHTED:
@@ -47,11 +47,73 @@ def select_catalog_entry(
         )[0]
         return selected, next_index, []
 
+    if mode is not RotationMode.SHUFFLE:
+        raise ValueError(f"Unsupported rotation mode: {mode}")
+
     remaining = [taxon_id for taxon_id in shuffle_remaining if taxon_id in by_taxon]
     if not remaining:
         remaining = list(by_taxon)
-        random_source.shuffle(remaining)
-        if len(remaining) > 1 and remaining[0] == last_taxon_id:
-            remaining[0], remaining[1] = remaining[1], remaining[0]
+        _shuffle_without_immediate_repeat(remaining, last_taxon_id, random_source)
     selected = by_taxon[remaining.pop(0)]
     return selected, next_index, remaining
+
+
+def select_shuffle_bag_entry(
+    entries: list[CatalogEntry],
+    *,
+    last_taxon_id: int | None,
+    shuffle_bag_remaining: list[int],
+    shuffle_bag_seen: list[int],
+    rng: random.Random | random.SystemRandom | None = None,
+) -> tuple[CatalogEntry, list[int], list[int]]:
+    """Select from a durable bag while admitting newly active entries immediately."""
+    if not entries:
+        raise ValueError("catalog entries must not be empty")
+
+    random_source = rng or random.SystemRandom()
+    by_taxon = _entries_by_taxon(entries)
+    active_taxon_ids = list(by_taxon)
+    _validate_unique_taxon_ids(shuffle_bag_remaining, "shuffle_bag_remaining")
+    _validate_unique_taxon_ids(shuffle_bag_seen, "shuffle_bag_seen")
+    if set(shuffle_bag_remaining) & set(shuffle_bag_seen):
+        raise ValueError("shuffle_bag_remaining and shuffle_bag_seen must not overlap")
+
+    remaining = [taxon_id for taxon_id in shuffle_bag_remaining if taxon_id in by_taxon]
+    seen = [taxon_id for taxon_id in shuffle_bag_seen if taxon_id in by_taxon]
+    known_taxon_ids = set(remaining) | set(seen)
+    additions = [taxon_id for taxon_id in active_taxon_ids if taxon_id not in known_taxon_ids]
+    if additions:
+        remaining.extend(additions)
+        _shuffle_without_immediate_repeat(remaining, last_taxon_id, random_source)
+    elif not remaining:
+        remaining = active_taxon_ids
+        seen = []
+        _shuffle_without_immediate_repeat(remaining, last_taxon_id, random_source)
+
+    selected_taxon_id = remaining.pop(0)
+    seen.append(selected_taxon_id)
+    return by_taxon[selected_taxon_id], remaining, seen
+
+
+def _entries_by_taxon(entries: list[CatalogEntry]) -> dict[int, CatalogEntry]:
+    by_taxon: dict[int, CatalogEntry] = {}
+    for entry in entries:
+        if entry.taxon_id in by_taxon:
+            raise ValueError(f"Duplicate catalog taxon ID: {entry.taxon_id}")
+        by_taxon[entry.taxon_id] = entry
+    return by_taxon
+
+
+def _validate_unique_taxon_ids(taxon_ids: list[int], name: str) -> None:
+    if len(taxon_ids) != len(set(taxon_ids)):
+        raise ValueError(f"{name} must not contain duplicate taxon IDs")
+
+
+def _shuffle_without_immediate_repeat(
+    taxon_ids: list[int],
+    last_taxon_id: int | None,
+    rng: random.Random | random.SystemRandom,
+) -> None:
+    rng.shuffle(taxon_ids)
+    if len(taxon_ids) > 1 and taxon_ids[0] == last_taxon_id:
+        taxon_ids[0], taxon_ids[1] = taxon_ids[1], taxon_ids[0]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -164,6 +164,17 @@ class ConfigTests(unittest.TestCase):
             with self.assertRaises(ConfigurationError):
                 load_config(path)
 
+    def test_loads_shuffle_bag_rotation_policy(self) -> None:
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(
+                CONFIG.replace('rotation_mode = "weighted"', 'rotation_mode = "shuffle_bag"')
+            )
+
+            config = load_config(path)
+
+        self.assertEqual(config.display_node.rotation_mode, RotationMode.SHUFFLE_BAG)
+
     def test_loads_research_queue_and_notification_settings(self) -> None:
         configured = (
             CONFIG

--- a/tests/test_display_node.py
+++ b/tests/test_display_node.py
@@ -2,13 +2,44 @@ from __future__ import annotations
 
 import hashlib
 import json
+import random
 import unittest
+from collections.abc import Callable
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
-from inky_bird_frame.config import DisplayNodeConfig
-from inky_bird_frame.display_node import run_display_cycle
+from inky_bird_frame.config import DisplayNodeConfig, RotationMode
+from inky_bird_frame.display_node import _read_state, parse_catalog_entries, run_display_cycle
+from inky_bird_frame.errors import CatalogError
+
+
+def catalog_payload(images: dict[int, bytes]) -> dict[str, object]:
+    species: list[dict[str, object]] = []
+    for taxon_id, image in images.items():
+        species.append(
+            {
+                "taxon_id": taxon_id,
+                "common_name": f"Bird {taxon_id}",
+                "scientific_name": f"Species {taxon_id}",
+                "slug": f"bird-{taxon_id}",
+                "portrait_path": f"species/{taxon_id}/portrait.png",
+                "portrait_sha256": "b" * 64,
+                "display_path": f"{taxon_id}.png",
+                "display_sha256": hashlib.sha256(image).hexdigest(),
+                "approved_at": "2026-07-09T00:00:00+00:00",
+            }
+        )
+    return {"schema_version": 1, "species": species}
+
+
+def asset_response(images: dict[int, bytes]) -> Callable[[str, float], bytes]:
+    def get_asset(url: str, timeout: float) -> bytes:
+        del timeout
+        taxon_id = int(url.rsplit("/", maxsplit=1)[-1].removesuffix(".png"))
+        return images[taxon_id]
+
+    return get_asset
 
 
 class DisplayNodeTests(unittest.TestCase):
@@ -93,10 +124,158 @@ class DisplayNodeTests(unittest.TestCase):
             ):
                 unchanged = run_display_cycle(config)
                 updated = run_display_cycle(config)
+                state = json.loads((state_dir / "state.json").read_text())
 
         self.assertEqual(unchanged["display_update"], "unchanged")
         self.assertEqual(updated["taxon_id"], 2)
+        self.assertEqual(state["schema_version"], 2)
         get_bytes.assert_called_once()
+
+    def test_shuffle_bag_persists_across_cycles_without_replacement(self) -> None:
+        images = {1: b"one", 2: b"two", 3: b"three"}
+        payload = catalog_payload(images)
+        with TemporaryDirectory() as temporary:
+            config = DisplayNodeConfig(
+                "http://controller.test",
+                Path(temporary),
+                RotationMode.SHUFFLE_BAG,
+            )
+            with (
+                patch("inky_bird_frame.display_node.get_json", return_value=payload),
+                patch("inky_bird_frame.display_node.get_bytes", side_effect=asset_response(images)),
+                patch("inky_bird_frame.display_node.show_on_inky", return_value=(1600, 1200)),
+            ):
+                first = run_display_cycle(config, rng=random.Random(7))
+                second = run_display_cycle(config, rng=random.Random(99))
+                state = json.loads((Path(temporary) / "state.json").read_text())
+
+        self.assertNotEqual(first["taxon_id"], second["taxon_id"])
+        self.assertEqual(state["schema_version"], 2)
+        self.assertEqual(len(state["shuffle_bag_seen"]), 2)
+        self.assertEqual(len(state["shuffle_bag_remaining"]), 1)
+
+    def test_shuffle_bag_state_is_independent_from_shuffle_on_mode_switch(self) -> None:
+        images = {1: b"one", 2: b"two", 3: b"three"}
+        payload = catalog_payload(images)
+        with TemporaryDirectory() as temporary:
+            state_path = Path(temporary) / "state.json"
+            state_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "next_index": 0,
+                        "last_sha256": "",
+                        "last_taxon_id": 1,
+                        "shuffle_remaining": [2],
+                        "shuffle_bag_remaining": [3],
+                        "shuffle_bag_seen": [1, 2],
+                    }
+                )
+            )
+            shuffle_bag_config = DisplayNodeConfig(
+                "http://controller.test", Path(temporary), RotationMode.SHUFFLE_BAG
+            )
+            shuffle_config = DisplayNodeConfig(
+                "http://controller.test", Path(temporary), RotationMode.SHUFFLE
+            )
+            with (
+                patch("inky_bird_frame.display_node.get_json", return_value=payload),
+                patch("inky_bird_frame.display_node.get_bytes", side_effect=asset_response(images)),
+                patch("inky_bird_frame.display_node.show_on_inky", return_value=(1600, 1200)),
+            ):
+                bag_result = run_display_cycle(shuffle_bag_config, rng=random.Random(1))
+                after_bag = json.loads(state_path.read_text())
+                shuffle_result = run_display_cycle(shuffle_config, rng=random.Random(1))
+
+        self.assertEqual(bag_result["taxon_id"], 3)
+        self.assertEqual(after_bag["shuffle_remaining"], [2])
+        self.assertEqual(shuffle_result["taxon_id"], 2)
+
+    def test_display_failure_does_not_advance_shuffle_bag_state(self) -> None:
+        images = {1: b"one", 2: b"two"}
+        payload = catalog_payload(images)
+        original_state = {
+            "schema_version": 2,
+            "next_index": 0,
+            "last_sha256": "",
+            "last_taxon_id": 1,
+            "shuffle_remaining": [],
+            "shuffle_bag_remaining": [2],
+            "shuffle_bag_seen": [1],
+        }
+        with TemporaryDirectory() as temporary:
+            state_path = Path(temporary) / "state.json"
+            state_path.write_text(json.dumps(original_state))
+            config = DisplayNodeConfig(
+                "http://controller.test", Path(temporary), RotationMode.SHUFFLE_BAG
+            )
+            with (
+                patch("inky_bird_frame.display_node.get_json", return_value=payload),
+                patch("inky_bird_frame.display_node.get_bytes", side_effect=asset_response(images)),
+                patch(
+                    "inky_bird_frame.display_node.show_on_inky", side_effect=OSError("panel failed")
+                ),
+                self.assertRaisesRegex(OSError, "panel failed"),
+            ):
+                run_display_cycle(config)
+            state_after_failure = json.loads(state_path.read_text())
+
+        self.assertEqual(state_after_failure, original_state)
+
+    def test_rejects_malformed_state_and_accepts_legacy_state(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_path = Path(temporary) / "state.json"
+            state_path.write_text(json.dumps({"next_index": 1, "shuffle_remaining": [2]}))
+            legacy = _read_state(state_path)
+
+            state_path.write_text(json.dumps({"schema_version": 3}))
+            with self.assertRaises(CatalogError):
+                _read_state(state_path)
+            state_path.write_text(json.dumps({"schema_version": 2}))
+            with self.assertRaises(CatalogError):
+                _read_state(state_path)
+            state_path.write_text(json.dumps({"shuffle_bag_remaining": [1, 1]}))
+            with self.assertRaises(CatalogError):
+                _read_state(state_path)
+            state_path.write_text(json.dumps({"shuffle_bag_remaining": [0]}))
+            with self.assertRaises(CatalogError):
+                _read_state(state_path)
+            state_path.write_bytes(b"\xff")
+            with self.assertRaises(CatalogError):
+                _read_state(state_path)
+
+        self.assertEqual(legacy.next_index, 1)
+        self.assertEqual(legacy.shuffle_remaining, (2,))
+
+    def test_rejects_duplicate_or_empty_catalogs(self) -> None:
+        payload = catalog_payload({1: b"one"})
+        cast_species = payload["species"]
+        assert isinstance(cast_species, list)
+        duplicate = dict(cast_species[0])
+        cast_species.append(duplicate)
+
+        with self.assertRaises(CatalogError):
+            parse_catalog_entries(payload)
+        invalid_taxon = catalog_payload({1: b"one"})
+        invalid_species = invalid_taxon["species"]
+        assert isinstance(invalid_species, list)
+        invalid_species[0]["taxon_id"] = True
+        with self.assertRaises(CatalogError):
+            parse_catalog_entries(invalid_taxon)
+        with self.assertRaises(CatalogError):
+            parse_catalog_entries({"schema_version": 1, "species": []})
+
+    def test_rejects_overlapping_display_cycles_before_fetching_catalog(self) -> None:
+        with TemporaryDirectory() as temporary:
+            config = DisplayNodeConfig("http://controller.test", Path(temporary))
+            with (
+                patch("inky_bird_frame.display_node.fcntl.flock", side_effect=BlockingIOError),
+                patch("inky_bird_frame.display_node.get_json") as get_json,
+                self.assertRaisesRegex(CatalogError, "already running"),
+            ):
+                run_display_cycle(config)
+
+        get_json.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -6,7 +6,11 @@ import unittest
 from inky_bird_frame.birds import BirdSpecies
 from inky_bird_frame.catalog import CatalogEntry
 from inky_bird_frame.config import RotationMode
-from inky_bird_frame.selection import select_catalog_entry, select_rotating_species
+from inky_bird_frame.selection import (
+    select_catalog_entry,
+    select_rotating_species,
+    select_shuffle_bag_entry,
+)
 
 
 def catalog_entry(taxon_id: int, count: int) -> CatalogEntry:
@@ -98,6 +102,95 @@ class SelectionTests(unittest.TestCase):
         )
 
         self.assertEqual(selected.taxon_id, 2)
+
+    def test_shuffle_bag_visits_each_entry_without_replacement_before_refill(self) -> None:
+        entries = [catalog_entry(1, 10), catalog_entry(2, 5), catalog_entry(3, 1)]
+        rng = random.Random(7)
+        remaining: list[int] = []
+        seen: list[int] = []
+        last_taxon_id: int | None = None
+        selected_ids: list[int] = []
+
+        for _ in range(len(entries) * 2):
+            selected, remaining, seen = select_shuffle_bag_entry(
+                entries,
+                last_taxon_id=last_taxon_id,
+                shuffle_bag_remaining=remaining,
+                shuffle_bag_seen=seen,
+                rng=rng,
+            )
+            selected_ids.append(selected.taxon_id)
+            last_taxon_id = selected.taxon_id
+
+        self.assertEqual(set(selected_ids[:3]), {1, 2, 3})
+        self.assertEqual(set(selected_ids[3:]), {1, 2, 3})
+        self.assertTrue(
+            all(left != right for left, right in zip(selected_ids, selected_ids[1:], strict=False))
+        )
+
+    def test_shuffle_bag_adds_new_entries_and_prunes_removed_entries_mid_bag(self) -> None:
+        entries = [catalog_entry(1, 10), catalog_entry(2, 5), catalog_entry(3, 1)]
+        rng = random.Random(7)
+        first, remaining, seen = select_shuffle_bag_entry(
+            entries,
+            last_taxon_id=None,
+            shuffle_bag_remaining=[],
+            shuffle_bag_seen=[],
+            rng=rng,
+        )
+        removed_taxon_id = remaining[0]
+        updated_entries = [entry for entry in entries if entry.taxon_id != removed_taxon_id] + [
+            catalog_entry(4, 2)
+        ]
+        selected_ids = [first.taxon_id]
+
+        while remaining:
+            selected, remaining, seen = select_shuffle_bag_entry(
+                updated_entries,
+                last_taxon_id=selected_ids[-1],
+                shuffle_bag_remaining=remaining,
+                shuffle_bag_seen=seen,
+                rng=rng,
+            )
+            selected_ids.append(selected.taxon_id)
+
+        self.assertNotIn(removed_taxon_id, selected_ids)
+        self.assertEqual(len(selected_ids), len(set(selected_ids)))
+        self.assertIn(4, selected_ids)
+
+    def test_shuffle_bag_selects_an_addition_before_refilling_shown_entries(self) -> None:
+        entries = [catalog_entry(1, 10), catalog_entry(3, 1)]
+
+        selected, remaining, seen = select_shuffle_bag_entry(
+            entries,
+            last_taxon_id=1,
+            shuffle_bag_remaining=[2],
+            shuffle_bag_seen=[1],
+            rng=random.Random(7),
+        )
+
+        self.assertEqual(selected.taxon_id, 3)
+        self.assertEqual(remaining, [])
+        self.assertEqual(seen, [1, 3])
+
+    def test_shuffle_bag_allows_a_singleton_catalog(self) -> None:
+        entries = [catalog_entry(1, 1)]
+        first, remaining, seen = select_shuffle_bag_entry(
+            entries,
+            last_taxon_id=None,
+            shuffle_bag_remaining=[],
+            shuffle_bag_seen=[],
+            rng=random.Random(1),
+        )
+        second, _, _ = select_shuffle_bag_entry(
+            entries,
+            last_taxon_id=first.taxon_id,
+            shuffle_bag_remaining=remaining,
+            shuffle_bag_seen=seen,
+            rng=random.Random(2),
+        )
+
+        self.assertEqual((first.taxon_id, second.taxon_id), (1, 1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add `shuffle_bag` as a fourth rotation policy without changing existing `shuffle`
- persist separate remaining/shown state across restarts, immediately admit newly active birds, and prune inactive birds
- avoid repeats within a bag and across refill boundaries when alternatives exist
- validate state/catalog IDs and serialize display cycles with a nonblocking process lock
- preserve selection state when panel updates fail
- document all rotation policies and state behavior

## Validation

- `uv run pytest` (149 passed)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `bash -n deploy/install-display-node.sh`
- `git diff --check`

## Live rollout

After review and merge, production will be changed from `shuffle` to `shuffle_bag` and redeployed to the CM4. The current three-minute rotation interval remains unchanged.
