### PR TITLE
Recommend practical defaults and require species taxa

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ uv run inky-bird-frame catalog-publish --config config.toml
 
 Observation windows are `last-day`, `last-week`, `last-30-days`, `last-year`,
 and `all-time`. Discovery distance is configured in kilometers with `radius_km`.
+Discovery admits only species-rank iNaturalist results, excluding unresolved
+genera, families, and other aggregate taxa from generation.
 Rotation modes are `sequential`, `shuffle`, `shuffle_bag`, and `weighted`.
 `shuffle` keeps its existing shuffled-round behavior. `shuffle_bag` persists a
 separate bag: it displays each currently active bird at most once before a

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,9 +1,15 @@
 [discovery]
 # This location is used only to discover species. It is never rendered on a plate.
 zip_code = "12345"
+# Eight kilometers is approximately five miles: local enough to feel relevant while
+# usually covering enough observations for variety. Increase it in sparsely observed areas.
 radius_km = 8
-species_limit = 12
-window = "last-week"
+# This caps the observation result set, not generation work per cycle. Fifty avoids
+# truncating typical local results while keeping the active catalog intentionally bounded.
+species_limit = 50
+# Thirty days balances seasonal relevance with coverage. Shorter windows can be sparse;
+# last-year and all-time are better suited to one-time catalog seeding.
+window = "last-30-days"
 
 [controller]
 workspace_dir = "."
@@ -26,9 +32,12 @@ retry_max_minutes = 1440
 insufficient_references_retry_minutes = 10080
 
 [research]
-# Successful profiles are cached by taxon. These limits apply only to new bounded searches.
+# Successful profiles are cached by taxon, so retries of the artwork do not research the
+# species again. Five searches/day matches the default four generation cycles/day with room
+# for one recovery. Raise it deliberately when generation_minutes is reduced or after seeding.
 enabled = true
 max_searches_per_day = 5
