### PR TITLE
Add eBird and combined discovery modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ is needed to flash the two cards. No HDMI cable, keyboard, mouse, right-angle
 cable, or display-node enclosure is required for normal operation.
 
 The controller requires Python 3.11 or newer, Codex CLI authenticated with a
-ChatGPT subscription, and network access to Codex, iNaturalist,
+ChatGPT subscription, and network access to Codex, iNaturalist, optional eBird,
 Zippopotam.us, and configured research sources. The display node requires
 Python 3.11 or newer with Pimoroni's Inky package and network access to the
 controller HTTP service.
@@ -211,7 +211,8 @@ uv run inky-bird-frame refresh --config config.toml
 uv run inky-bird-frame generate --config config.toml
 
 # Queue a broader one-time set without changing the active display window.
-uv run inky-bird-frame seed --config config.toml --window last-year --species-limit 500
+uv run inky-bird-frame seed --config config.toml --source inaturalist \
+  --window last-year --species-limit 500
 
 # Inspect approved, pending, and failed work.
 uv run inky-bird-frame status --config config.toml
@@ -225,17 +226,21 @@ uv run inky-bird-frame catalog-publish --config config.toml --dry-run
 uv run inky-bird-frame catalog-publish --config config.toml
 ```
 
+Discovery sources are `inaturalist`, `ebird`, and `combined`. eBird supplies
+bird-specific public sightings; every eBird result is exact-matched to an
+iNaturalist species before the existing licensed-reference pipeline accepts it.
 Observation windows are `last-day`, `last-week`, `last-30-days`, `last-year`,
-and `all-time`. Discovery distance is configured in kilometers with `radius_km`.
-Discovery admits only species-rank iNaturalist results, excluding unresolved
-genera, families, and other aggregate taxa from generation.
+and `all-time`; eBird modes support the first three and a maximum 50 km radius.
+See [Discovery sources](docs/discovery.md) for credentials, merging, failure
+handling, privacy, and provider limitations.
 Rotation modes are `sequential`, `shuffle`, `shuffle_bag`, and `weighted`.
 `shuffle` keeps its existing shuffled-round behavior. `shuffle_bag` persists a
 separate bag: it displays each currently active bird at most once before a
 refill, adds newly active birds to the current bag immediately, prunes inactive
 birds, and avoids a repeat at the refill boundary when alternatives exist.
-`weighted` uses local observation counts and avoids displaying the same bird
-twice in succession when alternatives are available.
+`weighted` uses iNaturalist observation counts where available; eBird-only
+species receive a presence weight of one. It avoids immediate repeats when
+alternatives are available.
 Recovery and operator-override commands are documented in
 [`docs/operations.md`](docs/operations.md).
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,4 +1,7 @@
 [discovery]
+# iNaturalist needs no credentials and supports every window. eBird provides bird-specific
+# recent sightings but requires a personal API key. combined queries both independently.
+source = "inaturalist"
 # This location is used only to discover species. It is never rendered on a plate.
 zip_code = "12345"
 # Eight kilometers is approximately five miles: local enough to feel relevant while
@@ -10,6 +13,10 @@ species_limit = 50
 # Thirty days balances seasonal relevance with coverage. Shorter windows can be sparse;
 # last-year and all-time are better suited to one-time catalog seeding.
 window = "last-30-days"
+# eBird and combined support last-day, last-week, and last-30-days, with a maximum 50 km
+# radius. Keep a real key only in this private mode-0600 file, or name an injected variable.
+# ebird_api_key = "YOUR_PERSONAL_EBIRD_API_KEY"
+# ebird_api_key_env = "EBIRD_API_KEY"
 
 [controller]
 workspace_dir = "."

--- a/deploy/install-controller-systemd.sh
+++ b/deploy/install-controller-systemd.sh
@@ -97,6 +97,11 @@ from inky_bird_frame.publisher import sync_public_catalog
 unit_dir, root, app_dir, config_path, home = map(Path, sys.argv[1:6])
 user = sys.argv[6]
 config = load_config(config_path)
+if config.discovery.source.uses_ebird and config.discovery.ebird_api_key_env is not None:
+    raise ConfigurationError(
+        "The systemd installer requires ebird_api_key in the private config file; "
+        "environment variables are not inherited by managed services"
+    )
 environment_destinations = [
     destination.name
     for destination in config.notifications.destinations

--- a/deploy/install-controller-systemd.sh
+++ b/deploy/install-controller-systemd.sh
@@ -74,7 +74,6 @@ chmod 600 "${config_path}"
 mkdir -p "${app_dir}/src" "${app_dir}/catalog" "${app_dir}/deploy" "${support_dir}"
 if [ "${root}" != "${app_dir}" ]; then
   rsync -a --delete "${root}/src/" "${app_dir}/src/"
-  rsync -a "${root}/catalog/" "${app_dir}/catalog/"
   install -m 0755 "${root}/deploy/install-controller-systemd.sh" "${app_dir}/deploy/"
   for file in pyproject.toml uv.lock README.md LICENSE; do
     install -m 0644 "${root}/${file}" "${app_dir}/${file}"

--- a/deploy/install-controller-systemd.sh
+++ b/deploy/install-controller-systemd.sh
@@ -116,7 +116,12 @@ if environment_destinations:
 config.controller.workspace_dir.mkdir(parents=True, exist_ok=True)
 config.controller.catalog_dir.parent.mkdir(parents=True, exist_ok=True)
 with catalog_state_lock(config.controller.state_dir):
-    sync_public_catalog(root / "catalog", config.controller.catalog_dir)
+    source_catalog = root / "catalog"
+    managed_catalog = app_dir / "catalog"
+    if root != app_dir and managed_catalog.resolve() != config.controller.catalog_dir.resolve():
+        sync_public_catalog(source_catalog, managed_catalog)
+        source_catalog = managed_catalog
+    sync_public_catalog(source_catalog, config.controller.catalog_dir)
 
 executable = app_dir / ".venv/bin/inky-bird-frame"
 units = controller_systemd_units(

--- a/deploy/install-controller.sh
+++ b/deploy/install-controller.sh
@@ -95,6 +95,11 @@ from inky_bird_frame.publisher import sync_public_catalog
 ) = map(Path, sys.argv[1:])
 executable = app_dir / ".venv/bin/inky-bird-frame"
 config = load_config(config_path)
+if config.discovery.source.uses_ebird and config.discovery.ebird_api_key_env is not None:
+    raise ConfigurationError(
+        "The macOS LaunchAgent installer requires ebird_api_key in the private config "
+        "file; environment variables are not inherited by managed services"
+    )
 environment_destinations = [
     destination.name
     for destination in config.notifications.destinations

--- a/deploy/install-controller.sh
+++ b/deploy/install-controller.sh
@@ -61,7 +61,6 @@ fi
 mkdir -p "${app_dir}/catalog" "${app_dir}/deploy" "${support_dir}" "${log_dir}" "${agents_dir}"
 if [ "${root}" != "${app_dir}" ]; then
   rsync -a --delete "${root}/src/" "${app_dir}/src/"
-  rsync -a "${root}/catalog/" "${app_dir}/catalog/"
   install -m 0755 "${root}/deploy/install-controller.sh" "${app_dir}/deploy/"
   for file in pyproject.toml uv.lock README.md LICENSE; do
     install -m 0644 "${root}/${file}" "${app_dir}/${file}"

--- a/deploy/install-controller.sh
+++ b/deploy/install-controller.sh
@@ -115,7 +115,12 @@ schedule = config.schedule
 config.controller.workspace_dir.mkdir(parents=True, exist_ok=True)
 config.controller.catalog_dir.parent.mkdir(parents=True, exist_ok=True)
 with catalog_state_lock(config.controller.state_dir):
-    sync_public_catalog(root / "catalog", config.controller.catalog_dir)
+    source_catalog = root / "catalog"
+    managed_catalog = app_dir / "catalog"
+    if root != app_dir and managed_catalog.resolve() != config.controller.catalog_dir.resolve():
+        sync_public_catalog(source_catalog, managed_catalog)
+        source_catalog = managed_catalog
+    sync_public_catalog(source_catalog, config.controller.catalog_dir)
 
 common = {
     "WorkingDirectory": str(app_dir),

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -1,0 +1,75 @@
+# Discovery sources
+
+Inky Bird Frame can discover nearby birds through iNaturalist, eBird, or both.
+Merlin Bird ID is Cornell's identification application; its nearby lists are
+powered by eBird. This project integrates the documented eBird API, not Merlin.
+
+## Choose a source
+
+| Source | Credentials | Windows | Best use |
+| --- | --- | --- | --- |
+| `inaturalist` | None | All | Default setup, historical seeds, and licensed references |
+| `ebird` | Personal eBird key | 1, 7, or 30 days | Bird-specific recent public sightings |
+| `combined` | Personal eBird key | 1, 7, or 30 days | Broad recent discovery with provider fallback |
+
+Request a personal key from [eBird](https://ebird.org/api/keygen). Store it in
+the private configuration or inject it through an environment variable:
+
+```toml
+[discovery]
+source = "combined"
+zip_code = "12345"
+radius_km = 8
+species_limit = 50
+window = "last-30-days"
+ebird_api_key_env = "EBIRD_API_KEY"
+```
+
+Keep the configuration outside the checkout with mode `0600`. The application
+never writes the key to state, logs, catalog files, or command output. Native
+services do not necessarily inherit an interactive shell environment; a direct
+value in the protected private TOML is the simplest option unless the service
+manager explicitly injects `EBIRD_API_KEY`.
+
+## How eBird enrichment works
+
+eBird returns recent public sightings and an eBird species code. The controller
+searches iNaturalist for the exact active species-rank scientific name and uses
+the resulting iNaturalist taxon ID as the canonical catalog identity. Ambiguous,
+inactive, hybrid, subspecies, domestic, and unmatched records are deferred. A
+seven-day negative cache prevents one mismatch from generating requests every
+15 minutes.
+
+iNaturalist remains the source for taxonomy and research-grade CC0/CC-BY
+reference photographs. eBird and Macaulay Library media are not copied into the
+generation pipeline.
+
+## Combined mode
+
+Each provider receives the configured `species_limit`; the merged result can be
+up to twice that size before duplicates are removed by iNaturalist taxon ID. If
+one provider fails, the successful provider still refreshes the active catalog
+and the controller records a provider-specific degradation. The refresh fails
+only when every configured provider fails, leaving the prior active catalog in
+place.
+
+iNaturalist supplies observation-frequency counts. eBird's nearby endpoint
+supplies recent presence rather than a comparable aggregate count, so eBird-only
+species receive weight one. `shuffle_bag` is the recommended source-neutral
+rotation policy.
+
+## Limits and data use
+
+The eBird nearby API supports at most 30 days and 50 km. Use an explicit
+iNaturalist seed for longer periods:
+
+```bash
+inky-bird-frame seed --config /path/to/config.toml \
+  --source inaturalist --window last-year --species-limit 500
+```
+
+Review the official [eBird API documentation](https://documenter.getpostman.com/view/664302/S1ENwy59/)
+and [eBird data-use guidance](https://support.ebird.org/en/support/solutions/articles/48001078113)
+before commercial use. The private discovery snapshot may contain provider
+diagnostics, but location and observation details never enter reusable plates
+or the public catalog.

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -13,7 +13,7 @@ powered by eBird. This project integrates the documented eBird API, not Merlin.
 | `combined` | Personal eBird key | 1, 7, or 30 days | Broad recent discovery with provider fallback |
 
 Request a personal key from [eBird](https://ebird.org/api/keygen). Store it in
-the private configuration or inject it through an environment variable:
+the private configuration:
 
 ```toml
 [discovery]
