### PR TITLE
Support explicit discovery provider lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,13 @@ window.
 
 ```mermaid
 flowchart LR
-    A["Local observations"] --> B["Species queue"]
-    B --> C["Facts + licensed references"]
-    C --> D["Field-journal plate"]
-    D --> E{"Independent AI review"}
-    E -->|pass| F["Approved local catalog"]
-    E -->|revise| D
-    F --> G["Active local rotation"]
-    G --> H["E-paper display"]
-    F --> I["Validated catalog-only PR"]
-    I --> J["Reusable project catalog"]
+    A["iNaturalist / eBird / BirdWeather"] --> B["Controller"]
+    B --> C["Approved plate catalog"]
+    C --> D["HTTP on the private network"]
+    D --> E["Raspberry Pi display node"]
+    E --> F["Pimoroni Inky Impression"]
+    B --> G["Codex generation and review"]
+    G --> C
 ```
 
 The system has two deliberately small roles:
@@ -52,6 +49,11 @@ The system has two deliberately small roles:
   and serves approved assets.
 - The **display node** downloads approved assets, verifies their checksums, and
   rotates them on the Inky panel. It does no AI or discovery work.
+
+The roles may run on one capable Raspberry Pi, but the recommended wall build
+keeps the lightweight display node behind the frame and runs the controller on
+an existing Mac, Linux computer, Raspberry Pi 4 or 5, or Docker host. A Pi Zero
+2 W is recommended for display duty, not Codex generation.
 
 <p align="center">
   <img src="docs/images/installation-architecture.png" alt="Inky Bird Frame architecture showing a Mac or Raspberry Pi controller serving approved bird plates over a private home network to a Raspberry Pi Zero 2 W display node" width="900">