+# Two allows one normal profile attempt and one bounded recovery for the same species.
 max_searches_per_species = 2
 allowed_domains = [
     "allaboutbirds.org",
@@ -44,10 +53,10 @@ allowed_domains = [
 [display_node]
 controller_url = "http://controller.example:8793"
 state_dir = "var/display-node"
-# sequential visits the sorted active catalog. shuffle preserves its existing shuffled
-# round behavior. shuffle_bag immediately adds new active birds to its durable bag and
-# visits each active bird at most once before refill. weighted uses observation counts.
-rotation_mode = "shuffle"
+# shuffle_bag is recommended: it visits every active bird once before refill and admits new
+# birds immediately. sequential is stable order; shuffle refills before admitting additions;
+# weighted favors frequently observed birds.
+rotation_mode = "shuffle_bag"
 
 [public_catalog]
 # The trusted controller opens and owner-merges catalog-only PRs in this repository.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,8 @@ The controller owns discovery and generation through independent schedules.
 An observation refresh:
 
 1. resolves the private discovery location;
-2. queries iNaturalist species counts for the configured radius and window;
+2. queries iNaturalist species counts for the configured radius and window,
+   requiring species rank in both the request and response;
 3. atomically stores the private observation snapshot; and
 4. publishes a private active catalog containing only observed taxa that
    already have approved plates.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -5,6 +5,27 @@
 Keep the deployment configuration outside the Git checkout. Required fields are
 documented in `config.example.toml`.
 
+Recommended starting values balance local relevance, seasonal variety, API use,
+and subscription-backed generation:
+
+| Setting | Recommended | Why |
+| --- | --- | --- |
+| `discovery.radius_km` | `8` | Approximately five miles; widen it in sparsely observed areas. |
+| `discovery.species_limit` | `50` | Avoids truncating normal local results without creating an unbounded active set. |
+| `discovery.window` | `"last-30-days"` | More reliable than a short window while remaining seasonally relevant. |
+| `schedule.refresh_minutes` | `15` | Keeps observations current at a modest API request rate. |
+| `schedule.generation_minutes` | `360` | Generates at most four new plates per day by default. |
+| `controller.generations_per_cycle` | `1` | Bounds work and recovery impact per invocation. |
+| `research.max_searches_per_day` | `5` | Covers the default generation rate plus one recovery. |
+| `research.max_searches_per_species` | `2` | Allows one normal attempt and one bounded recovery. |
+| `schedule.rotation_minutes` | `30` | A calm starting cadence for an e-paper display. |
+| `display_node.rotation_mode` | `"shuffle_bag"` | Shows every active bird once before repeating. |
+
+These are operating recommendations, not service limits. A controller configured
+to generate more frequently should raise `max_searches_per_day` intentionally;
+cached profiles do not consume the budget again. Use `seed` for a broad historical
+catalog instead of making the active observation window permanently broad.
+
 The controller's `workspace_dir` must be writable because the Codex image tool
 copies its final image there. `catalog_dir` and `state_dir` must persist across
 deployments. `codex_path` must point to a Codex CLI whose `login status` reports
@@ -32,7 +53,9 @@ use the longer `insufficient_references_retry_minutes` delay because source
 availability changes slowly. Later birds continue through the queue. Exhausted
 factual or visual review remains terminal and requires `retry TAXON_ID`.
 
-Species context uses iNaturalist first and the Cornell BirdNET Taxonomy API when
+Discovery requests and validates species-rank iNaturalist results so genera,
+families, and other aggregate taxa never enter generation. Species context uses
+iNaturalist first and the Cornell BirdNET Taxonomy API when
 iNaturalist omits its descriptive context. The fallback is accepted only when
 the iNaturalist taxon ID and scientific name match exactly. Licensed reference
 photos remain research-grade CC0 or CC BY iNaturalist observations from distinct

--- a/src/inky_bird_frame/birds.py
+++ b/src/inky_bird_frame/birds.py
@@ -92,6 +92,8 @@ def parse_inaturalist_species_counts(payload: object) -> list[BirdSpecies]:
         taxon = item.get("taxon")
         if not isinstance(taxon, dict):
             continue
+        if taxon.get("rank") != "species":
+            continue
         common = taxon.get("preferred_common_name")
         scientific = taxon.get("name")
         taxon_id = taxon.get("id")
@@ -135,6 +137,7 @@ def fetch_inaturalist_birds(
         "lat": f"{latitude:.6f}",
         "lng": f"{longitude:.6f}",
         "radius": str(radius_km),
+        "rank": "species",
         "verifiable": "true",
         "photos": "true",
         "per_page": str(limit),

--- a/tests/test_birds.py
+++ b/tests/test_birds.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import unittest
 from datetime import date
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlsplit
 
 from inky_bird_frame.birds import (
     ObservationWindow,
     date_range_for_window,
+    fetch_inaturalist_birds,
     fetch_taxon_context,
     parse_birdnet_taxon,
     parse_inaturalist_species_counts,
@@ -26,6 +28,16 @@ class InaturalistParsingTests(unittest.TestCase):
                         "id": 12942,
                         "preferred_common_name": "Eastern Bluebird",
                         "name": "Sialia sialis",
+                        "rank": "species",
+                    },
+                },
+                {
+                    "count": 4,
+                    "taxon": {
+                        "id": 7846,
+                        "preferred_common_name": "Flycatcher-shrikes",
+                        "name": "Malaconotidae",
+                        "rank": "family",
                     },
                 },
                 {"count": 2, "taxon": {"name": "No common name"}},
@@ -48,6 +60,23 @@ class InaturalistParsingTests(unittest.TestCase):
 
     def test_parse_species_counts_accepts_an_empty_result_set(self) -> None:
         self.assertEqual(parse_inaturalist_species_counts({"results": []}), [])
+
+    @patch("inky_bird_frame.birds.get_json", return_value={"results": []})
+    def test_fetch_species_counts_requests_species_rank(self, get_json: MagicMock) -> None:
+        species = fetch_inaturalist_birds(
+            latitude=38.0,
+            longitude=-77.0,
+            radius_km=8,
+            limit=50,
+            window=ObservationWindow.LAST_30_DAYS,
+            today=date(2026, 7, 9),
+        )
+
+        self.assertEqual(species, [])
+        url = get_json.call_args.args[0]
+        params = parse_qs(urlsplit(url).query)
+        self.assertEqual(params["rank"], ["species"])
+        self.assertEqual(params["per_page"], ["50"])
 
     def test_date_range_for_window(self) -> None:
         today = date(2026, 7, 9)


### PR DESCRIPTION
## Summary
- require species rank in iNaturalist discovery requests and validate it again when parsing responses
- update the example TOML to a practical local, seasonal, no-repeat starting profile
- document how discovery, scheduling, and research-budget settings relate

## Rationale
iNaturalist species counts use leaf counting by default and can include aggregate taxa above species rank. Those entries should not enter an image-generation pipeline. Public defaults remain conservative on subscription-backed generation, while discovery is broad enough to avoid truncating typical local observations.

## Validation
- 151 tests passed
- `ruff format --check .`
- `ruff check .`
- `mypy src`
- `git diff --check`
- example TOML validated through the application CLI
- live read-only iNaturalist comparison confirmed `rank=species` removed the aggregate taxon and returned only species-rank results