@@ -22,14 +22,16 @@ zip_code = "12345"
 radius_km = 8
 species_limit = 50
 window = "last-30-days"
-ebird_api_key_env = "EBIRD_API_KEY"
+ebird_api_key = "your-personal-api-key"
 ```
 
+For manually invoked commands, you may replace `ebird_api_key` with
+`ebird_api_key_env = "EBIRD_API_KEY"`. Managed controller services do not inherit the shell
+environment used during installation, so LaunchAgent and systemd installations require the direct
+value in the private mode-`0600` configuration file.
+
 Keep the configuration outside the checkout with mode `0600`. The application
-never writes the key to state, logs, catalog files, or command output. Native
-services do not necessarily inherit an interactive shell environment; a direct
-value in the protected private TOML is the simplest option unless the service
-manager explicitly injects `EBIRD_API_KEY`.
+never writes the key to state, logs, catalog files, or command output.
 
 ## How eBird enrichment works
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -408,7 +408,7 @@ blank the frame.
 
 | Section | Used by | Purpose |
 | --- | --- | --- |
-| `[discovery]` | Controller | ZIP, radius, active observation window, and species cap |
+| `[discovery]` | Controller | Source, credentials, ZIP, radius, observation window, and species cap |
 | `[controller]` | Controller | Persistent paths, Codex executable, HTTP bind, and generation bounds |
 | `[research]` | Controller | Bounded fallback research policy and approved domains |
 | `[notifications]` | Controller | Optional Apprise destinations, events, retries, and noise controls |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -95,12 +95,14 @@ currently active on the display:
 
 ```bash
 inky-bird-frame seed --config /path/to/config.toml \
-  --window last-year --species-limit 500 --dry-run
+  --source inaturalist --window last-year --species-limit 500 --dry-run
 inky-bird-frame seed --config /path/to/config.toml \
-  --window last-year --species-limit 500
+  --source inaturalist --window last-year --species-limit 500
 ```
 
-The configured radius is used unless `--radius-km` is provided. Repeating a seed
+The configured source is used unless `--source` is provided. eBird cannot query
+beyond 30 days, so historical seeds must use iNaturalist. The configured radius
+is used unless `--radius-km` is provided. Repeating a seed
 is idempotent: approved, terminal, and already queued taxa are not added again.
 Current observations remain ahead of seed-only taxa during generation.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -79,8 +79,10 @@ inky-bird-frame discover --config /path/to/config.toml
 inky-bird-frame refresh --config /path/to/config.toml
 ```
 
-Check DNS, outbound HTTPS, the ZIP code, and the controller clock. A refresh
-failure does not remove the existing active catalog.
+Check DNS, outbound HTTPS, the ZIP code, and the controller clock. For eBird,
+also run `config validate` and confirm that the personal API key is available.
+Combined mode reports each provider independently and continues when either one
+is healthy. A refresh failure does not remove the existing active catalog.
 
 ### Generation fails or keeps retrying
 

--- a/src/inky_bird_frame/birds.py
+++ b/src/inky_bird_frame/birds.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import fcntl
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 from enum import StrEnum
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Final
 from urllib.parse import quote, urlencode
 
-from .errors import DataSourceError
+from .errors import DataSourceError, TaxonomyMatchError
 from .http import get_json
 
 
@@ -18,6 +25,25 @@ class BirdSpecies:
     scientific_name: str
     observation_count: int
     source: str
+    sources: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.sources:
+            object.__setattr__(self, "sources", (self.source,))
+
+
+@dataclass(frozen=True)
+class EbirdSpecies:
+    species_code: str
+    common_name: str
+    scientific_name: str
+    observed_at: str
+
+
+@dataclass(frozen=True)
+class EbirdResolution:
+    species: list[BirdSpecies]
+    unresolved: list[EbirdSpecies]
 
 
 @dataclass(frozen=True)
@@ -36,6 +62,15 @@ class ObservationWindow(StrEnum):
     LAST_30_DAYS = "last-30-days"
     LAST_YEAR = "last-year"
     ALL_TIME = "all-time"
+
+
+EBIRD_BACK_DAYS: Final = {
+    ObservationWindow.LAST_DAY: 1,
+    ObservationWindow.LAST_WEEK: 7,
+    ObservationWindow.LAST_30_DAYS: 30,
+}
+EBIRD_MAX_RADIUS_KM: Final = 50
+EBIRD_UNRESOLVED_RETRY_DAYS: Final = 7
 
 
 @dataclass(frozen=True)
@@ -149,6 +184,271 @@ def fetch_inaturalist_birds(
         timeout_seconds,
     )
     return parse_inaturalist_species_counts(payload)