@@ -226,8 +228,9 @@ uv run inky-bird-frame catalog-publish --config config.toml --dry-run
 uv run inky-bird-frame catalog-publish --config config.toml
 ```
 
-Discovery sources are `inaturalist`, `ebird`, `combined`, `birdweather`, and
-`all`. BirdWeather adds species detected by one authenticated acoustic station;
+Configure any combination with `discovery.sources`, for example
+`["inaturalist", "ebird", "birdweather"]`. The older singular `source` values
+remain accepted for compatibility. BirdWeather adds species detected by one authenticated acoustic station;
 the project reads detection metadata only and never receives or manages audio.
 Every external species is exact-matched to iNaturalist taxonomy before the
 existing licensed-reference pipeline accepts it.
@@ -247,6 +250,18 @@ Counts from different providers are not equivalent evidence. It avoids
 immediate repeats when alternatives are available.
 Recovery and operator-override commands are documented in
 [`docs/operations.md`](docs/operations.md).
+
+## Related project
+
+Looking for a microphone-first bird station? [AvianVisitors](https://github.com/Twarner491/AvianVisitors)
+by Teddy Warner builds on BirdNET-Pi to identify birds heard by a local USB
+microphone and present them through a live illustrated collage. It also supports
+Home Assistant, MQTT, remote access, eBird regional filtering, optional e-ink
+hardware, BirdWeather operation, and complete kits. Inky Bird Frame instead
+focuses on rotating reusable scientific field-journal plates from configurable
+observation and detection services without managing audio. Teddy's detailed
+[AvianVisitors project write-up](https://theodore.net/projects/AvianVisitors/)
+shows the complete listening-station workflow.
 
 ## Notifications
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,8 +1,8 @@
 [discovery]
-# iNaturalist needs no credentials. eBird provides nearby public sightings. BirdWeather
-# provides acoustic detections from one authenticated station. combined is iNaturalist plus
-# eBird; all queries all three independently. See docs/discovery.md before choosing.
-source = "inaturalist"
+# Select one or more providers explicitly. iNaturalist needs no credentials, eBird provides
+# nearby public sightings, and BirdWeather provides detections from one authenticated station.
+# Legacy singular source values remain accepted for compatibility. See docs/discovery.md.
+sources = ["inaturalist"]
 # This location is used only to discover species. It is never rendered on a plate.
 zip_code = "12345"
 # Eight kilometers is approximately five miles: local enough to feel relevant while
@@ -14,11 +14,11 @@ species_limit = 50
 # Thirty days balances seasonal relevance with coverage. Shorter windows can be sparse;
 # last-year and all-time are better suited to one-time catalog seeding.
 window = "last-30-days"
-# eBird and combined support last-day, last-week, and last-30-days, with a maximum 50 km
+# Any selection containing eBird supports the first three windows, with a maximum 50 km
 # radius. Keep a real key only in this private mode-0600 file, or name an injected variable.
 # ebird_api_key = "YOUR_PERSONAL_EBIRD_API_KEY"
 # ebird_api_key_env = "EBIRD_API_KEY"
-# BirdWeather and all accept at most 100 species. This token authenticates one station and
+# Any selection containing BirdWeather accepts at most 100 species. This token authenticates one station and
 # belongs only in this private file or an injected environment variable.
 # birdweather_token = "YOUR_BIRDWEATHER_STATION_TOKEN"
 # birdweather_token_env = "BIRDWEATHER_TOKEN"

--- a/deploy/install-controller-systemd.sh
+++ b/deploy/install-controller-systemd.sh
@@ -88,7 +88,7 @@ import sys
 from pathlib import Path
 
 from inky_bird_frame.catalog import catalog_state_lock
-from inky_bird_frame.config import load_config
+from inky_bird_frame.config import DiscoveryProvider, load_config
 from inky_bird_frame.errors import ConfigurationError
 from inky_bird_frame.installation import controller_systemd_units
 from inky_bird_frame.publisher import sync_public_catalog
@@ -97,10 +97,19 @@ from inky_bird_frame.publisher import sync_public_catalog
 unit_dir, root, app_dir, config_path, home = map(Path, sys.argv[1:6])
 user = sys.argv[6]
 config = load_config(config_path)
-if config.discovery.source.uses_ebird and config.discovery.ebird_api_key_env is not None:
+environment_credentials = []
+if DiscoveryProvider.EBIRD in config.discovery.sources and config.discovery.ebird_api_key_env:
+    environment_credentials.append("ebird_api_key_env")
+if (
+    DiscoveryProvider.BIRDWEATHER in config.discovery.sources
+    and config.discovery.birdweather_token_env
+):
+    environment_credentials.append("birdweather_token_env")
+if environment_credentials:
+    names = ", ".join(environment_credentials)
     raise ConfigurationError(
-        "The systemd installer requires ebird_api_key in the private config file; "
-        "environment variables are not inherited by managed services"
+        f"The systemd installer cannot use {names}; store the corresponding credential "
+        "directly in the private config file"
     )
 environment_destinations = [
     destination.name

--- a/deploy/install-controller.sh
+++ b/deploy/install-controller.sh
@@ -78,7 +78,7 @@ import sys
 from pathlib import Path
 
 from inky_bird_frame.catalog import catalog_state_lock
-from inky_bird_frame.config import load_config
+from inky_bird_frame.config import DiscoveryProvider, load_config
 from inky_bird_frame.errors import ConfigurationError
 from inky_bird_frame.publisher import sync_public_catalog
 
@@ -95,10 +95,19 @@ from inky_bird_frame.publisher import sync_public_catalog
 ) = map(Path, sys.argv[1:])
 executable = app_dir / ".venv/bin/inky-bird-frame"
 config = load_config(config_path)
-if config.discovery.source.uses_ebird and config.discovery.ebird_api_key_env is not None:
+environment_credentials = []
+if DiscoveryProvider.EBIRD in config.discovery.sources and config.discovery.ebird_api_key_env:
+    environment_credentials.append("ebird_api_key_env")
+if (
+    DiscoveryProvider.BIRDWEATHER in config.discovery.sources
+    and config.discovery.birdweather_token_env
+):
+    environment_credentials.append("birdweather_token_env")
+if environment_credentials:
+    names = ", ".join(environment_credentials)
     raise ConfigurationError(
-        "The macOS LaunchAgent installer requires ebird_api_key in the private config "
-        "file; environment variables are not inherited by managed services"
+        f"The macOS LaunchAgent installer cannot use {names}; store the corresponding "
+        "credential directly in the private config file"
     )
 environment_destinations = [
     destination.name

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,10 +8,10 @@ The controller owns discovery and generation through independent schedules.
 An observation refresh:
 
 1. resolves the private discovery location;
-2. queries iNaturalist species counts for the configured radius and window,
-   requiring species rank in both the request and response;
-3. atomically stores the private observation snapshot; and
-4. publishes a private active catalog containing only observed taxa that
+2. queries each explicitly configured observation provider independently;
+3. exact-matches external taxonomy to canonical iNaturalist species IDs;
+4. atomically stores the private observation snapshot; and
+5. publishes a private active catalog containing only observed taxa that
    already have approved plates.
 
 A locked generation cycle reads the latest non-stale snapshot and the durable

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -6,22 +6,23 @@ these services and sends every result through one catalog and review pipeline.
 Merlin Bird ID is Cornell's identification application; its nearby lists are
 powered by eBird. This project integrates the documented eBird API, not Merlin.
 
-## Choose a source
+## Choose providers
 
 | Source | Credentials | Windows | Best use |
 | --- | --- | --- | --- |
 | `inaturalist` | None | All | Default setup, historical seeds, and licensed references |
 | `ebird` | Personal eBird key | 1, 7, or 30 days | Bird-specific recent public sightings |
-| `combined` | Personal eBird key | 1, 7, or 30 days | Broad recent discovery with provider fallback |
 | `birdweather` | BirdWeather station token | All | Species acoustically detected by one station |
-| `all` | Both credentials | 1, 7, or 30 days | Public observations plus station detections |
+
+Select any combination with a TOML array. Each configured provider runs
+independently:
 
 Request a personal key from [eBird](https://ebird.org/api/keygen). Store it in
 the private configuration:
 
 ```toml
 [discovery]
-source = "combined"
+sources = ["inaturalist", "ebird"]
 zip_code = "12345"
 radius_km = 8
 species_limit = 50
@@ -46,7 +47,7 @@ station authentication token into the private controller configuration:
 
 ```toml
 [discovery]
-source = "birdweather"
+sources = ["birdweather"]
 zip_code = "12345"
 radius_km = 8
 species_limit = 50
@@ -54,8 +55,8 @@ window = "last-30-days"
 birdweather_token = "your-station-token"
 ```
 
