### PR TITLE
Set uv path for deployment runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,9 @@ jobs:
           persist-credentials: false
 
       - name: Install controller revision and services
+        env:
+          # The launchd runner has a system-only PATH; uv is installed by Homebrew.
+          UV_BIN: /opt/homebrew/bin/uv
         run: ./deploy/install-controller.sh
 
       - name: Deploy display node

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ The system has two deliberately small roles:
 - The **display node** downloads approved assets, verifies their checksums, and
   rotates them on the Inky panel. It does no AI or discovery work.
 
+<p align="center">
+  <img src="docs/images/installation-architecture.png" alt="Inky Bird Frame architecture showing a Mac or Raspberry Pi controller serving approved bird plates over a private home network to a Raspberry Pi Zero 2 W display node" width="900">
+  <br><em>The controller performs discovery and generation; the display node only pulls approved plates over the local network.</em>
+</p>
+
 Discovery location is private controller configuration. Approved plates and
 manifests contain no ZIP code, coordinates, observation dates, local place
 names, network details, or machine paths. A plate generated for one installation


### PR DESCRIPTION
## Summary

- pass the Homebrew uv executable explicitly to the macOS controller installer
- avoid relying on the self-hosted launchd runner system-only PATH

## Validation

- 176 tests
- Ruff format and lint
- MyPy
- Actionlint and ShellCheck
- workflow action pinning
- catalog validation (41 species)

## Production evidence

Deploy run 29122573552 failed before display deployment because the runner could not find uv. The target controller confirms uv 0.9.29 is executable at /opt/homebrew/bin/uv.