+
+
+def parse_ebird_observations(payload: object) -> list[EbirdSpecies]:
+    if not isinstance(payload, list):
+        raise DataSourceError("eBird response was not a list")
+
+    species: list[EbirdSpecies] = []
+    seen: set[str] = set()
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        species_code = item.get("speciesCode")
+        common_name = item.get("comName")
+        scientific_name = item.get("sciName")
+        observed_at = item.get("obsDt")
+        if any(
+            not isinstance(value, str) or not value.strip()
+            for value in (species_code, common_name, scientific_name, observed_at)
+        ):
+            continue
+        assert isinstance(species_code, str)
+        if species_code in seen:
+            continue
+        seen.add(species_code)
+        species.append(
+            EbirdSpecies(
+                species_code=species_code,
+                common_name=str(common_name),
+                scientific_name=str(scientific_name),
+                observed_at=str(observed_at),
+            )
+        )
+    if payload and not species:
+        raise DataSourceError("eBird response did not include usable species observations")
+    return species
+
+
+def fetch_ebird_observations(
+    *,
+    latitude: float,
+    longitude: float,
+    radius_km: int,
+    limit: int,
+    window: ObservationWindow,
+    api_key: str,
+    timeout_seconds: float = 10.0,
+) -> list[EbirdSpecies]:
+    if window not in EBIRD_BACK_DAYS:
+        raise ValueError("eBird supports observation windows of 30 days or less")
+    if not 0 < radius_km <= EBIRD_MAX_RADIUS_KM:
+        raise ValueError(f"eBird radius_km must be between 1 and {EBIRD_MAX_RADIUS_KM}")
+    if not 0 < limit <= 10_000:
+        raise ValueError("eBird species_limit must be between 1 and 10000")
+    if not api_key.strip():
+        raise ValueError("eBird API key must not be empty")
+
+    params = urlencode(
+        {
+            "lat": f"{latitude:.2f}",
+            "lng": f"{longitude:.2f}",
+            "dist": str(radius_km),
+            "back": str(EBIRD_BACK_DAYS[window]),
+            "cat": "species",
+            "includeProvisional": "false",
+            "maxResults": str(limit),
+            "sort": "date",
+            "sppLocale": "en",
+        }
+    )
+    payload = get_json(
+        f"https://api.ebird.org/v2/data/obs/geo/recent?{params}",
+        timeout_seconds,
+        headers={"X-eBirdApiToken": api_key},
+    )
+    return parse_ebird_observations(payload)
+
+
+def parse_inaturalist_taxon_match(payload: object, scientific_name: str) -> BirdSpecies:
+    if not isinstance(payload, dict):
+        raise DataSourceError("iNaturalist taxon search response was not an object")
+    results = payload.get("results")
+    if not isinstance(results, list):
+        raise DataSourceError("iNaturalist taxon search response did not include results")
+
+    matches: list[BirdSpecies] = []
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        taxon_id = item.get("id")
+        common_name = item.get("preferred_common_name")
+        name = item.get("name")
+        if (
+            item.get("rank") == "species"
+            and item.get("is_active") is not False
+            and item.get("iconic_taxon_name") == "Aves"
+            and name == scientific_name
+            and isinstance(taxon_id, int)
+            and not isinstance(taxon_id, bool)
+            and isinstance(common_name, str)
+            and common_name
+        ):
+            matches.append(
+                BirdSpecies(
+                    taxon_id=taxon_id,
+                    common_name=common_name,
+                    scientific_name=name,
+                    observation_count=1,
+                    source="eBird",
+                )
+            )
+    if len(matches) != 1:
+        raise TaxonomyMatchError(
+            f"Expected one active iNaturalist bird species matching {scientific_name}; "
+            f"found {len(matches)}"
+        )
+    return matches[0]
+
+
+def fetch_inaturalist_taxon_match(
+    scientific_name: str, timeout_seconds: float = 10.0
+) -> BirdSpecies:
+    params = urlencode(
+        {
+            "q": scientific_name,
+            "rank": "species",
+            "taxon_id": "3",
+            "per_page": "20",
+        }
+    )
+    payload = get_json(f"https://api.inaturalist.org/v1/taxa?{params}", timeout_seconds)
+    return parse_inaturalist_taxon_match(payload, scientific_name)
+
+
+def resolve_ebird_species(
+    observations: list[EbirdSpecies],
+    cache_path: Path,
+    *,
+    now: datetime | None = None,
+    timeout_seconds: float = 10.0,
+) -> EbirdResolution:
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    with _ebird_crosswalk_lock(cache_path):
+        return _resolve_ebird_species_locked(
+            observations,
+            cache_path,
+            now=now,
+            timeout_seconds=timeout_seconds,
+        )
+
+
+def _resolve_ebird_species_locked(
+    observations: list[EbirdSpecies],
+    cache_path: Path,
+    *,
+    now: datetime | None,
+    timeout_seconds: float,
+) -> EbirdResolution:
+    current = (now or datetime.now(UTC)).astimezone(UTC).replace(microsecond=0)
+    cache = _read_ebird_crosswalk(cache_path)
+    resolved: list[BirdSpecies] = []
+    unresolved: list[EbirdSpecies] = []
+    changed = False
+
+    for observation in observations:
+        cached = cache.get(observation.species_code)
+        if cached is not None and cached.get("scientific_name") == observation.scientific_name:
+            taxon_id = cached.get("taxon_id")
+            common_name = cached.get("common_name")
+            if isinstance(taxon_id, int) and isinstance(common_name, str):
+                resolved.append(
+                    BirdSpecies(
+                        taxon_id=taxon_id,
+                        common_name=common_name,
+                        scientific_name=observation.scientific_name,
+                        observation_count=1,
+                        source="eBird",
+                    )
+                )
+                continue
+            retry_at = _parse_cache_datetime(cached.get("retry_at"))
+            if retry_at is not None and current < retry_at:
+                unresolved.append(observation)
+                continue
+
+        try:
+            species = fetch_inaturalist_taxon_match(
+                observation.scientific_name, timeout_seconds=timeout_seconds
+            )
+        except TaxonomyMatchError:
+            cache[observation.species_code] = {
+                "scientific_name": observation.scientific_name,
+                "retry_at": (current + timedelta(days=EBIRD_UNRESOLVED_RETRY_DAYS)).isoformat(),
+            }
+            unresolved.append(observation)
+            changed = True
+            continue
+        cache[observation.species_code] = {
+            "scientific_name": species.scientific_name,
+            "common_name": species.common_name,
+            "taxon_id": species.taxon_id,
+            "resolved_at": current.isoformat(),
+        }
+        resolved.append(species)
+        changed = True
+
+    if changed:
+        _write_ebird_crosswalk(cache_path, cache)
+    return EbirdResolution(species=resolved, unresolved=unresolved)
+
+
+@contextmanager
+def _ebird_crosswalk_lock(cache_path: Path) -> Iterator[None]:
+    with cache_path.with_suffix(f"{cache_path.suffix}.lock").open("a+") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _parse_cache_datetime(value: object) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(UTC)
+
+
+def _read_ebird_crosswalk(path: Path) -> dict[str, dict[str, object]]:
+    try:
+        raw = json.loads(path.read_text())
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError as exc:
+        raise DataSourceError(f"Invalid eBird taxonomy crosswalk: {path}") from exc
+    if not isinstance(raw, dict) or raw.get("schema_version") != 1:
+        raise DataSourceError(f"Unsupported eBird taxonomy crosswalk: {path}")
+    entries = raw.get("entries")
+    if not isinstance(entries, dict) or any(
+        not isinstance(key, str) or not isinstance(value, dict) for key, value in entries.items()
+    ):
+        raise DataSourceError(f"Invalid eBird taxonomy crosswalk: {path}")
+    return {str(key): dict(value) for key, value in entries.items()}
+
+
+def _write_ebird_crosswalk(path: Path, entries: dict[str, dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with NamedTemporaryFile(
+        "w",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as handle:
+        json.dump({"schema_version": 1, "entries": entries}, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+        temporary = Path(handle.name)
+    try:
+        temporary.replace(path)
+    finally:
+        temporary.unlink(missing_ok=True)
 
 
 def parse_inaturalist_taxon(payload: object) -> TaxonContext:

--- a/src/inky_bird_frame/birds.py
+++ b/src/inky_bird_frame/birds.py
@@ -242,8 +242,8 @@ def fetch_ebird_observations(
 
     params = urlencode(
         {
-            "lat": f"{latitude:.2f}",
-            "lng": f"{longitude:.2f}",
+            "lat": f"{latitude:.6f}",
+            "lng": f"{longitude:.6f}",
             "dist": str(radius_km),
             "back": str(EBIRD_BACK_DAYS[window]),
             "cat": "species",

--- a/src/inky_bird_frame/birds.py
+++ b/src/inky_bird_frame/birds.py
@@ -323,7 +323,16 @@ def resolve_ebird_species(
     *,
     now: datetime | None = None,
     timeout_seconds: float = 10.0,
+    persist_cache: bool = True,
 ) -> EbirdResolution:
+    if not persist_cache:
+        return _resolve_ebird_species_locked(
+            observations,
+            cache_path,
+            now=now,
+            timeout_seconds=timeout_seconds,
+            persist_cache=False,
+        )
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     with _ebird_crosswalk_lock(cache_path):
         return _resolve_ebird_species_locked(
@@ -331,6 +340,7 @@ def resolve_ebird_species(
             cache_path,
             now=now,
             timeout_seconds=timeout_seconds,
+            persist_cache=True,
         )
 
 
@@ -340,6 +350,7 @@ def _resolve_ebird_species_locked(
     *,
     now: datetime | None,
     timeout_seconds: float,
+    persist_cache: bool,
 ) -> EbirdResolution:
     current = (now or datetime.now(UTC)).astimezone(UTC).replace(microsecond=0)
     cache = _read_ebird_crosswalk(cache_path)
@@ -389,7 +400,7 @@ def _resolve_ebird_species_locked(
         resolved.append(species)
         changed = True
 
-    if changed:
+    if changed and persist_cache:
         _write_ebird_crosswalk(cache_path, cache)
     return EbirdResolution(species=resolved, unresolved=unresolved)
 

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -75,6 +75,7 @@ def species_to_dict(species: BirdSpecies) -> dict[str, object]:
         "common_name": species.common_name,
         "scientific_name": species.scientific_name,
         "observation_count": species.observation_count,
+        "source": species.source,
         "sources": list(species.sources),
     }
 

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -90,7 +90,7 @@ def _failure_notification(operation: str, exc: Exception) -> str:
 
 def discover_command(args: argparse.Namespace) -> int:
     config = _config(args)
-    discovery = discover_species(config)
+    discovery = discover_species(config, persist_taxonomy_cache=False)
     location = discovery.location
     print_result(
         {
@@ -134,6 +134,7 @@ def refresh_command(args: argparse.Namespace) -> int:
         body="Observation refresh is succeeding again.",
     )
     providers = result.get("providers")
+    ebird_succeeded = False
     if isinstance(providers, list):
         for provider in providers:
             if not isinstance(provider, dict) or not isinstance(provider.get("name"), str):
@@ -147,6 +148,8 @@ def refresh_command(args: argparse.Namespace) -> int:
                     body=f"The {name} provider failed; another configured provider supplied data.",
                 )
             else:
+                if name == "ebird":
+                    ebird_succeeded = True
                 safe_record_recovery(
                     config,
                     key=f"observation-provider-{name}",
@@ -161,7 +164,7 @@ def refresh_command(args: argparse.Namespace) -> int:
             title="Some eBird species are awaiting taxonomy matching",
             body=f"{len(unresolved)} species were deferred without blocking bird discovery.",
         )
-    elif config.discovery.source.uses_ebird:
+    elif ebird_succeeded:
         safe_record_recovery(
             config,
             key="ebird-taxonomy",

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -16,7 +16,7 @@ from .catalog import (
     rebuild_catalog_index,
     reject_candidate,
 )
-from .config import AppConfig, NotificationEvent, load_config
+from .config import AppConfig, DiscoverySource, NotificationEvent, load_config
 from .controller import (
     discover_species,
     enqueue_seed_species,
@@ -75,7 +75,7 @@ def species_to_dict(species: BirdSpecies) -> dict[str, object]:
         "common_name": species.common_name,
         "scientific_name": species.scientific_name,
         "observation_count": species.observation_count,
-        "source": species.source,
+        "sources": list(species.sources),
     }
 
 
@@ -89,7 +89,8 @@ def _failure_notification(operation: str, exc: Exception) -> str:
 
 def discover_command(args: argparse.Namespace) -> int:
     config = _config(args)
-    location, species = discover_species(config)
+    discovery = discover_species(config)
+    location = discovery.location
     print_result(
         {
             "location": {
@@ -99,7 +100,10 @@ def discover_command(args: argparse.Namespace) -> int:
             },
             "radius_km": config.discovery.radius_km,
             "window": config.discovery.observation_window.value,
-            "species": [species_to_dict(item) for item in species],
+            "source": config.discovery.source.value,
+            "providers": [provider.as_dict() for provider in discovery.providers],
+            "unresolved_count": len(discovery.unresolved),
+            "species": [species_to_dict(item) for item in discovery.species],
         }
     )
     return 0
@@ -128,6 +132,41 @@ def refresh_command(args: argparse.Namespace) -> int:
         title="Bird discovery recovered",
         body="Observation refresh is succeeding again.",
     )
+    providers = result.get("providers")
+    if isinstance(providers, list):
+        for provider in providers:
+            if not isinstance(provider, dict) or not isinstance(provider.get("name"), str):
+                continue
+            name = provider["name"]
+            if provider.get("status") == "error":
+                safe_record_degradation(
+                    config,
+                    key=f"observation-provider-{name}",
+                    title=f"{name} bird discovery is degraded",
+                    body=f"The {name} provider failed; another configured provider supplied data.",
+                )
+            else:
+                safe_record_recovery(
+                    config,
+                    key=f"observation-provider-{name}",
+                    title=f"{name} bird discovery recovered",
+                    body=f"The {name} provider is succeeding again.",
+                )
+    unresolved = result.get("unresolved_species")
+    if isinstance(unresolved, list) and unresolved:
+        safe_record_degradation(
+            config,
+            key="ebird-taxonomy",
+            title="Some eBird species are awaiting taxonomy matching",
+            body=f"{len(unresolved)} species were deferred without blocking bird discovery.",
+        )
+    elif config.discovery.source.uses_ebird:
+        safe_record_recovery(
+            config,
+            key="ebird-taxonomy",
+            title="eBird taxonomy matching recovered",
+            body="Deferred eBird taxonomy matches have cleared.",
+        )
     new_species = result.get("new_species")
     if isinstance(new_species, list) and new_species:
         names: list[str] = []
@@ -235,6 +274,7 @@ def seed_command(args: argparse.Namespace) -> int:
         enqueue_seed_species(
             _config(args),
             window=parse_observation_window(args.window),
+            source=DiscoverySource(args.source) if args.source is not None else None,
             radius_km=args.radius_km,
             species_limit=args.species_limit,
             dry_run=args.dry_run,
@@ -411,6 +451,12 @@ def config_validate_command(args: argparse.Namespace) -> int:
         {
             "config": str(args.config),
             "valid": True,
+            "discovery": {
+                "source": config.discovery.source.value,
+                "ebird_configured": config.discovery.ebird_api_key is not None,
+                "window": config.discovery.observation_window.value,
+                "radius_km": config.discovery.radius_km,
+            },
             "notifications": {
                 "enabled": config.notifications.enabled,
                 "destinations": destinations,
@@ -577,6 +623,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--window",
         required=True,
         choices=[window.value for window in ObservationWindow],
+    )
+    seed_parser.add_argument(
+        "--source",
+        choices=[source.value for source in DiscoverySource],
+        help="Override the configured discovery source for this seed run",
     )
     seed_parser.add_argument("--radius-km", type=int)
     seed_parser.add_argument("--species-limit", type=int)

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -365,7 +365,7 @@ def load_config(path: Path) -> AppConfig:
     if ebird_api_key_env_value is not None:
         environment_value = environ.get(ebird_api_key_env_value)
         ebird_api_key = environment_value.strip() if environment_value else None
-        if ebird_api_key is None:
+        if ebird_api_key is None and discovery_source.uses_ebird:
             raise ConfigurationError(
                 f"eBird discovery requires environment variable {ebird_api_key_env_value}"
             )

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -362,6 +362,13 @@ def load_config(path: Path) -> AppConfig:
     if ebird_api_key_value is not None and ebird_api_key_env_value is not None:
         raise ConfigurationError("Choose ebird_api_key or ebird_api_key_env, not both")
     ebird_api_key = ebird_api_key_value.strip() if isinstance(ebird_api_key_value, str) else None
+    if ebird_api_key_env_value is not None:
+        environment_value = environ.get(ebird_api_key_env_value)
+        ebird_api_key = environment_value.strip() if environment_value else None
+        if ebird_api_key is None:
+            raise ConfigurationError(
+                f"eBird discovery requires environment variable {ebird_api_key_env_value}"
+            )
     if discovery_source.uses_ebird:
         if window in {ObservationWindow.LAST_YEAR, ObservationWindow.ALL_TIME}:
             raise ConfigurationError("eBird discovery supports observation windows up to 30 days")
@@ -369,13 +376,6 @@ def load_config(path: Path) -> AppConfig:
             raise ConfigurationError("eBird discovery radius_km must not exceed 50")
         if species_limit > 10_000:
             raise ConfigurationError("eBird species_limit must not exceed 10000")
-        if ebird_api_key_env_value is not None:
-            environment_value = environ.get(ebird_api_key_env_value)
-            ebird_api_key = environment_value.strip() if environment_value else None
-            if not ebird_api_key:
-                raise ConfigurationError(
-                    f"eBird discovery requires environment variable {ebird_api_key_env_value}"
-                )
         if ebird_api_key is None:
             raise ConfigurationError("eBird discovery requires ebird_api_key or ebird_api_key_env")
 

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -22,6 +22,24 @@ class RotationMode(StrEnum):
     WEIGHTED = "weighted"
 
 
+class DiscoverySource(StrEnum):
+    INATURALIST = "inaturalist"
+    EBIRD = "ebird"
+    COMBINED = "combined"
+
+    @property
+    def uses_ebird(self) -> bool:
+        return self in {DiscoverySource.EBIRD, DiscoverySource.COMBINED}
+
+
+def parse_discovery_source(value: str) -> DiscoverySource:
+    try:
+        return DiscoverySource(value)
+    except ValueError as exc:
+        allowed = ", ".join(item.value for item in DiscoverySource)
+        raise ValueError(f"discovery source must be one of: {allowed}") from exc
+
+
 class NotificationEvent(StrEnum):
     DISCOVERY = "discovery"
     GENERATION_APPROVED = "generation_approved"
@@ -49,6 +67,9 @@ class DiscoveryConfig:
     radius_km: int
     species_limit: int
     observation_window: ObservationWindow
+    source: DiscoverySource = DiscoverySource.INATURALIST
+    ebird_api_key: str | None = field(default=None, repr=False)
+    ebird_api_key_env: str | None = field(default=None, repr=False)
 
 
 @dataclass(frozen=True)
@@ -316,6 +337,48 @@ def load_config(path: Path) -> AppConfig:
     except ValueError as exc:
         raise ConfigurationError(str(exc)) from exc
 
+    source_value = _optional_string(discovery, "source", default=DiscoverySource.INATURALIST.value)
+    try:
+        discovery_source = parse_discovery_source(source_value)
+    except ValueError as exc:
+        raise ConfigurationError(str(exc)) from exc
+    radius_km = _integer(discovery, "radius_km")
+    species_limit = _integer(discovery, "species_limit")
+    if radius_km <= 0:
+        raise ConfigurationError("radius_km must be greater than zero")
+    if species_limit <= 0:
+        raise ConfigurationError("species_limit must be greater than zero")
+
+    ebird_api_key_value = discovery.get("ebird_api_key")
+    ebird_api_key_env_value = discovery.get("ebird_api_key_env")
+    if ebird_api_key_value is not None and (
+        not isinstance(ebird_api_key_value, str) or not ebird_api_key_value.strip()
+    ):
+        raise ConfigurationError("ebird_api_key must be a non-empty string")
+    if ebird_api_key_env_value is not None and (
+        not isinstance(ebird_api_key_env_value, str) or not ebird_api_key_env_value.strip()
+    ):
+        raise ConfigurationError("ebird_api_key_env must be a non-empty string")
+    if ebird_api_key_value is not None and ebird_api_key_env_value is not None:
+        raise ConfigurationError("Choose ebird_api_key or ebird_api_key_env, not both")
+    ebird_api_key = ebird_api_key_value.strip() if isinstance(ebird_api_key_value, str) else None
+    if discovery_source.uses_ebird:
+        if window in {ObservationWindow.LAST_YEAR, ObservationWindow.ALL_TIME}:
+            raise ConfigurationError("eBird discovery supports observation windows up to 30 days")
+        if radius_km > 50:
+            raise ConfigurationError("eBird discovery radius_km must not exceed 50")
+        if species_limit > 10_000:
+            raise ConfigurationError("eBird species_limit must not exceed 10000")
+        if ebird_api_key_env_value is not None:
+            environment_value = environ.get(ebird_api_key_env_value)
+            ebird_api_key = environment_value.strip() if environment_value else None
+            if not ebird_api_key:
+                raise ConfigurationError(
+                    f"eBird discovery requires environment variable {ebird_api_key_env_value}"
+                )
+        if ebird_api_key is None:
+            raise ConfigurationError("eBird discovery requires ebird_api_key or ebird_api_key_env")
+
     controller_url = _string(display_node, "controller_url").rstrip("/")
     if not controller_url.startswith(("http://", "https://")):
         raise ConfigurationError("controller_url must start with http:// or https://")
@@ -378,10 +441,15 @@ def load_config(path: Path) -> AppConfig:
 
     return AppConfig(
         discovery=DiscoveryConfig(
+            source=discovery_source,
             zip_code=zip_code,
-            radius_km=_integer(discovery, "radius_km"),
-            species_limit=_integer(discovery, "species_limit"),
+            radius_km=radius_km,
+            species_limit=species_limit,
             observation_window=window,
+            ebird_api_key=ebird_api_key,
+            ebird_api_key_env=(
+                ebird_api_key_env_value if isinstance(ebird_api_key_env_value, str) else None
+            ),
         ),
         controller=ControllerConfig(
             workspace_dir=_path(_string(controller, "workspace_dir"), base_dir),

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -7,7 +7,7 @@ import json
 import os
 import shutil
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -127,6 +127,7 @@ def discover_species(
     window: ObservationWindow | None = None,
     radius_km: int | None = None,
     species_limit: int | None = None,
+    persist_taxonomy_cache: bool = True,
 ) -> DiscoveryResult:
     selected_source = source or config.discovery.source
     selected_window = window or config.discovery.observation_window
@@ -178,6 +179,7 @@ def discover_species(
             resolution = resolve_ebird_species(
                 observations,
                 config.controller.state_dir / "ebird-taxonomy-crosswalk.json",
+                persist_cache=persist_taxonomy_cache,
             )
         except (DataSourceError, ValueError) as exc:
             providers.append(ProviderStatus("ebird", "error", 0, error=str(exc)))
@@ -342,13 +344,15 @@ def enqueue_seed_species(
     if limit <= 0:
         raise ValueError("species_limit must be greater than zero")
 
-    with exclusive_cycle_lock(config.controller.state_dir):
+    cycle_lock = nullcontext() if dry_run else exclusive_cycle_lock(config.controller.state_dir)
+    with cycle_lock:
         discovery = discover_species(
             config,
             source=source,
             window=window,
             radius_km=radius,
             species_limit=limit,
+            persist_taxonomy_cache=not dry_run,
         )
         discovered = discovery.species
         approved = approved_taxon_ids(config.controller.catalog_dir)

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -13,7 +13,15 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import cast
 
-from .birds import BirdSpecies, ObservationWindow, fetch_inaturalist_birds, fetch_taxon_context
+from .birds import (
+    BirdSpecies,
+    EbirdSpecies,
+    ObservationWindow,
+    fetch_ebird_observations,
+    fetch_inaturalist_birds,
+    fetch_taxon_context,
+    resolve_ebird_species,
+)
 from .catalog import (
     approve_candidate,
     approved_taxon_ids,
@@ -27,7 +35,7 @@ from .catalog import (
     write_json_atomic,
 )
 from .codex_runner import CodexRunner, parse_species_profile
-from .config import AppConfig
+from .config import AppConfig, DiscoverySource
 from .errors import (
     CatalogError,
     DataSourceError,
@@ -52,6 +60,34 @@ class DiscoverySnapshot:
     place_name: str
     state: str
     species: list[BirdSpecies]
+
+
+@dataclass(frozen=True)
+class ProviderStatus:
+    name: str
+    status: str
+    species_count: int
+    unresolved_count: int = 0
+    error: str | None = None
+
+    def as_dict(self) -> dict[str, object]:
+        value: dict[str, object] = {
+            "name": self.name,
+            "status": self.status,
+            "species_count": self.species_count,
+            "unresolved_count": self.unresolved_count,
+        }
+        if self.error is not None:
+            value["error"] = self.error
+        return value
+
+
+@dataclass(frozen=True)
+class DiscoveryResult:
+    location: ZipLocation
+    species: list[BirdSpecies]
+    providers: list[ProviderStatus]
+    unresolved: list[EbirdSpecies]
 
 
 @contextmanager
@@ -83,16 +119,117 @@ def exclusive_refresh_lock(state_dir: Path) -> Iterator[None]:
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
-def discover_species(config: AppConfig) -> tuple[ZipLocation, list[BirdSpecies]]:
+def discover_species(
+    config: AppConfig,
+    *,
+    source: DiscoverySource | None = None,
+    window: ObservationWindow | None = None,
+    radius_km: int | None = None,
+    species_limit: int | None = None,
+) -> DiscoveryResult:
+    selected_source = source or config.discovery.source
+    selected_window = window or config.discovery.observation_window
+    selected_radius = radius_km if radius_km is not None else config.discovery.radius_km
+    selected_limit = species_limit if species_limit is not None else config.discovery.species_limit
+    if selected_source.uses_ebird:
+        if selected_window in {ObservationWindow.LAST_YEAR, ObservationWindow.ALL_TIME}:
+            raise ValueError("eBird discovery supports observation windows up to 30 days")
+        if not 0 < selected_radius <= 50:
+            raise ValueError("eBird discovery radius_km must be between 1 and 50")
+        if not 0 < selected_limit <= 10_000:
+            raise ValueError("eBird species_limit must be between 1 and 10000")
     location = lookup_us_zip(config.discovery.zip_code)
-    species = fetch_inaturalist_birds(
-        latitude=location.latitude,
-        longitude=location.longitude,
-        radius_km=config.discovery.radius_km,
-        limit=config.discovery.species_limit,
-        window=config.discovery.observation_window,
-    )
-    return location, species
+    providers: list[ProviderStatus] = []
+    provider_species: list[list[BirdSpecies]] = []
+    unresolved: list[EbirdSpecies] = []
+
+    if selected_source in {DiscoverySource.INATURALIST, DiscoverySource.COMBINED}:
+        try:
+            inaturalist = fetch_inaturalist_birds(
+                latitude=location.latitude,
+                longitude=location.longitude,
+                radius_km=selected_radius,
+                limit=selected_limit,
+                window=selected_window,
+            )
+        except DataSourceError as exc:
+            providers.append(ProviderStatus("inaturalist", "error", 0, error=str(exc)))
+        else:
+            provider_species.append(inaturalist)
+            providers.append(ProviderStatus("inaturalist", "ok", len(inaturalist)))
+
+    if selected_source in {DiscoverySource.EBIRD, DiscoverySource.COMBINED}:
+        try:
+            if config.discovery.ebird_api_key is None:
+                raise DataSourceError("eBird API key is not configured")
+            observations = fetch_ebird_observations(
+                latitude=location.latitude,
+                longitude=location.longitude,
+                radius_km=selected_radius,
+                limit=selected_limit,
+                window=selected_window,
+                api_key=config.discovery.ebird_api_key,
+            )
+            resolution = resolve_ebird_species(
+                observations,
+                config.controller.state_dir / "ebird-taxonomy-crosswalk.json",
+            )
+        except (DataSourceError, ValueError) as exc:
+            providers.append(ProviderStatus("ebird", "error", 0, error=str(exc)))
+        else:
+            unresolved.extend(resolution.unresolved)
+            if observations and not resolution.species:
+                providers.append(
+                    ProviderStatus(
+                        "ebird",
+                        "error",
+                        0,
+                        unresolved_count=len(resolution.unresolved),
+                        error="No eBird observations had an exact iNaturalist species match",
+                    )
+                )
+            else:
+                provider_species.append(resolution.species)
+                providers.append(
+                    ProviderStatus(
+                        "ebird",
+                        "ok",
+                        len(resolution.species),
+                        unresolved_count=len(resolution.unresolved),
+                    )
+                )
+
+    if not provider_species:
+        failures = "; ".join(
+            f"{provider.name}: {provider.error}" for provider in providers if provider.error
+        )
+        raise DataSourceError(f"All configured observation providers failed: {failures}")
+    species = _merge_provider_species(provider_species)
+    if selected_source is DiscoverySource.COMBINED:
+        species.sort(key=lambda item: (item.common_name.casefold(), item.taxon_id))
+    return DiscoveryResult(location, species, providers, unresolved)
+
+
+def _merge_provider_species(provider_species: list[list[BirdSpecies]]) -> list[BirdSpecies]:
+    merged: dict[int, BirdSpecies] = {}
+    order: list[int] = []
+    for result in provider_species:
+        for species in result:
+            existing = merged.get(species.taxon_id)
+            if existing is None:
+                merged[species.taxon_id] = species
+                order.append(species.taxon_id)
+                continue
+            sources = tuple(dict.fromkeys((*existing.sources, *species.sources)))
+            merged[species.taxon_id] = BirdSpecies(
+                taxon_id=existing.taxon_id,
+                common_name=existing.common_name,
+                scientific_name=existing.scientific_name,
+                observation_count=max(existing.observation_count, species.observation_count),
+                source="+".join(sources),
+                sources=sources,
+            )
+    return [merged[taxon_id] for taxon_id in order]
 
 
 def _snapshot_path(config: AppConfig) -> Path:
@@ -113,7 +250,7 @@ def _species_payload(species: BirdSpecies) -> dict[str, object]:
         "common_name": species.common_name,
         "scientific_name": species.scientific_name,
         "observation_count": species.observation_count,
-        "source": species.source,
+        "sources": list(species.sources),
     }
 
 
@@ -127,7 +264,10 @@ def _parse_species_list(raw: object, source: Path) -> list[BirdSpecies]:
             raise CatalogError(f"Invalid species in {source}")
         taxon_id = item.get("taxon_id")
         observation_count = item.get("observation_count")
-        strings = [item.get(name) for name in ("common_name", "scientific_name", "source")]
+        strings = [item.get(name) for name in ("common_name", "scientific_name")]
+        sources_value = item.get("sources")
+        if sources_value is None and isinstance(item.get("source"), str):
+            sources_value = [item["source"]]
         if (
             not isinstance(taxon_id, int)
             or isinstance(taxon_id, bool)
@@ -137,6 +277,9 @@ def _parse_species_list(raw: object, source: Path) -> list[BirdSpecies]:
             or isinstance(observation_count, bool)
             or observation_count < 0
             or any(not isinstance(value, str) or not value for value in strings)
+            or not isinstance(sources_value, list)
+            or not sources_value
+            or any(not isinstance(value, str) or not value for value in sources_value)
         ):
             raise CatalogError(f"Invalid species in {source}")
         seen.add(taxon_id)
@@ -146,7 +289,8 @@ def _parse_species_list(raw: object, source: Path) -> list[BirdSpecies]:
                 common_name=cast(str, strings[0]),
                 scientific_name=cast(str, strings[1]),
                 observation_count=observation_count,
-                source=cast(str, strings[2]),
+                source="+".join(cast(list[str], sources_value)),
+                sources=tuple(cast(list[str], sources_value)),
             )
         )
     return species
@@ -160,7 +304,7 @@ def read_generation_queue(config: AppConfig) -> list[BirdSpecies]:
         raw = json.loads(path.read_text())
     except json.JSONDecodeError as exc:
         raise CatalogError(f"Invalid generation queue: {path}") from exc
-    if not isinstance(raw, dict) or raw.get("schema_version") != 1:
+    if not isinstance(raw, dict) or raw.get("schema_version") not in {1, 2}:
         raise CatalogError(f"Unsupported generation queue: {path}")
     return _parse_species_list(raw.get("species"), path)
 
@@ -169,7 +313,7 @@ def _write_generation_queue(config: AppConfig, species: list[BirdSpecies]) -> No
     write_json_atomic(
         _generation_queue_path(config),
         {
-            "schema_version": 1,
+            "schema_version": 2,
             "updated_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
             "species": [_species_payload(item) for item in species],
         },
@@ -180,6 +324,7 @@ def enqueue_seed_species(
     config: AppConfig,
     *,
     window: ObservationWindow,
+    source: DiscoverySource | None = None,
     radius_km: int | None = None,
     species_limit: int | None = None,
     dry_run: bool = False,
@@ -192,14 +337,14 @@ def enqueue_seed_species(
         raise ValueError("species_limit must be greater than zero")
 
     with exclusive_cycle_lock(config.controller.state_dir):
-        location = lookup_us_zip(config.discovery.zip_code)
-        discovered = fetch_inaturalist_birds(
-            latitude=location.latitude,
-            longitude=location.longitude,
-            radius_km=radius,
-            limit=limit,
+        discovery = discover_species(
+            config,
+            source=source,
             window=window,
+            radius_km=radius,
+            species_limit=limit,
         )
+        discovered = discovery.species
         approved = approved_taxon_ids(config.controller.catalog_dir)
         existing = [
             species for species in read_generation_queue(config) if species.taxon_id not in approved
@@ -223,6 +368,7 @@ def enqueue_seed_species(
 
     return {
         "window": window.value,
+        "source": (source or config.discovery.source).value,
         "radius_km": radius,
         "species_limit": limit,
         "discovered_count": len(discovered),
@@ -232,6 +378,8 @@ def enqueue_seed_species(
         "queued_count": len(queued),
         "dry_run": dry_run,
         "added": [_species_payload(species) for species in added],
+        "providers": [provider.as_dict() for provider in discovery.providers],
+        "unresolved_count": len(discovery.unresolved),
     }
 
 
@@ -264,17 +412,20 @@ def run_refresh_cycle(config: AppConfig) -> dict[str, object]:
             previous_taxa = {
                 species.taxon_id for species in _read_discovery_snapshot(config).species
             }
-        location, species_list = discover_species(config)
+        discovery = discover_species(config)
+        location = discovery.location
+        species_list = discovery.species
         new_species = [species for species in species_list if species.taxon_id not in previous_taxa]
         with catalog_state_lock(config.controller.state_dir):
             refreshed_at = datetime.now(UTC).replace(microsecond=0)
             write_json_atomic(
                 _snapshot_path(config),
                 {
-                    "schema_version": 1,
+                    "schema_version": 2,
                     "refreshed_at": refreshed_at.isoformat(),
                     "place_name": location.place_name,
                     "state": location.state,
+                    "providers": [provider.as_dict() for provider in discovery.providers],
                     "species": [_species_payload(species) for species in species_list],
                 },
             )
@@ -285,6 +436,16 @@ def run_refresh_cycle(config: AppConfig) -> dict[str, object]:
         "state": location.state,
         "window": config.discovery.observation_window.value,
         "radius_km": config.discovery.radius_km,
+        "source": config.discovery.source.value,
+        "providers": [provider.as_dict() for provider in discovery.providers],
+        "unresolved_species": [
+            {
+                "species_code": species.species_code,
+                "common_name": species.common_name,
+                "scientific_name": species.scientific_name,
+            }
+            for species in discovery.unresolved
+        ],
         "species_count": len(species_list),
         "new_species": [_species_payload(species) for species in new_species],
         "active_approved_count": active_count,
@@ -299,7 +460,7 @@ def _read_discovery_snapshot(config: AppConfig) -> DiscoverySnapshot:
         raise DataSourceError("Discovery state is missing; run refresh before generation") from exc
     except json.JSONDecodeError as exc:
         raise CatalogError(f"Invalid discovery state: {path}") from exc
-    if not isinstance(raw, dict) or raw.get("schema_version") != 1:
+    if not isinstance(raw, dict) or raw.get("schema_version") not in {1, 2}:
         raise CatalogError(f"Unsupported discovery state: {path}")
     refreshed_at = raw.get("refreshed_at")
     place_name = raw.get("place_name")

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import fcntl
 import json
+import os
 import shutil
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -160,7 +161,11 @@ def discover_species(
 
     if selected_source in {DiscoverySource.EBIRD, DiscoverySource.COMBINED}:
         try:
-            if config.discovery.ebird_api_key is None:
+            api_key = config.discovery.ebird_api_key
+            if api_key is None and config.discovery.ebird_api_key_env is not None:
+                environment_value = os.environ.get(config.discovery.ebird_api_key_env)
+                api_key = environment_value.strip() if environment_value else None
+            if api_key is None:
                 raise DataSourceError("eBird API key is not configured")
             observations = fetch_ebird_observations(
                 latitude=location.latitude,
@@ -168,7 +173,7 @@ def discover_species(
                 radius_km=selected_radius,
                 limit=selected_limit,
                 window=selected_window,
-                api_key=config.discovery.ebird_api_key,
+                api_key=api_key,
             )
             resolution = resolve_ebird_species(
                 observations,
@@ -250,6 +255,7 @@ def _species_payload(species: BirdSpecies) -> dict[str, object]:
         "common_name": species.common_name,
         "scientific_name": species.scientific_name,
         "observation_count": species.observation_count,
+        "source": species.source,
         "sources": list(species.sources),
     }
 

--- a/src/inky_bird_frame/errors.py
+++ b/src/inky_bird_frame/errors.py
@@ -9,6 +9,10 @@ class DataSourceError(InkyBirdFrameError):
     """Raised when a remote data source cannot be used."""
 
 
+class TaxonomyMatchError(DataSourceError):
+    """Raised when a valid response has no unambiguous canonical species match."""
+
+
 class InsufficientReferencesError(DataSourceError):
     """Raised when a valid source response cannot satisfy reference policy."""
 

--- a/src/inky_bird_frame/http.py
+++ b/src/inky_bird_frame/http.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import cast
@@ -12,8 +13,16 @@ from urllib.request import Request, urlopen
 from .errors import DataSourceError
 
 
-def get_json(url: str, timeout_seconds: float = 10.0) -> object:
-    request = Request(url, headers={"User-Agent": "inky-bird-frame/0.1"})
+def get_json(
+    url: str,
+    timeout_seconds: float = 10.0,
+    *,
+    headers: Mapping[str, str] | None = None,
+) -> object:
+    request_headers = {"User-Agent": "inky-bird-frame/0.1"}
+    if headers is not None:
+        request_headers.update(headers)
+    request = Request(url, headers=request_headers)
     try:
         with urlopen(request, timeout=timeout_seconds) as response:
             body = response.read()

--- a/tests/test_birds.py
+++ b/tests/test_birds.py
@@ -1,21 +1,28 @@
 from __future__ import annotations
 
 import unittest
-from datetime import date
+from datetime import UTC, date, datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlsplit
 
 from inky_bird_frame.birds import (
+    EbirdSpecies,
     ObservationWindow,
     date_range_for_window,
+    fetch_ebird_observations,
     fetch_inaturalist_birds,
     fetch_taxon_context,
     parse_birdnet_taxon,
+    parse_ebird_observations,
     parse_inaturalist_species_counts,
     parse_inaturalist_taxon,
+    parse_inaturalist_taxon_match,
     parse_observation_window,
+    resolve_ebird_species,
 )
-from inky_bird_frame.errors import DataSourceError
+from inky_bird_frame.errors import DataSourceError, TaxonomyMatchError
 
 
 class InaturalistParsingTests(unittest.TestCase):
@@ -184,6 +191,114 @@ class InaturalistParsingTests(unittest.TestCase):
                 },
                 expected,
             )
+
+
+class EbirdTests(unittest.TestCase):
+    def test_parse_observations_keeps_complete_unique_species(self) -> None:
+        payload = [
+            {
+                "speciesCode": "easblu",
+                "comName": "Eastern Bluebird",
+                "sciName": "Sialia sialis",
+                "obsDt": "2026-07-12 08:15",
+            },
+            {
+                "speciesCode": "easblu",
+                "comName": "Eastern Bluebird",
+                "sciName": "Sialia sialis",
+                "obsDt": "2026-07-11 10:00",
+            },
+            {"speciesCode": "bad"},
+        ]
+
+        species = parse_ebird_observations(payload)
+
+        self.assertEqual(len(species), 1)
+        self.assertEqual(species[0].species_code, "easblu")
+
+    @patch("inky_bird_frame.birds.get_json", return_value=[])
+    def test_fetch_observations_uses_bounded_query_and_secret_header(
+        self, get_json: MagicMock
+    ) -> None:
+        fetch_ebird_observations(
+            latitude=38.12345,
+            longitude=-77.98765,
+            radius_km=11,
+            limit=50,
+            window=ObservationWindow.LAST_30_DAYS,
+            api_key="secret-token",
+        )
+
+        url = get_json.call_args.args[0]
+        params = parse_qs(urlsplit(url).query)
+        self.assertEqual(params["lat"], ["38.12"])
+        self.assertEqual(params["lng"], ["-77.99"])
+        self.assertEqual(params["dist"], ["11"])
+        self.assertEqual(params["back"], ["30"])
+        self.assertEqual(params["cat"], ["species"])
+        self.assertEqual(get_json.call_args.kwargs["headers"], {"X-eBirdApiToken": "secret-token"})
+        self.assertNotIn("secret-token", url)
+
+    def test_taxon_match_requires_one_exact_active_bird_species(self) -> None:
+        payload = {
+            "results": [
+                {
+                    "id": 12942,
+                    "preferred_common_name": "Eastern Bluebird",
+                    "name": "Sialia sialis",
+                    "rank": "species",
+                    "is_active": True,
+                    "iconic_taxon_name": "Aves",
+                },
+                {
+                    "id": 1,
+                    "preferred_common_name": "Other bird",
+                    "name": "Sialia currucoides",
+                    "rank": "species",
+                    "is_active": True,
+                    "iconic_taxon_name": "Aves",
+                },
+            ]
+        }
+
+        species = parse_inaturalist_taxon_match(payload, "Sialia sialis")
+
+        self.assertEqual(species.taxon_id, 12942)
+        self.assertEqual(species.sources, ("eBird",))
+
+    def test_resolution_uses_cached_exact_mapping(self) -> None:
+        observation = EbirdSpecies(
+            "easblu", "Eastern Bluebird", "Sialia sialis", "2026-07-12 08:15"
+        )
+        with TemporaryDirectory() as temporary:
+            cache = Path(temporary) / "crosswalk.json"
+            cache.write_text(
+                '{"schema_version":1,"entries":{"easblu":'
+                '{"scientific_name":"Sialia sialis","common_name":"Eastern Bluebird",'
+                '"taxon_id":12942}}}'
+            )
+            with patch("inky_bird_frame.birds.fetch_inaturalist_taxon_match") as fetch:
+                result = resolve_ebird_species([observation], cache)
+
+        fetch.assert_not_called()
+        self.assertEqual(result.species[0].taxon_id, 12942)
+        self.assertEqual(result.unresolved, [])
+
+    def test_unresolved_mapping_is_deferred_and_cached(self) -> None:
+        observation = EbirdSpecies("split", "Split Bird", "Avis split", "2026-07-12")
+        now = datetime(2026, 7, 12, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            cache = Path(temporary) / "crosswalk.json"
+            with patch(
+                "inky_bird_frame.birds.fetch_inaturalist_taxon_match",
+                side_effect=TaxonomyMatchError("no exact match"),
+            ) as fetch:
+                first = resolve_ebird_species([observation], cache, now=now)
+                second = resolve_ebird_species([observation], cache, now=now)
+
+        self.assertEqual(fetch.call_count, 1)
+        self.assertEqual(first.unresolved, [observation])
+        self.assertEqual(second.unresolved, [observation])
 
 
 if __name__ == "__main__":

--- a/tests/test_birds.py
+++ b/tests/test_birds.py
@@ -231,8 +231,8 @@ class EbirdTests(unittest.TestCase):
 
         url = get_json.call_args.args[0]
         params = parse_qs(urlsplit(url).query)
-        self.assertEqual(params["lat"], ["38.12"])
-        self.assertEqual(params["lng"], ["-77.99"])
+        self.assertEqual(params["lat"], ["38.123450"])
+        self.assertEqual(params["lng"], ["-77.987650"])
         self.assertEqual(params["dist"], ["11"])
         self.assertEqual(params["back"], ["30"])
         self.assertEqual(params["cat"], ["species"])

--- a/tests/test_birds.py
+++ b/tests/test_birds.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlsplit
 
 from inky_bird_frame.birds import (
+    BirdSpecies,
     EbirdSpecies,
     ObservationWindow,
     date_range_for_window,
@@ -299,6 +300,22 @@ class EbirdTests(unittest.TestCase):
         self.assertEqual(fetch.call_count, 1)
         self.assertEqual(first.unresolved, [observation])
         self.assertEqual(second.unresolved, [observation])
+
+    def test_non_persistent_resolution_does_not_create_cache_state(self) -> None:
+        observation = EbirdSpecies("easblu", "Eastern Bluebird", "Sialia sialis", "2026-07-12")
+        species = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 1, "eBird")
+        with TemporaryDirectory() as temporary:
+            cache = Path(temporary) / "state/crosswalk.json"
+            with patch(
+                "inky_bird_frame.birds.fetch_inaturalist_taxon_match",
+                return_value=species,
+            ):
+                result = resolve_ebird_species([observation], cache, persist_cache=False)
+
+            state_exists = cache.parent.exists()
+
+        self.assertEqual(result.species, [species])
+        self.assertFalse(state_exists)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,14 @@ from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from inky_bird_frame.cli import build_parser, generate_command, main, retry_command
+from inky_bird_frame.birds import BirdSpecies
+from inky_bird_frame.cli import (
+    build_parser,
+    generate_command,
+    main,
+    retry_command,
+    species_to_dict,
+)
 from inky_bird_frame.controller import exclusive_cycle_lock
 from inky_bird_frame.errors import DataSourceError, GenerationError
 
@@ -81,6 +88,14 @@ class CliTests(unittest.TestCase):
         self.assertEqual(args.radius_km, 16)
         self.assertEqual(args.species_limit, 500)
         self.assertTrue(args.dry_run)
+
+    def test_species_output_preserves_legacy_source(self) -> None:
+        species = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 3, "iNaturalist")
+
+        payload = species_to_dict(species)
+
+        self.assertEqual(payload["source"], "iNaturalist")
+        self.assertEqual(payload["sources"], ["iNaturalist"])
 
     def test_config_validation_and_notification_commands_require_config(self) -> None:
         validate = build_parser().parse_args(["config", "validate", "--config", "instance.toml"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,9 +15,11 @@ from inky_bird_frame.cli import (
     build_parser,
     generate_command,
     main,
+    refresh_command,
     retry_command,
     species_to_dict,
 )
+from inky_bird_frame.config import DiscoverySource
 from inky_bird_frame.controller import exclusive_cycle_lock
 from inky_bird_frame.errors import DataSourceError, GenerationError
 
@@ -236,6 +238,30 @@ class CliTests(unittest.TestCase):
         body = degradation.call_args.kwargs["body"]
         self.assertNotIn(secret, body)
         self.assertIn("DataSourceError", body)
+
+    def test_refresh_does_not_clear_taxonomy_alert_when_ebird_fails(self) -> None:
+        config = SimpleNamespace(
+            discovery=SimpleNamespace(source=DiscoverySource.COMBINED),
+        )
+        result = {
+            "providers": [
+                {"name": "inaturalist", "status": "ok"},
+                {"name": "ebird", "status": "error"},
+            ],
+            "unresolved_species": [],
+            "new_species": [],
+        }
+        with (
+            patch("inky_bird_frame.cli._config", return_value=config),
+            patch("inky_bird_frame.cli.run_refresh_cycle", return_value=result),
+            patch("inky_bird_frame.cli.safe_record_degradation"),
+            patch("inky_bird_frame.cli.safe_record_recovery") as recover,
+            redirect_stdout(io.StringIO()),
+        ):
+            refresh_command(Namespace())
+
+        recovered_keys = [call.kwargs["key"] for call in recover.call_args_list]
+        self.assertNotIn("ebird-taxonomy", recovered_keys)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,6 +66,8 @@ class CliTests(unittest.TestCase):
                 "instance.toml",
                 "--window",
                 "last-year",
+                "--source",
+                "inaturalist",
                 "--radius-km",
                 "16",
                 "--species-limit",
@@ -75,6 +77,7 @@ class CliTests(unittest.TestCase):
         )
 
         self.assertEqual(args.window, "last-year")
+        self.assertEqual(args.source, "inaturalist")
         self.assertEqual(args.radius_km, 16)
         self.assertEqual(args.species_limit, 500)
         self.assertTrue(args.dry_run)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from inky_bird_frame.birds import ObservationWindow
-from inky_bird_frame.config import NotificationEvent, RotationMode, load_config
+from inky_bird_frame.config import DiscoverySource, NotificationEvent, RotationMode, load_config
 from inky_bird_frame.errors import ConfigurationError
 
 CONFIG = """
@@ -61,6 +61,7 @@ class ConfigTests(unittest.TestCase):
             config = load_config(path)
 
         self.assertEqual(config.discovery.observation_window, ObservationWindow.LAST_30_DAYS)
+        self.assertIs(config.discovery.source, DiscoverySource.INATURALIST)
         self.assertEqual(config.discovery.radius_km, 16)
         self.assertEqual(config.controller.catalog_dir, (Path(temporary) / "catalog").resolve())
         self.assertEqual(config.controller.max_generation_attempts, 3)
@@ -83,6 +84,39 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(config.schedule.rotation_jitter_seconds, 7)
         self.assertEqual(config.schedule.display_startup_delay_seconds, 30)
         self.assertEqual(config.schedule.catalog_publish_minutes, 4)
+
+    def test_ebird_source_requires_a_key(self) -> None:
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(CONFIG.replace("[discovery]\n", '[discovery]\nsource = "ebird"\n'))
+
+            with self.assertRaisesRegex(ConfigurationError, "requires ebird_api_key"):
+                load_config(path)
+
+    def test_ebird_key_can_come_from_environment(self) -> None:
+        configured = CONFIG.replace(
+            "[discovery]\n",
+            '[discovery]\nsource = "combined"\nebird_api_key_env = "TEST_EBIRD_KEY"\n',
+        )
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(configured)
+            with patch.dict("os.environ", {"TEST_EBIRD_KEY": "secret"}):
+                config = load_config(path)
+
+        self.assertIs(config.discovery.source, DiscoverySource.COMBINED)
+        self.assertEqual(config.discovery.ebird_api_key, "secret")
+
+    def test_ebird_rejects_long_observation_windows(self) -> None:
+        configured = CONFIG.replace(
+            "[discovery]\n", '[discovery]\nsource = "ebird"\nebird_api_key = "secret"\n'
+        ).replace('window = "last-30-days"', 'window = "last-year"')
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(configured)
+
+            with self.assertRaisesRegex(ConfigurationError, "up to 30 days"):
+                load_config(path)
 
     def test_rejects_invalid_zip(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -107,6 +107,19 @@ class ConfigTests(unittest.TestCase):
         self.assertIs(config.discovery.source, DiscoverySource.COMBINED)
         self.assertEqual(config.discovery.ebird_api_key, "secret")
 
+    def test_inaturalist_default_resolves_key_for_source_override(self) -> None:
+        configured = CONFIG.replace(
+            "[discovery]\n", '[discovery]\nebird_api_key_env = "TEST_EBIRD_KEY"\n'
+        )
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(configured)
+            with patch.dict("os.environ", {"TEST_EBIRD_KEY": "secret"}):
+                config = load_config(path)
+
+        self.assertIs(config.discovery.source, DiscoverySource.INATURALIST)
+        self.assertEqual(config.discovery.ebird_api_key, "secret")
+
     def test_ebird_rejects_long_observation_windows(self) -> None:
         configured = CONFIG.replace(
             "[discovery]\n", '[discovery]\nsource = "ebird"\nebird_api_key = "secret"\n'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -120,6 +120,20 @@ class ConfigTests(unittest.TestCase):
         self.assertIs(config.discovery.source, DiscoverySource.INATURALIST)
         self.assertEqual(config.discovery.ebird_api_key, "secret")
 
+    def test_inaturalist_default_allows_missing_optional_ebird_environment(self) -> None:
+        configured = CONFIG.replace(
+            "[discovery]\n", '[discovery]\nebird_api_key_env = "TEST_EBIRD_KEY"\n'
+        )
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(configured)
+            with patch.dict("os.environ", {}, clear=True):
+                config = load_config(path)
+
+        self.assertIs(config.discovery.source, DiscoverySource.INATURALIST)
+        self.assertIsNone(config.discovery.ebird_api_key)
+        self.assertEqual(config.discovery.ebird_api_key_env, "TEST_EBIRD_KEY")
+
     def test_ebird_rejects_long_observation_windows(self) -> None:
         configured = CONFIG.replace(
             "[discovery]\n", '[discovery]\nsource = "ebird"\nebird_api_key = "secret"\n'

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -193,6 +193,32 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(queue["species"][0]["taxon_id"], 2)
         self.assertNotIn("zip_code", queue)
 
+    def test_seed_dry_run_does_not_create_controller_state(self) -> None:
+        species = BirdSpecies(2, "New Bird", "Avis nova", 1, "eBird")
+        location = ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            with (
+                patch(
+                    "inky_bird_frame.controller.discover_species",
+                    return_value=discovery_result(location, [species]),
+                ) as discover,
+                patch("inky_bird_frame.controller.approved_taxon_ids", return_value=set()),
+            ):
+                result = enqueue_seed_species(
+                    config,
+                    window=ObservationWindow.LAST_WEEK,
+                    dry_run=True,
+                )
+
+            state_exists = config.controller.state_dir.exists()
+
+        self.assertEqual(result["added_count"], 1)
+        self.assertFalse(state_exists)
+        self.assertFalse(discover.call_args.kwargs["persist_taxonomy_cache"])
+
     def test_generation_prioritizes_current_species_before_seed_queue(self) -> None:
         current = BirdSpecies(1, "Current Bird", "Avis current", 4, "iNaturalist")
         queued = BirdSpecies(2, "Queued Bird", "Avis queued", 3, "iNaturalist")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 from inky_bird_frame.birds import BirdSpecies, EbirdResolution, EbirdSpecies, ObservationWindow
 from inky_bird_frame.catalog import CatalogEntry, candidate_directory, write_candidate_manifest
 from inky_bird_frame.codex_runner import CodexRunner
-from inky_bird_frame.config import load_config
+from inky_bird_frame.config import DiscoverySource, load_config
 from inky_bird_frame.controller import (
     DiscoveryResult,
     DiscoverySnapshot,
@@ -188,6 +188,8 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(result["discovered_count"], 2)
         self.assertEqual(result["already_approved_count"], 1)
         self.assertEqual(result["added_count"], 1)
+        added = cast(list[dict[str, object]], result["added"])
+        self.assertEqual(added[0]["source"], "iNaturalist")
         self.assertEqual(queue["species"][0]["taxon_id"], 2)
         self.assertNotIn("zip_code", queue)
 
@@ -497,6 +499,7 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(active["species"][0]["observation_count"], 9)
         self.assertNotIn("zip_code", active)
         self.assertEqual(len(snapshot["species"]), 2)
+        self.assertEqual(snapshot["species"][0]["source"], "iNaturalist")
 
     def test_refresh_preserves_approved_catalog_order(self) -> None:
         first = BirdSpecies(1, "Alpha Bird", "Alpha avis", 2, "iNaturalist")
@@ -818,6 +821,38 @@ class ControllerTests(unittest.TestCase):
 
 
 class DiscoveryProviderTests(unittest.TestCase):
+    def test_ebird_override_resolves_environment_key_at_execution_time(self) -> None:
+        observation = EbirdSpecies("easblu", "Eastern Bluebird", "Sialia sialis", "2026-07-12")
+        resolved = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 1, "eBird")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(
+                CONFIG.replace(
+                    "[discovery]\n", '[discovery]\nebird_api_key_env = "TEST_EBIRD_KEY"\n'
+                )
+            )
+            with patch.dict("os.environ", {}, clear=True):
+                config = load_config(config_path)
+            with (
+                patch.dict("os.environ", {"TEST_EBIRD_KEY": "secret"}),
+                patch(
+                    "inky_bird_frame.controller.lookup_us_zip",
+                    return_value=ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0),
+                ),
+                patch(
+                    "inky_bird_frame.controller.fetch_ebird_observations",
+                    return_value=[observation],
+                ) as fetch,
+                patch(
+                    "inky_bird_frame.controller.resolve_ebird_species",
+                    return_value=EbirdResolution([resolved], []),
+                ),
+            ):
+                result = discover_species(config, source=DiscoverySource.EBIRD)
+
+        self.assertEqual(result.species, [resolved])
+        self.assertEqual(fetch.call_args.kwargs["api_key"], "secret")
+
     def test_combined_override_rejects_long_window_before_querying(self) -> None:
         with TemporaryDirectory() as temporary:
             config_path = Path(temporary) / "config.toml"

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -8,12 +8,15 @@ from tempfile import TemporaryDirectory
 from typing import cast
 from unittest.mock import patch
 
-from inky_bird_frame.birds import BirdSpecies, ObservationWindow
+from inky_bird_frame.birds import BirdSpecies, EbirdResolution, EbirdSpecies, ObservationWindow
 from inky_bird_frame.catalog import CatalogEntry, candidate_directory, write_candidate_manifest
 from inky_bird_frame.codex_runner import CodexRunner
 from inky_bird_frame.config import load_config
 from inky_bird_frame.controller import (
+    DiscoveryResult,
     DiscoverySnapshot,
+    ProviderStatus,
+    discover_species,
     enqueue_seed_species,
     exclusive_refresh_lock,
     generate_candidate,
@@ -33,6 +36,16 @@ from inky_bird_frame.geo import ZipLocation
 from inky_bird_frame.models import QualityReview, SpeciesProfileData
 from inky_bird_frame.prompts import PROMPT_VERSION
 from inky_bird_frame.retry import RetryStore
+
+
+def discovery_result(location: ZipLocation, species: list[BirdSpecies]) -> DiscoveryResult:
+    return DiscoveryResult(
+        location=location,
+        species=species,
+        providers=[ProviderStatus("inaturalist", "ok", len(species))],
+        unresolved=[],
+    )
+
 
 PROFILE = SpeciesProfileData(
     taxon_id=9083,
@@ -468,7 +481,7 @@ class ControllerTests(unittest.TestCase):
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",
-                    return_value=(location, [observed, unapproved]),
+                    return_value=discovery_result(location, [observed, unapproved]),
                 ),
                 patch(
                     "inky_bird_frame.controller.rebuild_catalog_index",
@@ -510,7 +523,7 @@ class ControllerTests(unittest.TestCase):
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",
-                    return_value=(location, [second, first]),
+                    return_value=discovery_result(location, [second, first]),
                 ),
                 patch(
                     "inky_bird_frame.controller.rebuild_catalog_index",
@@ -533,7 +546,7 @@ class ControllerTests(unittest.TestCase):
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",
-                    return_value=(location, [species]),
+                    return_value=discovery_result(location, [species]),
                 ),
                 patch("inky_bird_frame.controller.generate_candidate") as generate,
             ):
@@ -584,7 +597,7 @@ class ControllerTests(unittest.TestCase):
             )
             with patch(
                 "inky_bird_frame.controller.discover_species",
-                return_value=(location, [species]),
+                return_value=discovery_result(location, [species]),
             ):
                 result = run_controller_cycle(config)
 
@@ -623,7 +636,7 @@ class ControllerTests(unittest.TestCase):
             )
             with patch(
                 "inky_bird_frame.controller.discover_species",
-                return_value=(location, []),
+                return_value=discovery_result(location, []),
             ):
                 result = run_controller_cycle(config)
 
@@ -643,7 +656,7 @@ class ControllerTests(unittest.TestCase):
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",
-                    return_value=(location, [species]),
+                    return_value=discovery_result(location, [species]),
                 ),
                 patch("inky_bird_frame.controller.generate_candidate") as generate,
             ):
@@ -737,7 +750,7 @@ class ControllerTests(unittest.TestCase):
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",
-                    return_value=(location, [species]),
+                    return_value=discovery_result(location, [species]),
                 ),
                 patch("inky_bird_frame.controller.generate_candidate") as generate,
             ):
@@ -766,7 +779,7 @@ class ControllerTests(unittest.TestCase):
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",
-                    return_value=(location, [species]),
+                    return_value=discovery_result(location, [species]),
                 ),
                 patch("inky_bird_frame.controller.generate_candidate") as generate,
             ):
@@ -788,7 +801,7 @@ class ControllerTests(unittest.TestCase):
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",
-                    return_value=(location, [species]),
+                    return_value=discovery_result(location, [species]),
                 ),
                 patch("inky_bird_frame.controller.generate_candidate") as generate,
             ):
@@ -802,6 +815,94 @@ class ControllerTests(unittest.TestCase):
         self.assertIsInstance(failure_results, list)
         if isinstance(failure_results, list):
             self.assertTrue(failure_results[0]["terminal"])
+
+
+class DiscoveryProviderTests(unittest.TestCase):
+    def test_combined_override_rejects_long_window_before_querying(self) -> None:
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(
+                CONFIG.replace(
+                    "[discovery]\n",
+                    '[discovery]\nsource = "combined"\nebird_api_key = "secret"\n',
+                )
+            )
+            config = load_config(config_path)
+            with (
+                patch("inky_bird_frame.controller.lookup_us_zip") as lookup,
+                self.assertRaisesRegex(ValueError, "up to 30 days"),
+            ):
+                discover_species(config, window=ObservationWindow.LAST_YEAR)
+
+        lookup.assert_not_called()
+
+    def test_combined_mode_deduplicates_by_inaturalist_taxon(self) -> None:
+        inaturalist = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 9, "iNaturalist")
+        ebird = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 1, "eBird")
+        observation = EbirdSpecies("easblu", "Eastern Bluebird", "Sialia sialis", "2026-07-12")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(
+                CONFIG.replace(
+                    "[discovery]\n",
+                    '[discovery]\nsource = "combined"\nebird_api_key = "secret"\n',
+                )
+            )
+            config = load_config(config_path)
+            with (
+                patch(
+                    "inky_bird_frame.controller.lookup_us_zip",
+                    return_value=ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0),
+                ),
+                patch(
+                    "inky_bird_frame.controller.fetch_inaturalist_birds",
+                    return_value=[inaturalist],
+                ),
+                patch(
+                    "inky_bird_frame.controller.fetch_ebird_observations",
+                    return_value=[observation],
+                ),
+                patch(
+                    "inky_bird_frame.controller.resolve_ebird_species",
+                    return_value=EbirdResolution([ebird], []),
+                ),
+            ):
+                result = discover_species(config)
+
+        self.assertEqual(len(result.species), 1)
+        self.assertEqual(result.species[0].observation_count, 9)
+        self.assertEqual(result.species[0].sources, ("iNaturalist", "eBird"))
+        self.assertTrue(all(provider.status == "ok" for provider in result.providers))
+
+    def test_combined_mode_continues_when_ebird_fails(self) -> None:
+        inaturalist = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 9, "iNaturalist")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(
+                CONFIG.replace(
+                    "[discovery]\n",
+                    '[discovery]\nsource = "combined"\nebird_api_key = "secret"\n',
+                )
+            )
+            config = load_config(config_path)
+            with (
+                patch(
+                    "inky_bird_frame.controller.lookup_us_zip",
+                    return_value=ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0),
+                ),
+                patch(
+                    "inky_bird_frame.controller.fetch_inaturalist_birds",
+                    return_value=[inaturalist],
+                ),
+                patch(
+                    "inky_bird_frame.controller.fetch_ebird_observations",
+                    side_effect=DataSourceError("eBird unavailable"),
+                ),
+            ):
+                result = discover_species(config)
+
+        self.assertEqual(result.species, [inaturalist])
+        self.assertEqual(result.providers[1].status, "error")
 
 
 if __name__ == "__main__":

--- a/tests/test_deployment_scripts.py
+++ b/tests/test_deployment_scripts.py
@@ -21,6 +21,7 @@ def test_controller_installer_restores_schedule_without_run_at_load_on_failure()
     assert "publisher_was_loaded=true" in script[unload:validation]
     assert "/usr/bin/plutil -replace RunAtLoad -bool false" in script
     assert 'if [ "${root}" != "${app_dir}" ]; then' in script
+    assert 'rsync -a "${root}/catalog/" "${app_dir}/catalog/"' not in script
     assert 'sync_public_catalog(root / "catalog", config.controller.catalog_dir)' in script
     assert "config.controller.workspace_dir.mkdir(parents=True, exist_ok=True)" in script
     assert "config.controller.catalog_dir.parent.mkdir(parents=True, exist_ok=True)" in script
@@ -53,6 +54,7 @@ def test_systemd_controller_installer_restarts_boot_persistent_services() -> Non
     assert "systemctl is-enabled --quiet inky-bird-frame-catalog-publish.timer" in script
     assert "systemctl is-active --quiet inky-bird-frame-notifications.timer" in script
     assert 'if [ "${root}" != "${app_dir}" ]; then' in script
+    assert 'rsync -a "${root}/catalog/" "${app_dir}/catalog/"' not in script
     assert 'sync_public_catalog(root / "catalog", config.controller.catalog_dir)' in script
     assert "config.controller.workspace_dir.mkdir(parents=True, exist_ok=True)" in script
     assert "config.controller.catalog_dir.parent.mkdir(parents=True, exist_ok=True)" in script

--- a/tests/test_deployment_scripts.py
+++ b/tests/test_deployment_scripts.py
@@ -22,7 +22,9 @@ def test_controller_installer_restores_schedule_without_run_at_load_on_failure()
     assert "/usr/bin/plutil -replace RunAtLoad -bool false" in script
     assert 'if [ "${root}" != "${app_dir}" ]; then' in script
     assert 'rsync -a "${root}/catalog/" "${app_dir}/catalog/"' not in script
-    assert 'sync_public_catalog(root / "catalog", config.controller.catalog_dir)' in script
+    assert "sync_public_catalog(source_catalog, managed_catalog)" in script
+    assert "sync_public_catalog(source_catalog, config.controller.catalog_dir)" in script
+    assert "managed_catalog.resolve() != config.controller.catalog_dir.resolve()" in script
     assert "requires ebird_api_key in the private config" in script
     assert "config.controller.workspace_dir.mkdir(parents=True, exist_ok=True)" in script
     assert "config.controller.catalog_dir.parent.mkdir(parents=True, exist_ok=True)" in script
@@ -56,7 +58,9 @@ def test_systemd_controller_installer_restarts_boot_persistent_services() -> Non
     assert "systemctl is-active --quiet inky-bird-frame-notifications.timer" in script
     assert 'if [ "${root}" != "${app_dir}" ]; then' in script
     assert 'rsync -a "${root}/catalog/" "${app_dir}/catalog/"' not in script
-    assert 'sync_public_catalog(root / "catalog", config.controller.catalog_dir)' in script
+    assert "sync_public_catalog(source_catalog, managed_catalog)" in script
+    assert "sync_public_catalog(source_catalog, config.controller.catalog_dir)" in script
+    assert "managed_catalog.resolve() != config.controller.catalog_dir.resolve()" in script
     assert "requires ebird_api_key in the private config" in script
     assert "config.controller.workspace_dir.mkdir(parents=True, exist_ok=True)" in script
     assert "config.controller.catalog_dir.parent.mkdir(parents=True, exist_ok=True)" in script

--- a/tests/test_deployment_scripts.py
+++ b/tests/test_deployment_scripts.py
@@ -23,6 +23,7 @@ def test_controller_installer_restores_schedule_without_run_at_load_on_failure()
     assert 'if [ "${root}" != "${app_dir}" ]; then' in script
     assert 'rsync -a "${root}/catalog/" "${app_dir}/catalog/"' not in script
     assert 'sync_public_catalog(root / "catalog", config.controller.catalog_dir)' in script
+    assert "requires ebird_api_key in the private config" in script
     assert "config.controller.workspace_dir.mkdir(parents=True, exist_ok=True)" in script
     assert "config.controller.catalog_dir.parent.mkdir(parents=True, exist_ok=True)" in script
     assert "rebuild_catalog_index" not in script
@@ -56,6 +57,7 @@ def test_systemd_controller_installer_restarts_boot_persistent_services() -> Non
     assert 'if [ "${root}" != "${app_dir}" ]; then' in script
     assert 'rsync -a "${root}/catalog/" "${app_dir}/catalog/"' not in script
     assert 'sync_public_catalog(root / "catalog", config.controller.catalog_dir)' in script
+    assert "requires ebird_api_key in the private config" in script
     assert "config.controller.workspace_dir.mkdir(parents=True, exist_ok=True)" in script
     assert "config.controller.catalog_dir.parent.mkdir(parents=True, exist_ok=True)" in script
     assert "rebuild_catalog_index" not in script


### PR DESCRIPTION
## Summary
- add iNaturalist, eBird, and combined discovery modes
- exact-match eBird species to canonical iNaturalist taxa with a durable crosswalk cache
- preserve partial-provider operation, state compatibility, notifications, and historical iNaturalist seeding
- document credentials, limits, privacy, data use, and rotation semantics

## Validation
- `uv build`
- `uv run pytest -q`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- live eBird API request with the private key
- live five-species eBird-to-iNaturalist enrichment: 5 resolved, 0 unresolved
