### PR TITLE
Support noninteractive display deployment

### DIFF
--- a/deploy/install-display-local.sh
+++ b/deploy/install-display-local.sh
@@ -12,6 +12,7 @@ support_dir=${INKY_BIRD_SUPPORT_DIR:-"${HOME}/.config/inky-bird-frame"}
 config_path=${INKY_BIRD_CONFIG_PATH:-"${support_dir}/config.toml"}
 venv=${INKY_BIRD_DISPLAY_VENV:-"${HOME}/.virtualenvs/pimoroni"}
 run_initial_display=${INKY_BIRD_RUN_INITIAL_DISPLAY:-false}
+noninteractive_sudo=${INKY_BIRD_NONINTERACTIVE_SUDO:-false}
 
 if [ ! -f "${config_path}" ]; then
   echo "Display-node configuration is missing: ${config_path}" >&2
@@ -21,10 +22,22 @@ if [ ! -x "${venv}/bin/python" ]; then
   echo "Pimoroni Python environment is missing: ${venv}" >&2
   exit 1
 fi
-if ! sudo -v; then
-  echo "Administrator access is required to install the display service." >&2
-  exit 1
-fi
+sudo_command=(sudo)
+case "${noninteractive_sudo}" in
+  true)
+    sudo_command+=(-n)
+    ;;
+  false)
+    if ! sudo -v; then
+      echo "Administrator access is required to install the display service." >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "INKY_BIRD_NONINTERACTIVE_SUDO must be true or false." >&2
+    exit 1
+    ;;
+esac
 
 chmod 600 "${config_path}"
 mkdir -p "${app_dir}/src" "${app_dir}/catalog" "${app_dir}/deploy" "${support_dir}"
@@ -64,17 +77,17 @@ for name, content in units.items():
     (unit_dir / name).write_text(content)
 PY
 
-sudo install -m 0644 \
+"${sudo_command[@]}" install -m 0644 \
   "${unit_dir}/inky-bird-frame-display.service" \
   /etc/systemd/system/inky-bird-frame-display.service
-sudo install -m 0644 \
+"${sudo_command[@]}" install -m 0644 \
   "${unit_dir}/inky-bird-frame-display.timer" \
   /etc/systemd/system/inky-bird-frame-display.timer
-sudo systemctl daemon-reload
-sudo systemctl enable inky-bird-frame-display.timer
-sudo systemctl restart inky-bird-frame-display.timer
+"${sudo_command[@]}" systemctl daemon-reload
+"${sudo_command[@]}" systemctl enable inky-bird-frame-display.timer
+"${sudo_command[@]}" systemctl restart inky-bird-frame-display.timer
 if [ "${run_initial_display}" = true ]; then
-  sudo systemctl start inky-bird-frame-display.service
+  "${sudo_command[@]}" systemctl start inky-bird-frame-display.service
 fi
 systemctl is-enabled --quiet inky-bird-frame-display.timer
 systemctl is-active --quiet inky-bird-frame-display.timer

--- a/deploy/install-display-node.sh
+++ b/deploy/install-display-node.sh
@@ -45,6 +45,7 @@ INKY_BIRD_APP_DIR="${app_dir}" \
 INKY_BIRD_CONFIG_PATH="${config_path}" \
 INKY_BIRD_DISPLAY_VENV="${venv}" \
 INKY_BIRD_RUN_INITIAL_DISPLAY=true \
+INKY_BIRD_NONINTERACTIVE_SUDO=true \
   "${app_dir}/deploy/install-display-local.sh"
 REMOTE
 

--- a/tests/test_deployment_scripts.py
+++ b/tests/test_deployment_scripts.py
@@ -70,3 +70,14 @@ def test_local_display_installer_uses_configured_schedule_and_verifies_timer() -
     assert "systemctl restart inky-bird-frame-display.timer" in script
     assert "systemctl is-enabled --quiet inky-bird-frame-display.timer" in script
     assert "systemctl is-active --quiet inky-bird-frame-display.timer" in script
+    assert "noninteractive_sudo=${INKY_BIRD_NONINTERACTIVE_SUDO:-false}" in script
+    assert "sudo_command+=(-n)" in script
+    assert '"${sudo_command[@]}" systemctl daemon-reload' in script
+
+
+def test_remote_display_installer_selects_noninteractive_sudo() -> None:
+    script = (
+        Path(__file__).resolve().parents[1] / "deploy" / "install-display-node.sh"
+    ).read_text()
+
+    assert "INKY_BIRD_NONINTERACTIVE_SUDO=true" in script


### PR DESCRIPTION
## Summary

- preserve interactive sudo authorization for direct display setup
- add an explicit noninteractive mode that applies sudo -n to each privileged command
- select that mode from the remote display deployment wrapper

## Validation

- 177 tests
- Ruff format and lint
- MyPy
- Bash syntax and ShellCheck
- Actionlint and workflow action pinning
- catalog validation (41 species)

## Production evidence

Deploy run 29123141866 updated the controller successfully, then failed because sudo -v requested a terminal on the display node. The node has NOPASSWD: ALL and direct sudo -n install/systemctl commands succeed; sudo -v itself still requests a password because it validates credentials without a matched command.
