### PR TITLE
Add BirdWeather station discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,11 +226,14 @@ uv run inky-bird-frame catalog-publish --config config.toml --dry-run
 uv run inky-bird-frame catalog-publish --config config.toml
 ```
 
-Discovery sources are `inaturalist`, `ebird`, and `combined`. eBird supplies
-bird-specific public sightings; every eBird result is exact-matched to an
-iNaturalist species before the existing licensed-reference pipeline accepts it.
+Discovery sources are `inaturalist`, `ebird`, `combined`, `birdweather`, and
+`all`. BirdWeather adds species detected by one authenticated acoustic station;
+the project reads detection metadata only and never receives or manages audio.
+Every external species is exact-matched to iNaturalist taxonomy before the
+existing licensed-reference pipeline accepts it.
 Observation windows are `last-day`, `last-week`, `last-30-days`, `last-year`,
-and `all-time`; eBird modes support the first three and a maximum 50 km radius.
+and `all-time`; eBird modes support the first three and a maximum 50 km radius,
+while BirdWeather supports every window and at most 100 species.
 See [Discovery sources](docs/discovery.md) for credentials, merging, failure
 handling, privacy, and provider limitations.
 Rotation modes are `sequential`, `shuffle`, `shuffle_bag`, and `weighted`.
@@ -238,9 +241,10 @@ Rotation modes are `sequential`, `shuffle`, `shuffle_bag`, and `weighted`.
 separate bag: it displays each currently active bird at most once before a
 refill, adds newly active birds to the current bag immediately, prunes inactive
 birds, and avoids a repeat at the refill boundary when alternatives exist.
-`weighted` uses iNaturalist observation counts where available; eBird-only
-species receive a presence weight of one. It avoids immediate repeats when
-alternatives are available.
+`weighted` uses iNaturalist observation counts or BirdWeather station-detection
+counts where available; eBird-only species receive a presence weight of one.
+Counts from different providers are not equivalent evidence. It avoids
+immediate repeats when alternatives are available.
 Recovery and operator-override commands are documented in
 [`docs/operations.md`](docs/operations.md).
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,6 +1,7 @@
 [discovery]
-# iNaturalist needs no credentials and supports every window. eBird provides bird-specific
-# recent sightings but requires a personal API key. combined queries both independently.
+# iNaturalist needs no credentials. eBird provides nearby public sightings. BirdWeather
+# provides acoustic detections from one authenticated station. combined is iNaturalist plus
+# eBird; all queries all three independently. See docs/discovery.md before choosing.
 source = "inaturalist"
 # This location is used only to discover species. It is never rendered on a plate.
 zip_code = "12345"
@@ -17,6 +18,10 @@ window = "last-30-days"
 # radius. Keep a real key only in this private mode-0600 file, or name an injected variable.
 # ebird_api_key = "YOUR_PERSONAL_EBIRD_API_KEY"
 # ebird_api_key_env = "EBIRD_API_KEY"
+# BirdWeather and all accept at most 100 species. This token authenticates one station and
+# belongs only in this private file or an injected environment variable.
+# birdweather_token = "YOUR_BIRDWEATHER_STATION_TOKEN"
+# birdweather_token_env = "BIRDWEATHER_TOKEN"
 
 [controller]
 workspace_dir = "."

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -1,6 +1,8 @@
 # Discovery sources
 
-Inky Bird Frame can discover nearby birds through iNaturalist, eBird, or both.
+Inky Bird Frame can discover birds through public observations or an optional
+authenticated acoustic station. The controller consumes species metadata from
+these services and sends every result through one catalog and review pipeline.
 Merlin Bird ID is Cornell's identification application; its nearby lists are
 powered by eBird. This project integrates the documented eBird API, not Merlin.
 
@@ -11,6 +13,8 @@ powered by eBird. This project integrates the documented eBird API, not Merlin.
 | `inaturalist` | None | All | Default setup, historical seeds, and licensed references |
 | `ebird` | Personal eBird key | 1, 7, or 30 days | Bird-specific recent public sightings |
 | `combined` | Personal eBird key | 1, 7, or 30 days | Broad recent discovery with provider fallback |
+| `birdweather` | BirdWeather station token | All | Species acoustically detected by one station |
+| `all` | Both credentials | 1, 7, or 30 days | Public observations plus station detections |
 
 Request a personal key from [eBird](https://ebird.org/api/keygen). Store it in
 the private configuration:
@@ -33,6 +37,63 @@ value in the private mode-`0600` configuration file.
 Keep the configuration outside the checkout with mode `0600`. The application
 never writes the key to state, logs, catalog files, or command output.
 
+## BirdWeather station setup
+
+BirdWeather is optional. Create a BirdWeather account and station, then connect
+a compatible detector such as BirdNET-Pi by following the official
+[BirdNET-Pi integration guide](https://www.birdweather.com/birdnetpi). Copy the
+station authentication token into the private controller configuration:
+
+```toml
+[discovery]
+source = "birdweather"
+zip_code = "12345"
+radius_km = 8
+species_limit = 50
+window = "last-30-days"
+birdweather_token = "your-station-token"
+```
+
+Use `source = "all"` and configure both `ebird_api_key` and
+`birdweather_token` to query every provider. For manually invoked commands,
+`birdweather_token_env = "BIRDWEATHER_TOKEN"` is also supported. Managed
+services require the direct token in the private mode-`0600` file because they
+do not inherit the installation shell environment.
+
+The token authenticates one station. The application uses BirdWeather's
+documented station-species endpoint, requests only the `avian` classification,
+and uses the selected time window. It does not query nearby BirdWeather
+stations or infer a station from the configured ZIP code. The ZIP remains a
+required controller setting for compatibility and for location-based providers,
+but it does not select or filter BirdWeather station detections.
+
+### Supported boundary
+
+Inky Bird Frame supports:
+
+- reading species names, detection counts, and latest-detection timestamps from
+  the authenticated station;
+- exact scientific-name matching to the canonical iNaturalist taxon;
+- provider-specific health reporting, retries, and notifications;
+- approved catalog reuse, generation, review, rotation, and publication; and
+- every configured observation window, up to BirdWeather's 100-species API cap.
+
+Inky Bird Frame does not:
+
+- install, configure, update, or monitor BirdNET-Pi or other acoustic detectors;
+- configure microphones, recording schedules, storage, retention, or uploads;
+- download, proxy, play, retain, or independently review soundscape audio;
+- confirm that a machine classification represents a bird physically present;
+- correct detector confidence, placement, background-noise, or taxonomy errors;
+  or
+- submit detections to eBird or iNaturalist.
+
+An acoustic detection is a model classification, not a human-confirmed sighting.
+False positives, overlapping calls, recordings, rebroadcast audio, distant
+sounds, and detector configuration can affect the result. Inky Bird Frame uses
+the station's accepted BirdWeather species summary as supplied. Tune and review
+the detector in its own software before relying on those species for display.
+
 ## How eBird enrichment works
 
 eBird returns recent public sightings and an eBird species code. The controller
@@ -46,23 +107,25 @@ iNaturalist remains the source for taxonomy and research-grade CC0/CC-BY
 reference photographs. eBird and Macaulay Library media are not copied into the
 generation pipeline.
 
-## Combined mode
+## Combined and all modes
 
 Each provider receives the configured `species_limit`; the merged result can be
-up to twice that size before duplicates are removed by iNaturalist taxon ID. If
-one provider fails, the successful provider still refreshes the active catalog
-and the controller records a provider-specific degradation. The refresh fails
-only when every configured provider fails, leaving the prior active catalog in
-place.
+larger before duplicates are removed by iNaturalist taxon ID. `combined` queries
+iNaturalist and eBird. `all` adds BirdWeather. If one provider fails, successful
+providers still refresh the active catalog and the controller records a
+provider-specific degradation. The refresh fails only when every configured
+provider fails, leaving the prior active catalog in place.
 
-iNaturalist supplies observation-frequency counts. eBird's nearby endpoint
-supplies recent presence rather than a comparable aggregate count, so eBird-only
-species receive weight one. `shuffle_bag` is the recommended source-neutral
-rotation policy.
+iNaturalist supplies observation counts, BirdWeather supplies station detection
+counts, and eBird's nearby endpoint supplies presence rather than a comparable
+aggregate count. eBird-only species receive weight one. These counts describe
+different collection methods and should not be compared as equivalent evidence.
+`shuffle_bag` is the recommended source-neutral rotation policy.
 
 ## Limits and data use
 
-The eBird nearby API supports at most 30 days and 50 km. Use an explicit
+The eBird nearby API supports at most 30 days and 50 km. BirdWeather returns at
+most 100 species per station-species request. Use an explicit
 iNaturalist seed for longer periods:
 
 ```bash