-Use `source = "all"` and configure both `ebird_api_key` and
-`birdweather_token` to query every provider. For manually invoked commands,
+Use `sources = ["inaturalist", "ebird", "birdweather"]` and configure both
+credentials to query every current provider. For manually invoked commands,
 `birdweather_token_env = "BIRDWEATHER_TOKEN"` is also supported. Managed
 services require the direct token in the private mode-`0600` file because they
 do not inherit the installation shell environment.
@@ -107,14 +108,19 @@ iNaturalist remains the source for taxonomy and research-grade CC0/CC-BY
 reference photographs. eBird and Macaulay Library media are not copied into the
 generation pipeline.
 
-## Combined and all modes
+## Multiple providers
 
 Each provider receives the configured `species_limit`; the merged result can be
-larger before duplicates are removed by iNaturalist taxon ID. `combined` queries
-iNaturalist and eBird. `all` adds BirdWeather. If one provider fails, successful
+larger before duplicates are removed by iNaturalist taxon ID. If one provider fails, successful
 providers still refresh the active catalog and the controller records a
 provider-specific degradation. The refresh fails only when every configured
 provider fails, leaving the prior active catalog in place.
+
+The legacy singular values `source = "inaturalist"`, `"ebird"`, `"combined"`,
+`"birdweather"`, and `"all"` remain accepted. Do not set both `source` and
+`sources`. The meaning of legacy `all` is frozen to the three providers present
+when it was introduced, so an application upgrade cannot silently contact a
+future provider. New configurations should use the explicit array.
 
 iNaturalist supplies observation counts, BirdWeather supplies station detection
 counts, and eBird's nearby endpoint supplies presence rather than a comparable