@@ -72,6 +135,9 @@ inky-bird-frame seed --config /path/to/config.toml \
 
 Review the official [eBird API documentation](https://documenter.getpostman.com/view/664302/S1ENwy59/)
 and [eBird data-use guidance](https://support.ebird.org/en/support/solutions/articles/48001078113)
-before commercial use. The private discovery snapshot may contain provider
-diagnostics, but location and observation details never enter reusable plates
-or the public catalog.
+and the official [BirdWeather V1 API](https://app.birdweather.com/api/v1)
+before commercial use. BirdWeather is a hosted dependency and its availability,
+retention, accepted detection format, and API behavior remain outside this
+project's control. The private discovery snapshot may contain provider
+diagnostics and source names, but station tokens, location details, and
+observation details never enter reusable plates or the public catalog.

--- a/src/inky_bird_frame/birds.py
+++ b/src/inky_bird_frame/birds.py
@@ -41,6 +41,15 @@ class EbirdSpecies:
 
 
 @dataclass(frozen=True)
+class BirdWeatherSpecies:
+    species_id: int
+    common_name: str
+    scientific_name: str
+    detection_count: int
+    latest_detection_at: str
+
+
+@dataclass(frozen=True)
 class EbirdResolution:
     species: list[BirdSpecies]
     unresolved: list[EbirdSpecies]
@@ -71,6 +80,7 @@ EBIRD_BACK_DAYS: Final = {
 }
 EBIRD_MAX_RADIUS_KM: Final = 50
 EBIRD_UNRESOLVED_RETRY_DAYS: Final = 7
+BIRDWEATHER_MAX_SPECIES: Final = 100
 
 
 @dataclass(frozen=True)
@@ -261,6 +271,91 @@ def fetch_ebird_observations(
     return parse_ebird_observations(payload)
 
 
+def parse_birdweather_species(payload: object) -> list[BirdWeatherSpecies]:
+    if not isinstance(payload, dict) or payload.get("success") is not True:
+        raise DataSourceError("BirdWeather response was not successful")
+    results = payload.get("species")
+    if not isinstance(results, list):
+        raise DataSourceError("BirdWeather response did not include a species list")
+
+    species: list[BirdWeatherSpecies] = []
+    seen: set[int] = set()
+    for item in results:
+        if not isinstance(item, dict) or item.get("classification") != "avian":
+            continue
+        species_id = item.get("id")
+        common_name = item.get("commonName")
+        scientific_name = item.get("scientificName")
+        latest_detection_at = item.get("latestDetectionAt")
+        detections = item.get("detections")
+        count = detections.get("total") if isinstance(detections, dict) else None
+        if (
+            not isinstance(species_id, int)
+            or isinstance(species_id, bool)
+            or species_id <= 0
+            or species_id in seen
+            or not isinstance(common_name, str)
+            or not common_name.strip()
+            or not isinstance(scientific_name, str)
+            or not scientific_name.strip()
+            or not isinstance(latest_detection_at, str)
+            or not latest_detection_at.strip()
+            or not isinstance(count, int)
+            or isinstance(count, bool)
+            or count <= 0
+        ):
+            continue
+        seen.add(species_id)
+        species.append(
+            BirdWeatherSpecies(
+                species_id=species_id,
+                common_name=common_name.strip(),
+                scientific_name=scientific_name.strip(),
+                detection_count=count,
+                latest_detection_at=latest_detection_at.strip(),
+            )
+        )
+    if results and not species:
+        raise DataSourceError("BirdWeather response did not include usable avian species")
+    return species
+
+
+def fetch_birdweather_species(
+    *,
+    token: str,
+    limit: int,
+    window: ObservationWindow,
+    today: date | None = None,
+    timeout_seconds: float = 10.0,
+) -> list[BirdWeatherSpecies]:
+    if not token.strip():
+        raise ValueError("BirdWeather station token must not be empty")
+    if not 0 < limit <= BIRDWEATHER_MAX_SPECIES:
+        raise ValueError(
+            f"BirdWeather species_limit must be between 1 and {BIRDWEATHER_MAX_SPECIES}"
+        )
+    date_range = date_range_for_window(window, today)
+    query: dict[str, str] = {
+        "limit": str(limit),
+        "sort": "top",
+        "order": "desc",
+        "classification": "avian",
+    }
+    if date_range.start is None:
+        query["period"] = "all"
+    else:
+        query["from"] = date_range.start.isoformat()
+        if date_range.end is not None:
+            query["to"] = date_range.end.isoformat()
+    encoded_token = quote(token.strip(), safe="")
+    payload = get_json(
+        f"https://app.birdweather.com/api/v1/stations/{encoded_token}/species?{urlencode(query)}",
+        timeout_seconds,
+        error_label="BirdWeather API",
+    )
+    return parse_birdweather_species(payload)
+
+
 def parse_inaturalist_taxon_match(payload: object, scientific_name: str) -> BirdSpecies:
     if not isinstance(payload, dict):
         raise DataSourceError("iNaturalist taxon search response was not an object")
@@ -326,7 +421,7 @@ def resolve_ebird_species(
     persist_cache: bool = True,
 ) -> EbirdResolution:
     if not persist_cache:
-        return _resolve_ebird_species_locked(
+        return _resolve_external_species_locked(
             observations,
             cache_path,
             now=now,
@@ -334,8 +429,8 @@ def resolve_ebird_species(
             persist_cache=False,
         )
     cache_path.parent.mkdir(parents=True, exist_ok=True)
-    with _ebird_crosswalk_lock(cache_path):
-        return _resolve_ebird_species_locked(
+    with _taxonomy_crosswalk_lock(cache_path):
+        return _resolve_external_species_locked(
             observations,
             cache_path,
             now=now,
@@ -344,16 +439,18 @@ def resolve_ebird_species(
         )
 
 
-def _resolve_ebird_species_locked(
+def _resolve_external_species_locked(
     observations: list[EbirdSpecies],
     cache_path: Path,
     *,
     now: datetime | None,
     timeout_seconds: float,
     persist_cache: bool,
+    source: str = "eBird",
+    counts: dict[str, int] | None = None,
 ) -> EbirdResolution:
     current = (now or datetime.now(UTC)).astimezone(UTC).replace(microsecond=0)
-    cache = _read_ebird_crosswalk(cache_path)
+    cache = _read_taxonomy_crosswalk(cache_path)
     resolved: list[BirdSpecies] = []
     unresolved: list[EbirdSpecies] = []
     changed = False
@@ -369,8 +466,8 @@ def _resolve_ebird_species_locked(
                         taxon_id=taxon_id,
                         common_name=common_name,
                         scientific_name=observation.scientific_name,
-                        observation_count=1,
-                        source="eBird",
+                        observation_count=(counts or {}).get(observation.species_code, 1),
+                        source=source,
                     )
                 )
                 continue
@@ -397,16 +494,90 @@ def _resolve_ebird_species_locked(
             "taxon_id": species.taxon_id,
             "resolved_at": current.isoformat(),
         }
-        resolved.append(species)
+        resolved.append(
+            BirdSpecies(
+                taxon_id=species.taxon_id,
+                common_name=species.common_name,
+                scientific_name=species.scientific_name,
+                observation_count=(counts or {}).get(observation.species_code, 1),
+                source=source,
+            )
+        )
         changed = True
 
     if changed and persist_cache:
-        _write_ebird_crosswalk(cache_path, cache)
+        _write_taxonomy_crosswalk(cache_path, cache)
     return EbirdResolution(species=resolved, unresolved=unresolved)
 
 
+def resolve_birdweather_species(
+    detections: list[BirdWeatherSpecies],
+    cache_path: Path,
+    *,
+    now: datetime | None = None,
+    timeout_seconds: float = 10.0,
+    persist_cache: bool = True,
+) -> tuple[list[BirdSpecies], list[BirdWeatherSpecies]]:
+    observations = [
+        EbirdSpecies(
+            species_code=str(item.species_id),
+            common_name=item.common_name,
+            scientific_name=item.scientific_name,
+            observed_at=item.latest_detection_at,
+        )
+        for item in detections
+    ]
+    counts = {str(item.species_id): item.detection_count for item in detections}
+    resolution = _resolve_external_species(
+        observations,
+        cache_path,
+        source="BirdWeather",
+        counts=counts,
+        now=now,
+        timeout_seconds=timeout_seconds,
+        persist_cache=persist_cache,
+    )
+    unresolved_codes = {item.species_code for item in resolution.unresolved}
+    return resolution.species, [
+        item for item in detections if str(item.species_id) in unresolved_codes
+    ]
+
+
+def _resolve_external_species(
+    observations: list[EbirdSpecies],
+    cache_path: Path,
+    *,
+    source: str,
+    counts: dict[str, int],
+    now: datetime | None,
+    timeout_seconds: float,
+    persist_cache: bool,
+) -> EbirdResolution:
+    if not persist_cache:
+        return _resolve_external_species_locked(
+            observations,
+            cache_path,
+            now=now,
+            timeout_seconds=timeout_seconds,
+            persist_cache=False,
+            source=source,
+            counts=counts,
+        )
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    with _taxonomy_crosswalk_lock(cache_path):
+        return _resolve_external_species_locked(
+            observations,
+            cache_path,
+            now=now,
+            timeout_seconds=timeout_seconds,
+            persist_cache=True,
+            source=source,
+            counts=counts,
+        )
+
+
 @contextmanager
-def _ebird_crosswalk_lock(cache_path: Path) -> Iterator[None]:
+def _taxonomy_crosswalk_lock(cache_path: Path) -> Iterator[None]:
     with cache_path.with_suffix(f"{cache_path.suffix}.lock").open("a+") as handle:
         fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
         try:
@@ -427,24 +598,24 @@ def _parse_cache_datetime(value: object) -> datetime | None:
     return parsed.astimezone(UTC)
 
 
-def _read_ebird_crosswalk(path: Path) -> dict[str, dict[str, object]]:
+def _read_taxonomy_crosswalk(path: Path) -> dict[str, dict[str, object]]:
     try:
         raw = json.loads(path.read_text())
     except FileNotFoundError:
         return {}
     except json.JSONDecodeError as exc:
-        raise DataSourceError(f"Invalid eBird taxonomy crosswalk: {path}") from exc
+        raise DataSourceError(f"Invalid taxonomy crosswalk: {path}") from exc
     if not isinstance(raw, dict) or raw.get("schema_version") != 1:
-        raise DataSourceError(f"Unsupported eBird taxonomy crosswalk: {path}")
+        raise DataSourceError(f"Unsupported taxonomy crosswalk: {path}")
     entries = raw.get("entries")
     if not isinstance(entries, dict) or any(
         not isinstance(key, str) or not isinstance(value, dict) for key, value in entries.items()
     ):
-        raise DataSourceError(f"Invalid eBird taxonomy crosswalk: {path}")
+        raise DataSourceError(f"Invalid taxonomy crosswalk: {path}")
     return {str(key): dict(value) for key, value in entries.items()}
 
 
-def _write_ebird_crosswalk(path: Path, entries: dict[str, dict[str, object]]) -> None:
+def _write_taxonomy_crosswalk(path: Path, entries: dict[str, dict[str, object]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with NamedTemporaryFile(
         "w",

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -458,6 +458,7 @@ def config_validate_command(args: argparse.Namespace) -> int:
             "discovery": {
                 "source": config.discovery.source.value,
                 "ebird_configured": config.discovery.ebird_api_key is not None,
+                "birdweather_configured": config.discovery.birdweather_token is not None,
                 "window": config.discovery.observation_window.value,
                 "radius_km": config.discovery.radius_km,
             },

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -94,11 +94,15 @@ def discover_command(args: argparse.Namespace) -> int:
     location = discovery.location
     print_result(
         {
-            "location": {
-                "zip_code": location.zip_code,
-                "place_name": location.place_name,
-                "state": location.state,
-            },
+            "location": (
+                {
+                    "zip_code": location.zip_code,
+                    "place_name": location.place_name,
+                    "state": location.state,
+                }
+                if location is not None
+                else None
+            ),
             "radius_km": config.discovery.radius_km,
             "window": config.discovery.observation_window.value,
             "source": config.discovery.source.value,
@@ -134,7 +138,7 @@ def refresh_command(args: argparse.Namespace) -> int:
         body="Observation refresh is succeeding again.",
     )
     providers = result.get("providers")
-    ebird_succeeded = False
+    successful_providers: set[str] = set()
     if isinstance(providers, list):
         for provider in providers:
             if not isinstance(provider, dict) or not isinstance(provider.get("name"), str):
@@ -148,8 +152,7 @@ def refresh_command(args: argparse.Namespace) -> int:
                     body=f"The {name} provider failed; another configured provider supplied data.",
                 )
             else:
-                if name == "ebird":
-                    ebird_succeeded = True
+                successful_providers.add(name)
                 safe_record_recovery(
                     config,
                     key=f"observation-provider-{name}",
@@ -157,20 +160,30 @@ def refresh_command(args: argparse.Namespace) -> int:
                     body=f"The {name} provider is succeeding again.",
                 )
     unresolved = result.get("unresolved_species")
-    if isinstance(unresolved, list) and unresolved:
-        safe_record_degradation(
-            config,
-            key="ebird-taxonomy",
-            title="Some eBird species are awaiting taxonomy matching",
-            body=f"{len(unresolved)} species were deferred without blocking bird discovery.",
-        )
-    elif ebird_succeeded:
-        safe_record_recovery(
-            config,
-            key="ebird-taxonomy",
-            title="eBird taxonomy matching recovered",
-            body="Deferred eBird taxonomy matches have cleared.",
-        )
+    unresolved_by_provider: dict[str, int] = {}
+    if isinstance(unresolved, list):
+        for item in unresolved:
+            if not isinstance(item, dict) or not isinstance(item.get("provider"), str):
+                continue
+            provider = item["provider"]
+            unresolved_by_provider[provider] = unresolved_by_provider.get(provider, 0) + 1
+    taxonomy_providers = {"ebird": "eBird", "birdweather": "BirdWeather"}
+    for provider, display_name in taxonomy_providers.items():
+        unresolved_count = unresolved_by_provider.get(provider, 0)
+        if unresolved_count:
+            safe_record_degradation(
+                config,
+                key=f"{provider}-taxonomy",
+                title=f"Some {display_name} species are awaiting taxonomy matching",
+                body=(f"{unresolved_count} species were deferred without blocking bird discovery."),
+            )
+        elif provider in successful_providers:
+            safe_record_recovery(
+                config,
+                key=f"{provider}-taxonomy",
+                title=f"{display_name} taxonomy matching recovered",
+                body=f"Deferred {display_name} taxonomy matches have cleared.",
+            )
     new_species = result.get("new_species")
     if isinstance(new_species, list) and new_species:
         names: list[str] = []

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -26,10 +26,16 @@ class DiscoverySource(StrEnum):
     INATURALIST = "inaturalist"
     EBIRD = "ebird"
     COMBINED = "combined"
+    BIRDWEATHER = "birdweather"
+    ALL = "all"
 
     @property
     def uses_ebird(self) -> bool:
-        return self in {DiscoverySource.EBIRD, DiscoverySource.COMBINED}
+        return self in {DiscoverySource.EBIRD, DiscoverySource.COMBINED, DiscoverySource.ALL}
+
+    @property
+    def uses_birdweather(self) -> bool:
+        return self in {DiscoverySource.BIRDWEATHER, DiscoverySource.ALL}
 
 
 def parse_discovery_source(value: str) -> DiscoverySource:
@@ -70,6 +76,8 @@ class DiscoveryConfig:
     source: DiscoverySource = DiscoverySource.INATURALIST
     ebird_api_key: str | None = field(default=None, repr=False)
     ebird_api_key_env: str | None = field(default=None, repr=False)
+    birdweather_token: str | None = field(default=None, repr=False)
+    birdweather_token_env: str | None = field(default=None, repr=False)
 
 
 @dataclass(frozen=True)
@@ -310,6 +318,38 @@ def _executable_path(value: str, base_dir: Path) -> Path:
     return Path(resolved) if resolved is not None else path
 
 
+def _private_value(
+    section: dict[str, object],
+    name: str,
+    *,
+    required: bool,
+    provider_name: str,
+) -> tuple[str | None, str | None]:
+    direct_value = section.get(name)
+    environment_name = section.get(f"{name}_env")
+    if direct_value is not None and (not isinstance(direct_value, str) or not direct_value.strip()):
+        raise ConfigurationError(f"{name} must be a non-empty string")
+    if environment_name is not None and (
+        not isinstance(environment_name, str) or not environment_name.strip()
+    ):
+        raise ConfigurationError(f"{name}_env must be a non-empty string")
+    if direct_value is not None and environment_name is not None:
+        raise ConfigurationError(f"Choose {name} or {name}_env, not both")
+
+    resolved = direct_value.strip() if isinstance(direct_value, str) else None
+    variable = environment_name.strip() if isinstance(environment_name, str) else None
+    if variable is not None:
+        environment_value = environ.get(variable)
+        resolved = environment_value.strip() if environment_value else None
+        if required and resolved is None:
+            raise ConfigurationError(
+                f"{provider_name} discovery requires environment variable {variable}"
+            )
+    if required and resolved is None:
+        raise ConfigurationError(f"{provider_name} discovery requires {name} or {name}_env")
+    return resolved, variable
+
+
 def load_config(path: Path) -> AppConfig:
     try:
         raw = tomllib.loads(path.read_text())
@@ -349,26 +389,18 @@ def load_config(path: Path) -> AppConfig:
     if species_limit <= 0:
         raise ConfigurationError("species_limit must be greater than zero")
 
-    ebird_api_key_value = discovery.get("ebird_api_key")
-    ebird_api_key_env_value = discovery.get("ebird_api_key_env")
-    if ebird_api_key_value is not None and (
-        not isinstance(ebird_api_key_value, str) or not ebird_api_key_value.strip()
-    ):
-        raise ConfigurationError("ebird_api_key must be a non-empty string")
-    if ebird_api_key_env_value is not None and (
-        not isinstance(ebird_api_key_env_value, str) or not ebird_api_key_env_value.strip()
-    ):
-        raise ConfigurationError("ebird_api_key_env must be a non-empty string")
-    if ebird_api_key_value is not None and ebird_api_key_env_value is not None:
-        raise ConfigurationError("Choose ebird_api_key or ebird_api_key_env, not both")
-    ebird_api_key = ebird_api_key_value.strip() if isinstance(ebird_api_key_value, str) else None
-    if ebird_api_key_env_value is not None:
-        environment_value = environ.get(ebird_api_key_env_value)
-        ebird_api_key = environment_value.strip() if environment_value else None
-        if ebird_api_key is None and discovery_source.uses_ebird:
-            raise ConfigurationError(
-                f"eBird discovery requires environment variable {ebird_api_key_env_value}"
-            )
+    ebird_api_key, ebird_api_key_env = _private_value(
+        discovery,
+        "ebird_api_key",
+        required=discovery_source.uses_ebird,
+        provider_name="eBird",
+    )
+    birdweather_token, birdweather_token_env = _private_value(
+        discovery,
+        "birdweather_token",
+        required=discovery_source.uses_birdweather,
+        provider_name="BirdWeather",
+    )
     if discovery_source.uses_ebird:
         if window in {ObservationWindow.LAST_YEAR, ObservationWindow.ALL_TIME}:
             raise ConfigurationError("eBird discovery supports observation windows up to 30 days")
@@ -376,8 +408,8 @@ def load_config(path: Path) -> AppConfig:
             raise ConfigurationError("eBird discovery radius_km must not exceed 50")
         if species_limit > 10_000:
             raise ConfigurationError("eBird species_limit must not exceed 10000")
-        if ebird_api_key is None:
-            raise ConfigurationError("eBird discovery requires ebird_api_key or ebird_api_key_env")
+    if discovery_source.uses_birdweather and species_limit > 100:
+        raise ConfigurationError("BirdWeather species_limit must not exceed 100")
 
     controller_url = _string(display_node, "controller_url").rstrip("/")
     if not controller_url.startswith(("http://", "https://")):
@@ -447,9 +479,9 @@ def load_config(path: Path) -> AppConfig:
             species_limit=species_limit,
             observation_window=window,
             ebird_api_key=ebird_api_key,
-            ebird_api_key_env=(
-                ebird_api_key_env_value if isinstance(ebird_api_key_env_value, str) else None
-            ),
+            ebird_api_key_env=ebird_api_key_env,
+            birdweather_token=birdweather_token,
+            birdweather_token_env=birdweather_token_env,
         ),
         controller=ControllerConfig(
             workspace_dir=_path(_string(controller, "workspace_dir"), base_dir),

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -514,8 +514,9 @@ def run_refresh_cycle(config: AppConfig) -> dict[str, object]:
         if _snapshot_path(config).exists():
             previous = _read_discovery_snapshot(config)
             previous_taxa = {species.taxon_id for species in previous.species}
-            place_name = previous.place_name
-            state = previous.state
+            if config.discovery.source is not DiscoverySource.BIRDWEATHER:
+                place_name = previous.place_name
+                state = previous.state
         discovery = discover_species(config)
         location = discovery.location
         if location is not None:

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -16,11 +16,14 @@ from typing import cast
 
 from .birds import (
     BirdSpecies,
+    BirdWeatherSpecies,
     EbirdSpecies,
     ObservationWindow,
+    fetch_birdweather_species,
     fetch_ebird_observations,
     fetch_inaturalist_birds,
     fetch_taxon_context,
+    resolve_birdweather_species,
     resolve_ebird_species,
 )
 from .catalog import (
@@ -88,7 +91,7 @@ class DiscoveryResult:
     location: ZipLocation
     species: list[BirdSpecies]
     providers: list[ProviderStatus]
-    unresolved: list[EbirdSpecies]
+    unresolved: list[EbirdSpecies | BirdWeatherSpecies]
 
 
 @contextmanager
@@ -140,12 +143,18 @@ def discover_species(
             raise ValueError("eBird discovery radius_km must be between 1 and 50")
         if not 0 < selected_limit <= 10_000:
             raise ValueError("eBird species_limit must be between 1 and 10000")
+    if selected_source.uses_birdweather and not 0 < selected_limit <= 100:
+        raise ValueError("BirdWeather species_limit must be between 1 and 100")
     location = lookup_us_zip(config.discovery.zip_code)
     providers: list[ProviderStatus] = []
     provider_species: list[list[BirdSpecies]] = []
-    unresolved: list[EbirdSpecies] = []
+    unresolved: list[EbirdSpecies | BirdWeatherSpecies] = []
 
-    if selected_source in {DiscoverySource.INATURALIST, DiscoverySource.COMBINED}:
+    if selected_source in {
+        DiscoverySource.INATURALIST,
+        DiscoverySource.COMBINED,
+        DiscoverySource.ALL,
+    }:
         try:
             inaturalist = fetch_inaturalist_birds(
                 latitude=location.latitude,
@@ -160,7 +169,7 @@ def discover_species(
             provider_species.append(inaturalist)
             providers.append(ProviderStatus("inaturalist", "ok", len(inaturalist)))
 
-    if selected_source in {DiscoverySource.EBIRD, DiscoverySource.COMBINED}:
+    if selected_source in {DiscoverySource.EBIRD, DiscoverySource.COMBINED, DiscoverySource.ALL}:
         try:
             api_key = config.discovery.ebird_api_key
             if api_key is None and config.discovery.ebird_api_key_env is not None:
@@ -206,13 +215,56 @@ def discover_species(
                     )
                 )
 
+    if selected_source in {DiscoverySource.BIRDWEATHER, DiscoverySource.ALL}:
+        try:
+            token = config.discovery.birdweather_token
+            if token is None and config.discovery.birdweather_token_env is not None:
+                environment_value = os.environ.get(config.discovery.birdweather_token_env)
+                token = environment_value.strip() if environment_value else None
+            if token is None:
+                raise DataSourceError("BirdWeather station token is not configured")
+            detections = fetch_birdweather_species(
+                token=token,
+                limit=selected_limit,
+                window=selected_window,
+            )
+            resolved, birdweather_unresolved = resolve_birdweather_species(
+                detections,
+                config.controller.state_dir / "birdweather-taxonomy-crosswalk.json",
+                persist_cache=persist_taxonomy_cache,
+            )
+        except (DataSourceError, ValueError) as exc:
+            providers.append(ProviderStatus("birdweather", "error", 0, error=str(exc)))
+        else:
+            unresolved.extend(birdweather_unresolved)
+            if detections and not resolved:
+                providers.append(
+                    ProviderStatus(
+                        "birdweather",
+                        "error",
+                        0,
+                        unresolved_count=len(birdweather_unresolved),
+                        error="No BirdWeather detections had an exact iNaturalist species match",
+                    )
+                )
+            else:
+                provider_species.append(resolved)
+                providers.append(
+                    ProviderStatus(
+                        "birdweather",
+                        "ok",
+                        len(resolved),
+                        unresolved_count=len(birdweather_unresolved),
+                    )
+                )
+
     if not provider_species:
         failures = "; ".join(
             f"{provider.name}: {provider.error}" for provider in providers if provider.error
         )
         raise DataSourceError(f"All configured observation providers failed: {failures}")
     species = _merge_provider_species(provider_species)
-    if selected_source is DiscoverySource.COMBINED:
+    if selected_source in {DiscoverySource.COMBINED, DiscoverySource.ALL}:
         species.sort(key=lambda item: (item.common_name.casefold(), item.taxon_id))
     return DiscoveryResult(location, species, providers, unresolved)
 
@@ -259,6 +311,23 @@ def _species_payload(species: BirdSpecies) -> dict[str, object]:
         "observation_count": species.observation_count,
         "source": species.source,
         "sources": list(species.sources),
+    }
+
+
+def _unresolved_species_payload(
+    species: EbirdSpecies | BirdWeatherSpecies,
+) -> dict[str, object]:
+    if isinstance(species, EbirdSpecies):
+        provider = "ebird"
+        provider_species_id = species.species_code
+    else:
+        provider = "birdweather"
+        provider_species_id = str(species.species_id)
+    return {
+        "provider": provider,
+        "species_code": provider_species_id,
+        "common_name": species.common_name,
+        "scientific_name": species.scientific_name,
     }
 
 
@@ -449,12 +518,7 @@ def run_refresh_cycle(config: AppConfig) -> dict[str, object]:
         "source": config.discovery.source.value,
         "providers": [provider.as_dict() for provider in discovery.providers],
         "unresolved_species": [
-            {
-                "species_code": species.species_code,
-                "common_name": species.common_name,
-                "scientific_name": species.scientific_name,
-            }
-            for species in discovery.unresolved
+            _unresolved_species_payload(species) for species in discovery.unresolved
         ],
         "species_count": len(species_list),
         "new_species": [_species_payload(species) for species in new_species],

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -88,7 +88,7 @@ class ProviderStatus:
 
 @dataclass(frozen=True)
 class DiscoveryResult:
-    location: ZipLocation
+    location: ZipLocation | None
     species: list[BirdSpecies]
     providers: list[ProviderStatus]
     unresolved: list[EbirdSpecies | BirdWeatherSpecies]
@@ -145,12 +145,30 @@ def discover_species(
             raise ValueError("eBird species_limit must be between 1 and 10000")
     if selected_source.uses_birdweather and not 0 < selected_limit <= 100:
         raise ValueError("BirdWeather species_limit must be between 1 and 100")
-    location = lookup_us_zip(config.discovery.zip_code)
     providers: list[ProviderStatus] = []
     provider_species: list[list[BirdSpecies]] = []
     unresolved: list[EbirdSpecies | BirdWeatherSpecies] = []
+    location: ZipLocation | None = None
 
+    location_provider_names: list[str] = []
     if selected_source in {
+        DiscoverySource.INATURALIST,
+        DiscoverySource.COMBINED,
+        DiscoverySource.ALL,
+    }:
+        location_provider_names.append("inaturalist")
+    if selected_source in {DiscoverySource.EBIRD, DiscoverySource.COMBINED, DiscoverySource.ALL}:
+        location_provider_names.append("ebird")
+    if location_provider_names:
+        try:
+            location = lookup_us_zip(config.discovery.zip_code)
+        except DataSourceError as exc:
+            providers.extend(
+                ProviderStatus(name, "error", 0, error=f"ZIP lookup failed: {exc}")
+                for name in location_provider_names
+            )
+
+    if location is not None and selected_source in {
         DiscoverySource.INATURALIST,
         DiscoverySource.COMBINED,
         DiscoverySource.ALL,
@@ -169,7 +187,11 @@ def discover_species(
             provider_species.append(inaturalist)
             providers.append(ProviderStatus("inaturalist", "ok", len(inaturalist)))
 
-    if selected_source in {DiscoverySource.EBIRD, DiscoverySource.COMBINED, DiscoverySource.ALL}:
+    if location is not None and selected_source in {
+        DiscoverySource.EBIRD,
+        DiscoverySource.COMBINED,
+        DiscoverySource.ALL,
+    }:
         try:
             api_key = config.discovery.ebird_api_key
             if api_key is None and config.discovery.ebird_api_key_env is not None:
@@ -487,12 +509,18 @@ def _write_active_catalog(config: AppConfig, species_list: list[BirdSpecies]) ->
 def run_refresh_cycle(config: AppConfig) -> dict[str, object]:
     with exclusive_refresh_lock(config.controller.state_dir):
         previous_taxa: set[int] = set()
+        place_name = ""
+        state = ""
         if _snapshot_path(config).exists():
-            previous_taxa = {
-                species.taxon_id for species in _read_discovery_snapshot(config).species
-            }
+            previous = _read_discovery_snapshot(config)
+            previous_taxa = {species.taxon_id for species in previous.species}
+            place_name = previous.place_name
+            state = previous.state
         discovery = discover_species(config)
         location = discovery.location
+        if location is not None:
+            place_name = location.place_name
+            state = location.state
         species_list = discovery.species
         new_species = [species for species in species_list if species.taxon_id not in previous_taxa]
         with catalog_state_lock(config.controller.state_dir):
@@ -502,8 +530,8 @@ def run_refresh_cycle(config: AppConfig) -> dict[str, object]:
                 {
                     "schema_version": 2,
                     "refreshed_at": refreshed_at.isoformat(),
-                    "place_name": location.place_name,
-                    "state": location.state,
+                    "place_name": place_name,
+                    "state": state,
                     "providers": [provider.as_dict() for provider in discovery.providers],
                     "species": [_species_payload(species) for species in species_list],
                 },
@@ -511,8 +539,8 @@ def run_refresh_cycle(config: AppConfig) -> dict[str, object]:
             active_count = _write_active_catalog(config, species_list)
     return {
         "refreshed_at": refreshed_at.isoformat(),
-        "place_name": location.place_name,
-        "state": location.state,
+        "place_name": place_name,
+        "state": state,
         "window": config.discovery.observation_window.value,
         "radius_km": config.discovery.radius_km,
         "source": config.discovery.source.value,

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -514,9 +514,6 @@ def run_refresh_cycle(config: AppConfig) -> dict[str, object]:
         if _snapshot_path(config).exists():
             previous = _read_discovery_snapshot(config)
             previous_taxa = {species.taxon_id for species in previous.species}
-            if config.discovery.source is not DiscoverySource.BIRDWEATHER:
-                place_name = previous.place_name
-                state = previous.state
         discovery = discover_species(config)
         location = discovery.location
         if location is not None:

--- a/src/inky_bird_frame/http.py
+++ b/src/inky_bird_frame/http.py
@@ -18,25 +18,27 @@ def get_json(
     timeout_seconds: float = 10.0,
     *,
     headers: Mapping[str, str] | None = None,
+    error_label: str | None = None,
 ) -> object:
     request_headers = {"User-Agent": "inky-bird-frame/0.1"}
     if headers is not None:
         request_headers.update(headers)
     request = Request(url, headers=request_headers)
+    display_url = error_label or url
     try:
         with urlopen(request, timeout=timeout_seconds) as response:
             body = response.read()
     except HTTPError as exc:
-        raise DataSourceError(f"HTTP {exc.code} from {url}") from exc
+        raise DataSourceError(f"HTTP {exc.code} from {display_url}") from exc
     except URLError as exc:
-        raise DataSourceError(f"Could not reach {url}: {exc.reason}") from exc
+        raise DataSourceError(f"Could not reach {display_url}: {exc.reason}") from exc
     except TimeoutError as exc:
-        raise DataSourceError(f"Timed out reading {url}") from exc
+        raise DataSourceError(f"Timed out reading {display_url}") from exc
 
     try:
         return cast(object, json.loads(body))
     except json.JSONDecodeError as exc:
-        raise DataSourceError(f"Invalid JSON from {url}") from exc
+        raise DataSourceError(f"Invalid JSON from {display_url}") from exc
 
 
 def get_bytes(url: str, timeout_seconds: float = 30.0) -> bytes:

--- a/src/inky_bird_frame/installation.py
+++ b/src/inky_bird_frame/installation.py
@@ -623,7 +623,22 @@ def setup(
     venv: Path | None = None,
 ) -> dict[str, object]:
     config_path = config_path.expanduser().resolve()
-    load_config(config_path)
+    config = load_config(config_path)
+    if role is InstallationRole.CONTROLLER:
+        environment_credentials: list[str] = []
+        if config.discovery.source.uses_ebird and config.discovery.ebird_api_key_env is not None:
+            environment_credentials.append("ebird_api_key_env")
+        if (
+            config.discovery.source.uses_birdweather
+            and config.discovery.birdweather_token_env is not None
+        ):
+            environment_credentials.append("birdweather_token_env")
+        if environment_credentials:
+            names = ", ".join(environment_credentials)
+            raise InstallationError(
+                f"Managed controller services cannot use {names}; store the corresponding "
+                "credential directly in the private mode-0600 configuration file"
+            )
     script = _setup_script(role, source_dir)
     if not script.is_file():
         raise InstallationError(f"Installer is missing: {script}")

--- a/tests/test_birds.py
+++ b/tests/test_birds.py
@@ -9,18 +9,22 @@ from urllib.parse import parse_qs, urlsplit
 
 from inky_bird_frame.birds import (
     BirdSpecies,
+    BirdWeatherSpecies,
     EbirdSpecies,
     ObservationWindow,
     date_range_for_window,
+    fetch_birdweather_species,
     fetch_ebird_observations,
     fetch_inaturalist_birds,
     fetch_taxon_context,
     parse_birdnet_taxon,
+    parse_birdweather_species,
     parse_ebird_observations,
     parse_inaturalist_species_counts,
     parse_inaturalist_taxon,
     parse_inaturalist_taxon_match,
     parse_observation_window,
+    resolve_birdweather_species,
     resolve_ebird_species,
 )
 from inky_bird_frame.errors import DataSourceError, TaxonomyMatchError
@@ -316,6 +320,94 @@ class EbirdTests(unittest.TestCase):
 
         self.assertEqual(result.species, [species])
         self.assertFalse(state_exists)
+
+
+class BirdWeatherTests(unittest.TestCase):
+    def test_parse_species_keeps_complete_unique_avian_detections(self) -> None:
+        payload = {
+            "success": True,
+            "species": [
+                {
+                    "id": 42,
+                    "commonName": "Eastern Bluebird",
+                    "scientificName": "Sialia sialis",
+                    "classification": "avian",
+                    "detections": {"total": 7},
+                    "latestDetectionAt": "2026-07-12T08:15:00-04:00",
+                },
+                {
+                    "id": 42,
+                    "commonName": "Eastern Bluebird",
+                    "scientificName": "Sialia sialis",
+                    "classification": "avian",
+                    "detections": {"total": 6},
+                    "latestDetectionAt": "2026-07-11T08:15:00-04:00",
+                },
+                {
+                    "id": 9,
+                    "commonName": "Little Brown Bat",
+                    "scientificName": "Myotis lucifugus",
+                    "classification": "bat",
+                    "detections": {"total": 2},
+                    "latestDetectionAt": "2026-07-12T01:00:00-04:00",
+                },
+            ],
+        }
+
+        species = parse_birdweather_species(payload)
+
+        self.assertEqual(
+            species,
+            [
+                BirdWeatherSpecies(
+                    42,
+                    "Eastern Bluebird",
+                    "Sialia sialis",
+                    7,
+                    "2026-07-12T08:15:00-04:00",
+                )
+            ],
+        )
+
+    def test_parse_species_rejects_unsuccessful_response(self) -> None:
+        with self.assertRaisesRegex(DataSourceError, "not successful"):
+            parse_birdweather_species({"success": False})
+
+    @patch("inky_bird_frame.birds.get_json", return_value={"success": True, "species": []})
+    def test_fetch_species_bounds_window_and_redacts_token(self, get_json: MagicMock) -> None:
+        fetch_birdweather_species(
+            token="station/token",
+            limit=50,
+            window=ObservationWindow.LAST_YEAR,
+            today=date(2026, 7, 12),
+        )
+
+        url = get_json.call_args.args[0]
+        params = parse_qs(urlsplit(url).query)
+        self.assertIn("station%2Ftoken", url)
+        self.assertEqual(params["from"], ["2025-07-12"])
+        self.assertEqual(params["to"], ["2026-07-12"])
+        self.assertEqual(params["classification"], ["avian"])
+        self.assertEqual(get_json.call_args.kwargs["error_label"], "BirdWeather API")
+
+    def test_resolution_preserves_detection_count_and_source(self) -> None:
+        detection = BirdWeatherSpecies(
+            42,
+            "Eastern Bluebird",
+            "Sialia sialis",
+            7,
+            "2026-07-12T08:15:00-04:00",
+        )
+        match = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 1, "eBird")
+        with TemporaryDirectory() as temporary:
+            cache = Path(temporary) / "crosswalk.json"
+            with patch("inky_bird_frame.birds.fetch_inaturalist_taxon_match", return_value=match):
+                species, unresolved = resolve_birdweather_species([detection], cache)
+
+        self.assertEqual(unresolved, [])
+        self.assertEqual(species[0].taxon_id, 12942)
+        self.assertEqual(species[0].observation_count, 7)
+        self.assertEqual(species[0].sources, ("BirdWeather",))
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -263,6 +263,40 @@ class CliTests(unittest.TestCase):
         recovered_keys = [call.kwargs["key"] for call in recover.call_args_list]
         self.assertNotIn("ebird-taxonomy", recovered_keys)
 
+    def test_refresh_tracks_taxonomy_alerts_by_provider(self) -> None:
+        config = SimpleNamespace(discovery=SimpleNamespace(source=DiscoverySource.ALL))
+        result = {
+            "providers": [
+                {"name": "inaturalist", "status": "ok"},
+                {"name": "ebird", "status": "ok"},
+                {"name": "birdweather", "status": "ok"},
+            ],
+            "unresolved_species": [
+                {
+                    "provider": "birdweather",
+                    "species_code": "42",
+                    "common_name": "Split Bird",
+                    "scientific_name": "Avis split",
+                }
+            ],
+            "new_species": [],
+        }
+        with (
+            patch("inky_bird_frame.cli._config", return_value=config),
+            patch("inky_bird_frame.cli.run_refresh_cycle", return_value=result),
+            patch("inky_bird_frame.cli.safe_record_degradation") as degradation,
+            patch("inky_bird_frame.cli.safe_record_recovery") as recovery,
+            redirect_stdout(io.StringIO()),
+        ):
+            refresh_command(Namespace())
+
+        degraded_keys = [call.kwargs["key"] for call in degradation.call_args_list]
+        recovered_keys = [call.kwargs["key"] for call in recovery.call_args_list]
+        self.assertIn("birdweather-taxonomy", degraded_keys)
+        self.assertNotIn("ebird-taxonomy", degraded_keys)
+        self.assertIn("ebird-taxonomy", recovered_keys)
+        self.assertNotIn("birdweather-taxonomy", recovered_keys)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -145,6 +145,55 @@ class ConfigTests(unittest.TestCase):
             with self.assertRaisesRegex(ConfigurationError, "up to 30 days"):
                 load_config(path)
 
+    def test_birdweather_source_requires_a_station_token(self) -> None:
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(
+                CONFIG.replace("[discovery]\n", '[discovery]\nsource = "birdweather"\n')
+            )
+
+            with self.assertRaisesRegex(ConfigurationError, "requires birdweather_token"):
+                load_config(path)
+
+    def test_birdweather_token_can_come_from_environment(self) -> None:
+        configured = CONFIG.replace(
+            "[discovery]\n",
+            '[discovery]\nsource = "birdweather"\n'
+            'birdweather_token_env = "TEST_BIRDWEATHER_TOKEN"\n',
+        )
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(configured)
+            with patch.dict("os.environ", {"TEST_BIRDWEATHER_TOKEN": "secret"}):
+                config = load_config(path)
+
+        self.assertIs(config.discovery.source, DiscoverySource.BIRDWEATHER)
+        self.assertEqual(config.discovery.birdweather_token, "secret")
+
+    def test_all_source_requires_both_provider_credentials(self) -> None:
+        configured = CONFIG.replace(
+            "[discovery]\n",
+            '[discovery]\nsource = "all"\nebird_api_key = "ebird-secret"\n',
+        )
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(configured)
+
+            with self.assertRaisesRegex(ConfigurationError, "requires birdweather_token"):
+                load_config(path)
+
+    def test_birdweather_rejects_species_limit_over_api_maximum(self) -> None:
+        configured = CONFIG.replace(
+            "[discovery]\n",
+            '[discovery]\nsource = "birdweather"\nbirdweather_token = "secret"\n',
+        ).replace("species_limit = 20", "species_limit = 101")
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(configured)
+
+            with self.assertRaisesRegex(ConfigurationError, "must not exceed 100"):
+                load_config(path)
+
     def test_rejects_invalid_zip(self) -> None:
         with TemporaryDirectory() as temporary:
             path = Path(temporary) / "config.toml"

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -896,6 +896,55 @@ class DiscoveryProviderTests(unittest.TestCase):
         self.assertEqual(snapshot["place_name"], "")
         self.assertEqual(snapshot["state"], "")
 
+    def test_all_mode_station_fallback_clears_previous_location_metadata(self) -> None:
+        species = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 7, "BirdWeather")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(
+                CONFIG.replace(
+                    "[discovery]\n",
+                    '[discovery]\nsource = "all"\n'
+                    'ebird_api_key = "ebird-secret"\n'
+                    'birdweather_token = "station-secret"\n',
+                )
+            )
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            (config.controller.state_dir / "discovery.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "refreshed_at": "2026-07-12T08:00:00+00:00",
+                        "place_name": "Old Location",
+                        "state": "XY",
+                        "providers": [],
+                        "species": [],
+                    }
+                )
+            )
+            discovery = DiscoveryResult(
+                location=None,
+                species=[species],
+                providers=[
+                    ProviderStatus("inaturalist", "error", 0),
+                    ProviderStatus("ebird", "error", 0),
+                    ProviderStatus("birdweather", "ok", 1),
+                ],
+                unresolved=[],
+            )
+            with (
+                patch("inky_bird_frame.controller.discover_species", return_value=discovery),
+                patch("inky_bird_frame.controller._write_active_catalog", return_value=0),
+            ):
+                result = run_refresh_cycle(config)
+
+            snapshot = json.loads((config.controller.state_dir / "discovery.json").read_text())
+
+        self.assertEqual(result["place_name"], "")
+        self.assertEqual(result["state"], "")
+        self.assertEqual(snapshot["place_name"], "")
+        self.assertEqual(snapshot["state"], "")
+
     def test_birdweather_source_uses_station_detections(self) -> None:
         detection = BirdWeatherSpecies(
             42,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -8,7 +8,13 @@ from tempfile import TemporaryDirectory
 from typing import cast
 from unittest.mock import patch
 
-from inky_bird_frame.birds import BirdSpecies, EbirdResolution, EbirdSpecies, ObservationWindow
+from inky_bird_frame.birds import (
+    BirdSpecies,
+    BirdWeatherSpecies,
+    EbirdResolution,
+    EbirdSpecies,
+    ObservationWindow,
+)
 from inky_bird_frame.catalog import CatalogEntry, candidate_directory, write_candidate_manifest
 from inky_bird_frame.codex_runner import CodexRunner
 from inky_bird_frame.config import DiscoverySource, load_config
@@ -847,6 +853,87 @@ class ControllerTests(unittest.TestCase):
 
 
 class DiscoveryProviderTests(unittest.TestCase):
+    def test_birdweather_source_uses_station_detections(self) -> None:
+        detection = BirdWeatherSpecies(
+            42,
+            "Eastern Bluebird",
+            "Sialia sialis",
+            7,
+            "2026-07-12T08:15:00-04:00",
+        )
+        resolved = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 7, "BirdWeather")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(
+                CONFIG.replace(
+                    "[discovery]\n",
+                    '[discovery]\nsource = "birdweather"\nbirdweather_token = "station-secret"\n',
+                )
+            )
+            config = load_config(config_path)
+            with (
+                patch(
+                    "inky_bird_frame.controller.lookup_us_zip",
+                    return_value=ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0),
+                ),
+                patch(
+                    "inky_bird_frame.controller.fetch_birdweather_species",
+                    return_value=[detection],
+                ) as fetch,
+                patch(
+                    "inky_bird_frame.controller.resolve_birdweather_species",
+                    return_value=([resolved], []),
+                ),
+            ):
+                result = discover_species(config)
+
+        self.assertEqual(result.species, [resolved])
+        self.assertEqual(result.providers, [ProviderStatus("birdweather", "ok", 1)])
+        self.assertEqual(fetch.call_args.kwargs["token"], "station-secret")
+
+    def test_all_mode_continues_when_birdweather_fails(self) -> None:
+        inaturalist = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 9, "iNaturalist")
+        ebird = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 1, "eBird")
+        observation = EbirdSpecies("easblu", "Eastern Bluebird", "Sialia sialis", "2026-07-12")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(
+                CONFIG.replace(
+                    "[discovery]\n",
+                    '[discovery]\nsource = "all"\n'
+                    'ebird_api_key = "ebird-secret"\n'
+                    'birdweather_token = "station-secret"\n',
+                )
+            )
+            config = load_config(config_path)
+            with (
+                patch(
+                    "inky_bird_frame.controller.lookup_us_zip",
+                    return_value=ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0),
+                ),
+                patch(
+                    "inky_bird_frame.controller.fetch_inaturalist_birds",
+                    return_value=[inaturalist],
+                ),
+                patch(
+                    "inky_bird_frame.controller.fetch_ebird_observations",
+                    return_value=[observation],
+                ),
+                patch(
+                    "inky_bird_frame.controller.resolve_ebird_species",
+                    return_value=EbirdResolution([ebird], []),
+                ),
+                patch(
+                    "inky_bird_frame.controller.fetch_birdweather_species",
+                    side_effect=DataSourceError("BirdWeather unavailable"),
+                ),
+            ):
+                result = discover_species(config)
+
+        self.assertEqual(len(result.species), 1)
+        self.assertEqual(result.species[0].sources, ("iNaturalist", "eBird"))
+        self.assertEqual(result.providers[2].status, "error")
+
     def test_ebird_override_resolves_environment_key_at_execution_time(self) -> None:
         observation = EbirdSpecies("easblu", "Eastern Bluebird", "Sialia sialis", "2026-07-12")
         resolved = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 1, "eBird")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -872,10 +872,7 @@ class DiscoveryProviderTests(unittest.TestCase):
             )
             config = load_config(config_path)
             with (
-                patch(
-                    "inky_bird_frame.controller.lookup_us_zip",
-                    return_value=ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0),
-                ),
+                patch("inky_bird_frame.controller.lookup_us_zip") as lookup,
                 patch(
                     "inky_bird_frame.controller.fetch_birdweather_species",
                     return_value=[detection],
@@ -888,8 +885,57 @@ class DiscoveryProviderTests(unittest.TestCase):
                 result = discover_species(config)
 
         self.assertEqual(result.species, [resolved])
+        self.assertIsNone(result.location)
         self.assertEqual(result.providers, [ProviderStatus("birdweather", "ok", 1)])
         self.assertEqual(fetch.call_args.kwargs["token"], "station-secret")
+        lookup.assert_not_called()
+
+    def test_all_mode_uses_birdweather_when_zip_lookup_fails(self) -> None:
+        detection = BirdWeatherSpecies(
+            42,
+            "Eastern Bluebird",
+            "Sialia sialis",
+            7,
+            "2026-07-12T08:15:00-04:00",
+        )
+        resolved = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 7, "BirdWeather")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(
+                CONFIG.replace(
+                    "[discovery]\n",
+                    '[discovery]\nsource = "all"\n'
+                    'ebird_api_key = "ebird-secret"\n'
+                    'birdweather_token = "station-secret"\n',
+                )
+            )
+            config = load_config(config_path)
+            with (
+                patch(
+                    "inky_bird_frame.controller.lookup_us_zip",
+                    side_effect=DataSourceError("ZIP service unavailable"),
+                ),
+                patch("inky_bird_frame.controller.fetch_inaturalist_birds") as inaturalist,
+                patch("inky_bird_frame.controller.fetch_ebird_observations") as ebird,
+                patch(
+                    "inky_bird_frame.controller.fetch_birdweather_species",
+                    return_value=[detection],
+                ),
+                patch(
+                    "inky_bird_frame.controller.resolve_birdweather_species",
+                    return_value=([resolved], []),
+                ),
+            ):
+                result = discover_species(config)
+
+        self.assertEqual(result.species, [resolved])
+        self.assertIsNone(result.location)
+        self.assertEqual(
+            [(provider.name, provider.status) for provider in result.providers],
+            [("inaturalist", "error"), ("ebird", "error"), ("birdweather", "ok")],
+        )
+        inaturalist.assert_not_called()
+        ebird.assert_not_called()
 
     def test_all_mode_continues_when_birdweather_fails(self) -> None:
         inaturalist = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 9, "iNaturalist")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -853,6 +853,49 @@ class ControllerTests(unittest.TestCase):
 
 
 class DiscoveryProviderTests(unittest.TestCase):
+    def test_birdweather_refresh_clears_previous_location_metadata(self) -> None:
+        species = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 7, "BirdWeather")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(
+                CONFIG.replace(
+                    "[discovery]\n",
+                    '[discovery]\nsource = "birdweather"\nbirdweather_token = "station-secret"\n',
+                )
+            )
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            (config.controller.state_dir / "discovery.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "refreshed_at": "2026-07-12T08:00:00+00:00",
+                        "place_name": "Old Location",
+                        "state": "XY",
+                        "providers": [],
+                        "species": [],
+                    }
+                )
+            )
+            discovery = DiscoveryResult(
+                location=None,
+                species=[species],
+                providers=[ProviderStatus("birdweather", "ok", 1)],
+                unresolved=[],
+            )
+            with (
+                patch("inky_bird_frame.controller.discover_species", return_value=discovery),
+                patch("inky_bird_frame.controller._write_active_catalog", return_value=0),
+            ):
+                result = run_refresh_cycle(config)
+
+            snapshot = json.loads((config.controller.state_dir / "discovery.json").read_text())
+
+        self.assertEqual(result["place_name"], "")
+        self.assertEqual(result["state"], "")
+        self.assertEqual(snapshot["place_name"], "")
+        self.assertEqual(snapshot["state"], "")
+
     def test_birdweather_source_uses_station_detections(self) -> None:
         detection = BirdWeatherSpecies(
             42,

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import unittest
+from email.message import Message
+from unittest.mock import patch
+from urllib.error import HTTPError
+
+from inky_bird_frame.errors import DataSourceError
+from inky_bird_frame.http import get_json
+
+
+class JsonHttpTests(unittest.TestCase):
+    def test_error_label_redacts_sensitive_url(self) -> None:
+        url = "https://example.test/stations/private-token/species"
+        error = HTTPError(url, 401, "Unauthorized", Message(), None)
+
+        with (
+            patch("inky_bird_frame.http.urlopen", side_effect=error),
+            self.assertRaises(DataSourceError) as raised,
+        ):
+            get_json(url, error_label="BirdWeather API")
+
+        self.assertEqual(str(raised.exception), "HTTP 401 from BirdWeather API")
+        self.assertNotIn("private-token", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -173,6 +173,32 @@ display_startup_delay_seconds = 30
         self.assertIn("--yes", str(result["confirmation"]))
         run.assert_not_called()
 
+    def test_managed_controller_rejects_environment_provider_credentials(self) -> None:
+        cases = (
+            (
+                'source = "ebird"\nebird_api_key_env = "TEST_PROVIDER_TOKEN"\n',
+                "ebird_api_key_env",
+            ),
+            (
+                'source = "birdweather"\nbirdweather_token_env = "TEST_PROVIDER_TOKEN"\n',
+                "birdweather_token_env",
+            ),
+        )
+        for configuration, expected in cases:
+            with self.subTest(expected=expected), TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                codex = root / "codex"
+                codex.touch(mode=0o700)
+                config = write_config(root, codex)
+                config.write_text(
+                    config.read_text().replace("[discovery]\n", f"[discovery]\n{configuration}")
+                )
+                with (
+                    patch.dict("os.environ", {"TEST_PROVIDER_TOKEN": "secret"}),
+                    self.assertRaisesRegex(InstallationError, expected),
+                ):
+                    setup(InstallationRole.CONTROLLER, config, apply=False)
+
     def test_setup_uses_explicit_source_checkout(self) -> None:
         with TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## Summary

- add authenticated BirdWeather station discovery as an optional metadata-only provider
- preserve existing `combined` behavior and add explicit `birdweather` and `all` source modes
- normalize acoustic detections through exact iNaturalist taxonomy matching and existing catalog generation
- document supported behavior, recording boundaries, classifier limitations, credentials, and API constraints
- redact station tokens from HTTP failures and reject environment-only provider credentials for managed services

## User-visible behavior

Users can select `source = "birdweather"` to display species detected by one BirdWeather station, or `source = "all"` to merge iNaturalist, eBird, and BirdWeather with provider-isolated failure handling. Inky Bird Frame consumes species metadata only. It does not install or manage detectors, microphones, recordings, audio, confidence thresholds, or detection review.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q`
- `uv run inky-bird-frame catalog validate --catalog catalog`
- `uv build`
- `git diff --check`

All passed locally. The test suite has one existing Apprise `imghdr` deprecation warning.

## Security and compatibility

- `combined` remains iNaturalist plus eBird, so upgrades do not silently contact BirdWeather.
- BirdWeather tokens are accepted only in private configuration or explicit environment variables for manual commands.
- HTTP errors use a redacted service label rather than the token-bearing URL.
- No station, location, observation, audio, or credential data enters reusable plates or the public catalog.
- No dependencies were added.