@@ -132,6 +138,10 @@ iNaturalist seed for longer periods:
 inky-bird-frame seed --config /path/to/config.toml \
   --source inaturalist --window last-year --species-limit 500
 ```
+
+Repeat `--source` for a multi-provider seed, for example `--source inaturalist
+--source ebird`. CLI overrides accept concrete providers rather than legacy
+group aliases.
 
 Review the official [eBird API documentation](https://documenter.getpostman.com/view/664302/S1ENwy59/)
 and [eBird data-use guidance](https://support.ebird.org/en/support/solutions/articles/48001078113)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,12 +12,14 @@ stays on the trusted network.*
 
 ## Choose the two computers
 
-The controller and display node have different requirements. They may be on the
-same computer for development, but the supported framed installation uses two.
+The controller and display node have different requirements. A capable Linux
+Raspberry Pi may run both roles, but the recommended framed installation uses a
+small display node and a separate controller. The controller may also run as a
+container on an existing Docker host.
 
 | Role | Recommended | Supported | Notes |
 | --- | --- | --- | --- |
-| Controller | Existing Apple silicon Mac or Ubuntu Server 24.04 LTS computer | macOS with launchd; 64-bit Ubuntu 24.04 with systemd; 64-bit Raspberry Pi OS Bookworm or later with systemd | Codex publishes native macOS, Linux x86_64, and Linux arm64 builds. A Raspberry Pi 4 with 4GB is the smallest recommended dedicated controller. |
+| Controller | Existing Apple silicon Mac or Ubuntu Server 24.04 LTS computer | macOS with launchd; 64-bit Ubuntu 24.04 with systemd; 64-bit Raspberry Pi OS Bookworm or later with systemd | A Raspberry Pi 4 with 4GB is the smallest recommended dedicated controller. Docker installation is documented separately. |
 | Display | Raspberry Pi Zero 2 W with pre-soldered 40-pin header and Raspberry Pi OS Lite 64-bit | Raspberry Pi OS Bookworm or later on a 40-pin Raspberry Pi | This release supports the Pimoroni Inky Impression 13.3 inch PIM774 at 1600x1200. |
 
 The setup command detects launchd or systemd capabilities, but that does not
@@ -408,7 +410,7 @@ blank the frame.
 
 | Section | Used by | Purpose |
 | --- | --- | --- |
-| `[discovery]` | Controller | Source, credentials, ZIP, radius, observation window, and species cap |
+| `[discovery]` | Controller | Providers, credentials, ZIP, radius, observation window, and species cap |
 | `[controller]` | Controller | Persistent paths, Codex executable, HTTP bind, and generation bounds |
 | `[research]` | Controller | Bounded fallback research policy and approved domains |
 | `[notifications]` | Controller | Optional Apprise destinations, events, retries, and noise controls |

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -16,7 +16,13 @@ from .catalog import (
     rebuild_catalog_index,
     reject_candidate,
 )
-from .config import AppConfig, DiscoverySource, NotificationEvent, load_config
+from .config import (
+    AppConfig,
+    DiscoveryProvider,
+    NotificationEvent,
+    discovery_source_label,
+    load_config,
+)
 from .controller import (
     discover_species,
     enqueue_seed_species,
@@ -105,7 +111,8 @@ def discover_command(args: argparse.Namespace) -> int:
             ),
             "radius_km": config.discovery.radius_km,
             "window": config.discovery.observation_window.value,
-            "source": config.discovery.source.value,
+            "source": discovery_source_label(config.discovery.sources),
+            "sources": [provider.value for provider in config.discovery.sources],
             "providers": [provider.as_dict() for provider in discovery.providers],
             "unresolved_count": len(discovery.unresolved),
             "species": [species_to_dict(item) for item in discovery.species],
@@ -287,11 +294,18 @@ def generate_command(args: argparse.Namespace) -> int:
 
 
 def seed_command(args: argparse.Namespace) -> int:
+    source_values = args.source
+    if source_values is not None and len(source_values) != len(set(source_values)):
+        raise ValueError("--source must not repeat a provider")
     print_result(
         enqueue_seed_species(
             _config(args),
             window=parse_observation_window(args.window),
-            source=DiscoverySource(args.source) if args.source is not None else None,
+            sources=(
+                tuple(DiscoveryProvider(value) for value in source_values)
+                if source_values is not None
+                else None
+            ),
             radius_km=args.radius_km,
             species_limit=args.species_limit,
             dry_run=args.dry_run,
@@ -469,7 +483,8 @@ def config_validate_command(args: argparse.Namespace) -> int:
             "config": str(args.config),
             "valid": True,
             "discovery": {
-                "source": config.discovery.source.value,
+                "source": discovery_source_label(config.discovery.sources),
+                "sources": [provider.value for provider in config.discovery.sources],
                 "ebird_configured": config.discovery.ebird_api_key is not None,
                 "birdweather_configured": config.discovery.birdweather_token is not None,
                 "window": config.discovery.observation_window.value,
@@ -644,8 +659,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     seed_parser.add_argument(
         "--source",
-        choices=[source.value for source in DiscoverySource],
-        help="Override the configured discovery source for this seed run",
+        action="append",
+        choices=[provider.value for provider in DiscoveryProvider],
+        help="Override discovery with one provider; repeat to select multiple providers",
     )
     seed_parser.add_argument("--radius-km", type=int)
     seed_parser.add_argument("--species-limit", type=int)

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -22,28 +22,38 @@ class RotationMode(StrEnum):
     WEIGHTED = "weighted"
 
 
-class DiscoverySource(StrEnum):
+class DiscoveryProvider(StrEnum):
     INATURALIST = "inaturalist"
     EBIRD = "ebird"
-    COMBINED = "combined"
     BIRDWEATHER = "birdweather"
-    ALL = "all"
-
-    @property
-    def uses_ebird(self) -> bool:
-        return self in {DiscoverySource.EBIRD, DiscoverySource.COMBINED, DiscoverySource.ALL}
-
-    @property
-    def uses_birdweather(self) -> bool:
-        return self in {DiscoverySource.BIRDWEATHER, DiscoverySource.ALL}
 
 
-def parse_discovery_source(value: str) -> DiscoverySource:
+LEGACY_DISCOVERY_SOURCES: dict[str, tuple[DiscoveryProvider, ...]] = {
+    "inaturalist": (DiscoveryProvider.INATURALIST,),
+    "ebird": (DiscoveryProvider.EBIRD,),
+    "combined": (DiscoveryProvider.INATURALIST, DiscoveryProvider.EBIRD),
+    "birdweather": (DiscoveryProvider.BIRDWEATHER,),
+    "all": (
+        DiscoveryProvider.INATURALIST,
+        DiscoveryProvider.EBIRD,
+        DiscoveryProvider.BIRDWEATHER,
+    ),
+}
+
+
+def parse_discovery_provider(value: str) -> DiscoveryProvider:
     try:
-        return DiscoverySource(value)
+        return DiscoveryProvider(value)
     except ValueError as exc:
-        allowed = ", ".join(item.value for item in DiscoverySource)
-        raise ValueError(f"discovery source must be one of: {allowed}") from exc
+        allowed = ", ".join(item.value for item in DiscoveryProvider)
+        raise ValueError(f"discovery provider must be one of: {allowed}") from exc
+
+
+def discovery_source_label(providers: tuple[DiscoveryProvider, ...]) -> str:
+    for label, legacy_providers in LEGACY_DISCOVERY_SOURCES.items():
+        if providers == legacy_providers:
+            return label
+    return ",".join(provider.value for provider in providers)
 
 
 class NotificationEvent(StrEnum):
@@ -73,7 +83,7 @@ class DiscoveryConfig:
     radius_km: int
     species_limit: int
     observation_window: ObservationWindow
-    source: DiscoverySource = DiscoverySource.INATURALIST
+    sources: tuple[DiscoveryProvider, ...] = (DiscoveryProvider.INATURALIST,)
     ebird_api_key: str | None = field(default=None, repr=False)
     ebird_api_key_env: str | None = field(default=None, repr=False)
     birdweather_token: str | None = field(default=None, repr=False)
@@ -377,11 +387,23 @@ def load_config(path: Path) -> AppConfig:
     except ValueError as exc:
         raise ConfigurationError(str(exc)) from exc
 
-    source_value = _optional_string(discovery, "source", default=DiscoverySource.INATURALIST.value)
-    try:
-        discovery_source = parse_discovery_source(source_value)
-    except ValueError as exc:
-        raise ConfigurationError(str(exc)) from exc
+    if "source" in discovery and "sources" in discovery:
+        raise ConfigurationError("Choose discovery.source or discovery.sources, not both")
+    if "sources" in discovery:
+        source_values = _string_tuple(discovery, "sources")
+        if not source_values:
+            raise ConfigurationError("discovery.sources must contain at least one provider")
+        try:
+            discovery_sources = tuple(parse_discovery_provider(value) for value in source_values)
+        except ValueError as exc:
+            raise ConfigurationError(str(exc)) from exc
+    else:
+        source_value = _optional_string(discovery, "source", default="inaturalist")
+        try:
+            discovery_sources = LEGACY_DISCOVERY_SOURCES[source_value]
+        except KeyError as exc:
+            allowed = ", ".join(LEGACY_DISCOVERY_SOURCES)
+            raise ConfigurationError(f"discovery source must be one of: {allowed}") from exc
     radius_km = _integer(discovery, "radius_km")
     species_limit = _integer(discovery, "species_limit")
     if radius_km <= 0:
@@ -392,23 +414,23 @@ def load_config(path: Path) -> AppConfig:
     ebird_api_key, ebird_api_key_env = _private_value(
         discovery,
         "ebird_api_key",
-        required=discovery_source.uses_ebird,
+        required=DiscoveryProvider.EBIRD in discovery_sources,
         provider_name="eBird",
     )
     birdweather_token, birdweather_token_env = _private_value(
         discovery,
         "birdweather_token",
-        required=discovery_source.uses_birdweather,
+        required=DiscoveryProvider.BIRDWEATHER in discovery_sources,
         provider_name="BirdWeather",
     )
-    if discovery_source.uses_ebird:
+    if DiscoveryProvider.EBIRD in discovery_sources:
         if window in {ObservationWindow.LAST_YEAR, ObservationWindow.ALL_TIME}:
             raise ConfigurationError("eBird discovery supports observation windows up to 30 days")
         if radius_km > 50:
             raise ConfigurationError("eBird discovery radius_km must not exceed 50")
         if species_limit > 10_000:
             raise ConfigurationError("eBird species_limit must not exceed 10000")
-    if discovery_source.uses_birdweather and species_limit > 100:
+    if DiscoveryProvider.BIRDWEATHER in discovery_sources and species_limit > 100:
         raise ConfigurationError("BirdWeather species_limit must not exceed 100")
 
     controller_url = _string(display_node, "controller_url").rstrip("/")
@@ -473,7 +495,7 @@ def load_config(path: Path) -> AppConfig:
 
     return AppConfig(
         discovery=DiscoveryConfig(
-            source=discovery_source,
+            sources=discovery_sources,
             zip_code=zip_code,
             radius_km=radius_km,
             species_limit=species_limit,

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -39,7 +39,7 @@ from .catalog import (
     write_json_atomic,
 )
 from .codex_runner import CodexRunner, parse_species_profile
-from .config import AppConfig, DiscoverySource
+from .config import AppConfig, DiscoveryProvider, discovery_source_label
 from .errors import (
     CatalogError,
     DataSourceError,
@@ -126,24 +126,24 @@ def exclusive_refresh_lock(state_dir: Path) -> Iterator[None]:
 def discover_species(
     config: AppConfig,
     *,
-    source: DiscoverySource | None = None,
+    sources: tuple[DiscoveryProvider, ...] | None = None,
     window: ObservationWindow | None = None,
     radius_km: int | None = None,
     species_limit: int | None = None,
     persist_taxonomy_cache: bool = True,
 ) -> DiscoveryResult:
-    selected_source = source or config.discovery.source
+    selected_sources = sources or config.discovery.sources
     selected_window = window or config.discovery.observation_window
     selected_radius = radius_km if radius_km is not None else config.discovery.radius_km
     selected_limit = species_limit if species_limit is not None else config.discovery.species_limit
-    if selected_source.uses_ebird:
+    if DiscoveryProvider.EBIRD in selected_sources:
         if selected_window in {ObservationWindow.LAST_YEAR, ObservationWindow.ALL_TIME}:
             raise ValueError("eBird discovery supports observation windows up to 30 days")
         if not 0 < selected_radius <= 50:
             raise ValueError("eBird discovery radius_km must be between 1 and 50")
         if not 0 < selected_limit <= 10_000:
             raise ValueError("eBird species_limit must be between 1 and 10000")
-    if selected_source.uses_birdweather and not 0 < selected_limit <= 100:
+    if DiscoveryProvider.BIRDWEATHER in selected_sources and not 0 < selected_limit <= 100:
         raise ValueError("BirdWeather species_limit must be between 1 and 100")
     providers: list[ProviderStatus] = []
     provider_species: list[list[BirdSpecies]] = []
@@ -151,13 +151,9 @@ def discover_species(
     location: ZipLocation | None = None
 
     location_provider_names: list[str] = []
-    if selected_source in {
-        DiscoverySource.INATURALIST,
-        DiscoverySource.COMBINED,
-        DiscoverySource.ALL,
-    }:
+    if DiscoveryProvider.INATURALIST in selected_sources:
         location_provider_names.append("inaturalist")
-    if selected_source in {DiscoverySource.EBIRD, DiscoverySource.COMBINED, DiscoverySource.ALL}:
+    if DiscoveryProvider.EBIRD in selected_sources:
         location_provider_names.append("ebird")
     if location_provider_names:
         try:
@@ -168,11 +164,7 @@ def discover_species(
                 for name in location_provider_names
             )
 
-    if location is not None and selected_source in {
-        DiscoverySource.INATURALIST,
-        DiscoverySource.COMBINED,
-        DiscoverySource.ALL,
-    }:
+    if location is not None and DiscoveryProvider.INATURALIST in selected_sources:
         try:
             inaturalist = fetch_inaturalist_birds(
                 latitude=location.latitude,
@@ -187,11 +179,7 @@ def discover_species(
             provider_species.append(inaturalist)
             providers.append(ProviderStatus("inaturalist", "ok", len(inaturalist)))
 
-    if location is not None and selected_source in {
-        DiscoverySource.EBIRD,
-        DiscoverySource.COMBINED,
-        DiscoverySource.ALL,
-    }:
+    if location is not None and DiscoveryProvider.EBIRD in selected_sources:
         try:
             api_key = config.discovery.ebird_api_key
             if api_key is None and config.discovery.ebird_api_key_env is not None:
@@ -237,7 +225,7 @@ def discover_species(
                     )
                 )
 
-    if selected_source in {DiscoverySource.BIRDWEATHER, DiscoverySource.ALL}:
+    if DiscoveryProvider.BIRDWEATHER in selected_sources:
         try:
             token = config.discovery.birdweather_token
             if token is None and config.discovery.birdweather_token_env is not None:
@@ -286,7 +274,7 @@ def discover_species(
         )
         raise DataSourceError(f"All configured observation providers failed: {failures}")
     species = _merge_provider_species(provider_species)
-    if selected_source in {DiscoverySource.COMBINED, DiscoverySource.ALL}:
+    if len(selected_sources) > 1:
         species.sort(key=lambda item: (item.common_name.casefold(), item.taxon_id))
     return DiscoveryResult(location, species, providers, unresolved)
 
@@ -423,7 +411,7 @@ def enqueue_seed_species(
     config: AppConfig,
     *,
     window: ObservationWindow,
-    source: DiscoverySource | None = None,
+    sources: tuple[DiscoveryProvider, ...] | None = None,
     radius_km: int | None = None,
     species_limit: int | None = None,
     dry_run: bool = False,
@@ -439,7 +427,7 @@ def enqueue_seed_species(
     with cycle_lock:
         discovery = discover_species(
             config,
-            source=source,
+            sources=sources,
             window=window,
             radius_km=radius,
             species_limit=limit,
@@ -469,7 +457,8 @@ def enqueue_seed_species(
 
     return {
         "window": window.value,
-        "source": (source or config.discovery.source).value,
+        "source": discovery_source_label(sources or config.discovery.sources),
+        "sources": [provider.value for provider in (sources or config.discovery.sources)],
         "radius_km": radius,
         "species_limit": limit,
         "discovered_count": len(discovered),
@@ -541,7 +530,8 @@ def run_refresh_cycle(config: AppConfig) -> dict[str, object]:
         "state": state,
         "window": config.discovery.observation_window.value,
         "radius_km": config.discovery.radius_km,
-        "source": config.discovery.source.value,
+        "source": discovery_source_label(config.discovery.sources),
+        "sources": [provider.value for provider in config.discovery.sources],
         "providers": [provider.as_dict() for provider in discovery.providers],
         "unresolved_species": [
             _unresolved_species_payload(species) for species in discovery.unresolved

--- a/src/inky_bird_frame/installation.py
+++ b/src/inky_bird_frame/installation.py
@@ -14,7 +14,7 @@ from enum import StrEnum
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
-from .config import AppConfig, load_config
+from .config import AppConfig, DiscoveryProvider, load_config
 from .errors import ConfigurationError, InkyBirdFrameError, InstallationError
 from .http import get_json
 
@@ -626,10 +626,13 @@ def setup(
     config = load_config(config_path)
     if role is InstallationRole.CONTROLLER:
         environment_credentials: list[str] = []
-        if config.discovery.source.uses_ebird and config.discovery.ebird_api_key_env is not None:
+        if (
+            DiscoveryProvider.EBIRD in config.discovery.sources
+            and config.discovery.ebird_api_key_env is not None
+        ):
             environment_credentials.append("ebird_api_key_env")
         if (
-            config.discovery.source.uses_birdweather
+            DiscoveryProvider.BIRDWEATHER in config.discovery.sources
             and config.discovery.birdweather_token_env is not None
         ):
             environment_credentials.append("birdweather_token_env")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,9 +17,10 @@ from inky_bird_frame.cli import (
     main,
     refresh_command,
     retry_command,
+    seed_command,
     species_to_dict,
 )
-from inky_bird_frame.config import DiscoverySource
+from inky_bird_frame.config import DiscoveryProvider
 from inky_bird_frame.controller import exclusive_cycle_lock
 from inky_bird_frame.errors import DataSourceError, GenerationError
 
@@ -77,6 +78,8 @@ class CliTests(unittest.TestCase):
                 "last-year",
                 "--source",
                 "inaturalist",
+                "--source",
+                "ebird",
                 "--radius-km",
                 "16",
                 "--species-limit",
@@ -86,7 +89,7 @@ class CliTests(unittest.TestCase):
         )
 
         self.assertEqual(args.window, "last-year")
-        self.assertEqual(args.source, "inaturalist")
+        self.assertEqual(args.source, ["inaturalist", "ebird"])
         self.assertEqual(args.radius_km, 16)
         self.assertEqual(args.species_limit, 500)
         self.assertTrue(args.dry_run)
@@ -98,6 +101,10 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(payload["source"], "iNaturalist")
         self.assertEqual(payload["sources"], ["iNaturalist"])
+
+    def test_seed_rejects_duplicate_source_overrides(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must not repeat"):
+            seed_command(Namespace(source=["ebird", "ebird"]))
 
     def test_config_validation_and_notification_commands_require_config(self) -> None:
         validate = build_parser().parse_args(["config", "validate", "--config", "instance.toml"])
@@ -241,7 +248,9 @@ class CliTests(unittest.TestCase):
 
     def test_refresh_does_not_clear_taxonomy_alert_when_ebird_fails(self) -> None:
         config = SimpleNamespace(
-            discovery=SimpleNamespace(source=DiscoverySource.COMBINED),
+            discovery=SimpleNamespace(
+                sources=(DiscoveryProvider.INATURALIST, DiscoveryProvider.EBIRD)
+            ),
         )
         result = {
             "providers": [
@@ -264,7 +273,7 @@ class CliTests(unittest.TestCase):
         self.assertNotIn("ebird-taxonomy", recovered_keys)
 
     def test_refresh_tracks_taxonomy_alerts_by_provider(self) -> None:
-        config = SimpleNamespace(discovery=SimpleNamespace(source=DiscoverySource.ALL))
+        config = SimpleNamespace(discovery=SimpleNamespace(sources=tuple(DiscoveryProvider)))
         result = {
             "providers": [
                 {"name": "inaturalist", "status": "ok"},

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from inky_bird_frame.birds import ObservationWindow
-from inky_bird_frame.config import DiscoverySource, NotificationEvent, RotationMode, load_config
+from inky_bird_frame.config import DiscoveryProvider, NotificationEvent, RotationMode, load_config
 from inky_bird_frame.errors import ConfigurationError
 
 CONFIG = """
@@ -61,7 +61,7 @@ class ConfigTests(unittest.TestCase):
             config = load_config(path)
 
         self.assertEqual(config.discovery.observation_window, ObservationWindow.LAST_30_DAYS)
-        self.assertIs(config.discovery.source, DiscoverySource.INATURALIST)
+        self.assertEqual(config.discovery.sources, (DiscoveryProvider.INATURALIST,))
         self.assertEqual(config.discovery.radius_km, 16)
         self.assertEqual(config.controller.catalog_dir, (Path(temporary) / "catalog").resolve())
         self.assertEqual(config.controller.max_generation_attempts, 3)
@@ -104,7 +104,10 @@ class ConfigTests(unittest.TestCase):
             with patch.dict("os.environ", {"TEST_EBIRD_KEY": "secret"}):
                 config = load_config(path)
 
-        self.assertIs(config.discovery.source, DiscoverySource.COMBINED)
+        self.assertEqual(
+            config.discovery.sources,
+            (DiscoveryProvider.INATURALIST, DiscoveryProvider.EBIRD),
+        )
         self.assertEqual(config.discovery.ebird_api_key, "secret")
 
     def test_inaturalist_default_resolves_key_for_source_override(self) -> None:
@@ -117,7 +120,7 @@ class ConfigTests(unittest.TestCase):
             with patch.dict("os.environ", {"TEST_EBIRD_KEY": "secret"}):
                 config = load_config(path)
 
-        self.assertIs(config.discovery.source, DiscoverySource.INATURALIST)
+        self.assertEqual(config.discovery.sources, (DiscoveryProvider.INATURALIST,))
         self.assertEqual(config.discovery.ebird_api_key, "secret")
 
     def test_inaturalist_default_allows_missing_optional_ebird_environment(self) -> None:
@@ -130,7 +133,7 @@ class ConfigTests(unittest.TestCase):
             with patch.dict("os.environ", {}, clear=True):
                 config = load_config(path)
 
-        self.assertIs(config.discovery.source, DiscoverySource.INATURALIST)
+        self.assertEqual(config.discovery.sources, (DiscoveryProvider.INATURALIST,))
         self.assertIsNone(config.discovery.ebird_api_key)
         self.assertEqual(config.discovery.ebird_api_key_env, "TEST_EBIRD_KEY")
 
@@ -167,8 +170,49 @@ class ConfigTests(unittest.TestCase):
             with patch.dict("os.environ", {"TEST_BIRDWEATHER_TOKEN": "secret"}):
                 config = load_config(path)
 
-        self.assertIs(config.discovery.source, DiscoverySource.BIRDWEATHER)
+        self.assertEqual(config.discovery.sources, (DiscoveryProvider.BIRDWEATHER,))
         self.assertEqual(config.discovery.birdweather_token, "secret")
+
+    def test_sources_array_selects_arbitrary_providers(self) -> None:
+        configured = CONFIG.replace(
+            "[discovery]\n",
+            '[discovery]\nsources = ["ebird", "birdweather"]\n'
+            'ebird_api_key = "ebird-secret"\n'
+            'birdweather_token = "station-secret"\n',
+        )
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(configured)
+            config = load_config(path)
+
+        self.assertEqual(
+            config.discovery.sources,
+            (DiscoveryProvider.EBIRD, DiscoveryProvider.BIRDWEATHER),
+        )
+
+    def test_rejects_source_and_sources_together(self) -> None:
+        configured = CONFIG.replace(
+            "[discovery]\n",
+            '[discovery]\nsource = "inaturalist"\nsources = ["inaturalist"]\n',
+        )
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(configured)
+            with self.assertRaisesRegex(ConfigurationError, "source or discovery.sources"):
+                load_config(path)
+
+    def test_rejects_empty_or_duplicate_sources(self) -> None:
+        for value, message in (
+            ("[]", "at least one"),
+            ('["inaturalist", "inaturalist"]', "duplicates"),
+        ):
+            with self.subTest(value=value), TemporaryDirectory() as temporary:
+                path = Path(temporary) / "config.toml"
+                path.write_text(
+                    CONFIG.replace("[discovery]\n", f"[discovery]\nsources = {value}\n")
+                )
+                with self.assertRaisesRegex(ConfigurationError, message):
+                    load_config(path)
 
     def test_all_source_requires_both_provider_credentials(self) -> None:
         configured = CONFIG.replace(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -17,7 +17,7 @@ from inky_bird_frame.birds import (
 )
 from inky_bird_frame.catalog import CatalogEntry, candidate_directory, write_candidate_manifest
 from inky_bird_frame.codex_runner import CodexRunner
-from inky_bird_frame.config import DiscoverySource, load_config
+from inky_bird_frame.config import DiscoveryProvider, load_config
 from inky_bird_frame.controller import (
     DiscoveryResult,
     DiscoverySnapshot,
@@ -1099,7 +1099,7 @@ class DiscoveryProviderTests(unittest.TestCase):
                     return_value=EbirdResolution([resolved], []),
                 ),
             ):
-                result = discover_species(config, source=DiscoverySource.EBIRD)
+                result = discover_species(config, sources=(DiscoveryProvider.EBIRD,))
 
         self.assertEqual(result.species, [resolved])
         self.assertEqual(fetch.call_args.kwargs["api_key"], "secret")

--- a/tests/test_deployment_scripts.py
+++ b/tests/test_deployment_scripts.py
@@ -3,6 +3,21 @@ from __future__ import annotations
 from pathlib import Path
 
 
+def _controller_installers() -> list[str]:
+    root = Path(__file__).resolve().parents[1] / "deploy"
+    return [
+        (root / "install-controller.sh").read_text(),
+        (root / "install-controller-systemd.sh").read_text(),
+    ]
+
+
+def test_controller_installers_use_provider_lists_for_managed_credentials() -> None:
+    for script in _controller_installers():
+        assert "DiscoveryProvider.EBIRD in config.discovery.sources" in script
+        assert "DiscoveryProvider.BIRDWEATHER in config.discovery.sources" in script
+        assert "config.discovery.source." not in script
+
+
 def test_controller_installer_restores_schedule_without_run_at_load_on_failure() -> None:
     script = (Path(__file__).resolve().parents[1] / "deploy" / "install-controller.sh").read_text()
 
@@ -25,7 +40,9 @@ def test_controller_installer_restores_schedule_without_run_at_load_on_failure()
     assert "sync_public_catalog(source_catalog, managed_catalog)" in script
     assert "sync_public_catalog(source_catalog, config.controller.catalog_dir)" in script
     assert "managed_catalog.resolve() != config.controller.catalog_dir.resolve()" in script
-    assert "requires ebird_api_key in the private config" in script
+    assert "cannot use {names}" in script
+    assert 'environment_credentials.append("ebird_api_key_env")' in script
+    assert 'environment_credentials.append("birdweather_token_env")' in script
     assert "config.controller.workspace_dir.mkdir(parents=True, exist_ok=True)" in script
     assert "config.controller.catalog_dir.parent.mkdir(parents=True, exist_ok=True)" in script
     assert "rebuild_catalog_index" not in script
@@ -61,7 +78,9 @@ def test_systemd_controller_installer_restarts_boot_persistent_services() -> Non
     assert "sync_public_catalog(source_catalog, managed_catalog)" in script
     assert "sync_public_catalog(source_catalog, config.controller.catalog_dir)" in script
     assert "managed_catalog.resolve() != config.controller.catalog_dir.resolve()" in script
-    assert "requires ebird_api_key in the private config" in script
+    assert "cannot use {names}" in script
+    assert 'environment_credentials.append("ebird_api_key_env")' in script
+    assert 'environment_credentials.append("birdweather_token_env")' in script
     assert "config.controller.workspace_dir.mkdir(parents=True, exist_ok=True)" in script
     assert "config.controller.catalog_dir.parent.mkdir(parents=True, exist_ok=True)" in script
     assert "rebuild_catalog_index" not in script


### PR DESCRIPTION
## Summary
- support arbitrary discovery provider lists with native TOML arrays and repeatable CLI overrides
- preserve singular source aliases and additive command-output compatibility
- simplify the architecture explanation, document deployment choices, and point microphone-first users to AvianVisitors

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q`
- `uv run inky-bird-frame catalog validate --catalog catalog`
- `git diff --check`