### PR TITLE
Prioritize newly detected birds on the display

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -69,6 +69,9 @@ state_dir = "var/display-node"
 # birds immediately. sequential is stable order; shuffle refills before admitting additions;
 # weighted favors frequently observed birds.
 rotation_mode = "shuffle_bag"
+# When BirdWeather is configured, show the newest station detection once before resuming
+# rotation. Disable this to make every display update follow rotation_mode exclusively.
+prioritize_latest_detection = true
 
 [public_catalog]
 # The trusted controller opens and owner-merges catalog-only PRs in this repository.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,9 +59,12 @@ The display node does not discover birds or generate art. Each timer cycle:
 
 1. fetches the private active catalog;
 2. selects an entry using the configured sequential, shuffle, `shuffle_bag`, or
-   observation-weighted policy and durable local state. `shuffle_bag` has its
-   own persisted remaining/shown state, so catalog additions join the active bag
-   without restoring species already shown in that bag;
+   observation-weighted policy and durable local state. A newer BirdWeather
+   station detection may take priority once and counts as shown in the current
+   rotation when applicable. `shuffle_bag` has its own persisted
+   remaining/shown state, so catalog
+   additions join the active bag without restoring species already shown in
+   that bag;
 3. downloads the display asset;
 4. verifies its SHA-256 checksum;
 5. writes it to a local cache atomically; and

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -128,6 +128,13 @@ aggregate count. eBird-only species receive weight one. These counts describe
 different collection methods and should not be compared as equivalent evidence.
 `shuffle_bag` is the recommended source-neutral rotation policy.
 
+BirdWeather also supplies each species' latest station-detection timestamp.
+By default, a display node shows the newest detection once before returning to
+its configured rotation. This is display priority, not a confidence claim or a
+live event stream: the timestamp advances only when the controller refreshes
+the station summary, and recording-only detection limitations still apply.
+Configure `display_node.prioritize_latest_detection = false` to disable it.
+
 ## Limits and data use
 
 The eBird nearby API supports at most 30 days and 50 km. BirdWeather returns at

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -80,6 +80,16 @@ facts rather than trusting the profile's citations.
 - `weighted`: random selection weighted by current observation count, without
   immediate repeats when another species is active.
 
+`prioritize_latest_detection = true` is the default. When the active catalog
+contains BirdWeather timestamps, the newest detection later than the display
+node's durable watermark is shown once before the configured rotation resumes.
+The priority display counts as shown when that bird is already next in sequence
+or present in a shuffle pool, which prevents an immediate duplicate without
+reordering the other birds. A failed panel update does not consume the
+detection, and a first run shows only the current newest detection rather than
+replaying the historical window. Set the option to `false` to use
+`rotation_mode` for every update.
+
 Approved plates use the project's canonical 1200x1600 portrait and 1600x1200
 display assets. This geometry is a catalog contract so committed plates remain
 portable across installations using the supported panel. Controller and display

--- a/src/inky_bird_frame/birds.py
+++ b/src/inky_bird_frame/birds.py
@@ -6,7 +6,7 @@ import fcntl
 import json
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, date, datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
@@ -26,6 +26,7 @@ class BirdSpecies:
     observation_count: int
     source: str
     sources: tuple[str, ...] = ()
+    latest_detection_at: str | None = None
 
     def __post_init__(self) -> None:
         if not self.sources:
@@ -300,6 +301,7 @@ def parse_birdweather_species(payload: object) -> list[BirdWeatherSpecies]:
             or not scientific_name.strip()
             or not isinstance(latest_detection_at, str)
             or not latest_detection_at.strip()
+            or _parse_cache_datetime(latest_detection_at) is None
             or not isinstance(count, int)
             or isinstance(count, bool)
             or count <= 0
@@ -538,9 +540,16 @@ def resolve_birdweather_species(
         persist_cache=persist_cache,
     )
     unresolved_codes = {item.species_code for item in resolution.unresolved}
-    return resolution.species, [
-        item for item in detections if str(item.species_id) in unresolved_codes
+    resolved_detections = [
+        item for item in detections if str(item.species_id) not in unresolved_codes
     ]
+    if len(resolution.species) != len(resolved_detections):
+        raise DataSourceError("BirdWeather taxonomy resolution returned inconsistent results")
+    resolved = [
+        replace(species, latest_detection_at=detection.latest_detection_at)
+        for species, detection in zip(resolution.species, resolved_detections, strict=True)
+    ]
+    return resolved, [item for item in detections if str(item.species_id) in unresolved_codes]
 
 
 def _resolve_external_species(

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -45,6 +45,7 @@ class CatalogEntry:
     display_sha256: str
     approved_at: str
     observation_count: int | None = None
+    latest_detection_at: str | None = None
 
     def as_dict(self) -> dict[str, object]:
         value: dict[str, object] = {
@@ -60,6 +61,8 @@ class CatalogEntry:
         }
         if self.observation_count is not None:
             value["observation_count"] = self.observation_count
+        if self.latest_detection_at is not None:
+            value["latest_detection_at"] = self.latest_detection_at
         return value
 
 

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -148,6 +148,7 @@ class DisplayNodeConfig:
     controller_url: str
     state_dir: Path
     rotation_mode: RotationMode = RotationMode.SEQUENTIAL
+    prioritize_latest_detection: bool = True
 
 
 @dataclass(frozen=True)
@@ -536,6 +537,9 @@ def load_config(path: Path, *, load_secrets: bool = True) -> AppConfig:
             controller_url=controller_url,
             state_dir=_path(_string(display_node, "state_dir"), base_dir),
             rotation_mode=rotation_mode,
+            prioritize_latest_detection=_optional_boolean(
+                display_node, "prioritize_latest_detection", default=True
+            ),
         ),
         public_catalog=PublicCatalogConfig(
             enabled=public_catalog_enabled,

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -297,6 +297,7 @@ def _merge_provider_species(provider_species: list[list[BirdSpecies]]) -> list[B
                 observation_count=max(existing.observation_count, species.observation_count),
                 source="+".join(sources),
                 sources=sources,
+                latest_detection_at=(existing.latest_detection_at or species.latest_detection_at),
             )
     return [merged[taxon_id] for taxon_id in order]
 
@@ -314,7 +315,7 @@ def _generation_queue_path(config: AppConfig) -> Path:
 
 
 def _species_payload(species: BirdSpecies) -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "taxon_id": species.taxon_id,
         "common_name": species.common_name,
         "scientific_name": species.scientific_name,
@@ -322,6 +323,9 @@ def _species_payload(species: BirdSpecies) -> dict[str, object]:
         "source": species.source,
         "sources": list(species.sources),
     }
+    if species.latest_detection_at is not None:
+        payload["latest_detection_at"] = species.latest_detection_at
+    return payload
 
 
 def _unresolved_species_payload(
@@ -353,6 +357,7 @@ def _parse_species_list(raw: object, source: Path) -> list[BirdSpecies]:
         observation_count = item.get("observation_count")
         strings = [item.get(name) for name in ("common_name", "scientific_name")]
         sources_value = item.get("sources")
+        latest_detection_at = item.get("latest_detection_at")
         if sources_value is None and isinstance(item.get("source"), str):
             sources_value = [item["source"]]
         if (
@@ -367,6 +372,10 @@ def _parse_species_list(raw: object, source: Path) -> list[BirdSpecies]:
             or not isinstance(sources_value, list)
             or not sources_value
             or any(not isinstance(value, str) or not value for value in sources_value)
+            or (
+                latest_detection_at is not None
+                and (not isinstance(latest_detection_at, str) or not latest_detection_at)
+            )
         ):
             raise CatalogError(f"Invalid species in {source}")
         seen.add(taxon_id)
@@ -378,6 +387,7 @@ def _parse_species_list(raw: object, source: Path) -> list[BirdSpecies]:
                 observation_count=observation_count,
                 source="+".join(cast(list[str], sources_value)),
                 sources=tuple(cast(list[str], sources_value)),
+                latest_detection_at=latest_detection_at,
             )
         )
     return species
@@ -483,6 +493,8 @@ def _write_active_catalog(config: AppConfig, species_list: list[BirdSpecies]) ->
             continue
         value = entry.as_dict()
         value["observation_count"] = species.observation_count
+        if species.latest_detection_at is not None:
+            value["latest_detection_at"] = species.latest_detection_at
         active.append(value)
     write_json_atomic(
         _active_catalog_path(config),

--- a/src/inky_bird_frame/display_node.py
+++ b/src/inky_bird_frame/display_node.py
@@ -33,6 +33,7 @@ class DisplayState:
     shuffle_bag_remaining: tuple[int, ...] = ()
     shuffle_bag_seen: tuple[int, ...] = ()
     last_prioritized_detection_at: str | None = None
+    prioritized_detection_taxa: tuple[int, ...] = ()
 
 
 @contextmanager
@@ -127,7 +128,9 @@ def _detection_datetime(value: object, source: str) -> datetime:
 
 
 def _latest_unseen_detection(
-    entries: list[CatalogEntry], last_prioritized_at: str | None
+    entries: list[CatalogEntry],
+    last_prioritized_at: str | None,
+    prioritized_taxa: tuple[int, ...],
 ) -> CatalogEntry | None:
     watermark = (
         _detection_datetime(last_prioritized_at, "display-node state")
@@ -139,7 +142,14 @@ def _latest_unseen_detection(
         for entry in entries
         if entry.latest_detection_at is not None
     ]
-    unseen = [item for item in candidates if watermark is None or item[0] > watermark]
+    consumed_taxa = set(prioritized_taxa)
+    unseen = [
+        item
+        for item in candidates
+        if watermark is None
+        or item[0] > watermark
+        or (item[0] == watermark and item[1].taxon_id not in consumed_taxa)
+    ]
     if not unseen:
         return None
     return max(unseen, key=lambda item: (item[0], -item[1].taxon_id))[1]
@@ -181,6 +191,7 @@ def _read_state(path: Path) -> DisplayState:
             "shuffle_bag_remaining",
             "shuffle_bag_seen",
             "last_prioritized_detection_at",
+            "prioritized_detection_taxa",
         )
     ):
         raise CatalogError(f"Invalid display-node state: {path}")
@@ -191,6 +202,7 @@ def _read_state(path: Path) -> DisplayState:
     shuffle_bag_remaining = _state_taxon_ids(raw.get("shuffle_bag_remaining", []), path)
     shuffle_bag_seen = _state_taxon_ids(raw.get("shuffle_bag_seen", []), path)
     last_prioritized_detection_at = raw.get("last_prioritized_detection_at")
+    prioritized_detection_taxa = _state_taxon_ids(raw.get("prioritized_detection_taxa", []), path)
     if (
         not isinstance(next_index, int)
         or isinstance(next_index, bool)
@@ -209,6 +221,8 @@ def _read_state(path: Path) -> DisplayState:
             last_prioritized_detection_at is not None
             and not isinstance(last_prioritized_detection_at, str)
         )
+        or (last_prioritized_detection_at is None and prioritized_detection_taxa)
+        or (last_prioritized_detection_at is not None and not prioritized_detection_taxa)
     ):
         raise CatalogError(f"Invalid display-node state: {path}")
     if isinstance(last_prioritized_detection_at, str):
@@ -221,6 +235,7 @@ def _read_state(path: Path) -> DisplayState:
         shuffle_bag_remaining=shuffle_bag_remaining,
         shuffle_bag_seen=shuffle_bag_seen,
         last_prioritized_detection_at=last_prioritized_detection_at,
+        prioritized_detection_taxa=prioritized_detection_taxa,
     )
 
 
@@ -234,6 +249,7 @@ def _write_state(
     shuffle_bag_seen: list[int],
     last_sha256: str,
     last_prioritized_detection_at: str | None,
+    prioritized_detection_taxa: list[int],
 ) -> None:
     write_json_atomic(
         path,
@@ -246,8 +262,27 @@ def _write_state(
             "shuffle_bag_remaining": shuffle_bag_remaining,
             "shuffle_bag_seen": shuffle_bag_seen,
             "last_prioritized_detection_at": last_prioritized_detection_at,
+            "prioritized_detection_taxa": prioritized_detection_taxa,
         },
     )
+
+
+def _advanced_priority_state(state: DisplayState, selected: CatalogEntry) -> tuple[str, list[int]]:
+    timestamp = selected.latest_detection_at
+    if timestamp is None:
+        raise CatalogError("Prioritized catalog entry has no detection timestamp")
+    selected_at = _detection_datetime(timestamp, "controller catalog")
+    if state.last_prioritized_detection_at is not None and selected_at == _detection_datetime(
+        state.last_prioritized_detection_at, "display-node state"
+    ):
+        taxa = list(state.prioritized_detection_taxa)
+        watermark = state.last_prioritized_detection_at
+    else:
+        taxa = []
+        watermark = timestamp
+    if selected.taxon_id not in taxa:
+        taxa.append(selected.taxon_id)
+    return watermark, taxa
 
 
 def run_display_cycle(
@@ -265,21 +300,36 @@ def run_display_cycle(
         shuffle_bag_remaining = list(state.shuffle_bag_remaining)
         shuffle_bag_seen = list(state.shuffle_bag_seen)
         prioritized = (
-            _latest_unseen_detection(entries, state.last_prioritized_detection_at)
+            _latest_unseen_detection(
+                entries,
+                state.last_prioritized_detection_at,
+                state.prioritized_detection_taxa,
+            )
             if config.prioritize_latest_detection
             else None
         )
+        prioritized_at = state.last_prioritized_detection_at
+        prioritized_taxa = list(state.prioritized_detection_taxa)
         if prioritized is not None:
             selected = prioritized
+            prioritized_at, prioritized_taxa = _advanced_priority_state(state, selected)
             following_index = state.next_index
             if config.rotation_mode is RotationMode.SEQUENTIAL:
                 next_entry = entries[state.next_index % len(entries)]
                 if next_entry.taxon_id == selected.taxon_id:
                     following_index = (state.next_index + 1) % len(entries)
             elif config.rotation_mode is RotationMode.SHUFFLE:
+                active_taxa = {entry.taxon_id for entry in entries}
                 shuffle_remaining = [
-                    taxon_id for taxon_id in shuffle_remaining if taxon_id != selected.taxon_id
+                    taxon_id
+                    for taxon_id in shuffle_remaining
+                    if taxon_id in active_taxa and taxon_id != selected.taxon_id
                 ]
+                if not shuffle_remaining:
+                    shuffle_remaining = [
+                        entry.taxon_id for entry in entries if entry.taxon_id != selected.taxon_id
+                    ]
+                    (rng or random.SystemRandom()).shuffle(shuffle_remaining)
             elif config.rotation_mode is RotationMode.SHUFFLE_BAG:
                 shuffle_bag_remaining = [
                     taxon_id for taxon_id in shuffle_bag_remaining if taxon_id != selected.taxon_id
@@ -313,11 +363,8 @@ def run_display_cycle(
                 shuffle_bag_remaining=shuffle_bag_remaining,
                 shuffle_bag_seen=shuffle_bag_seen,
                 last_sha256=state.last_sha256,
-                last_prioritized_detection_at=(
-                    selected.latest_detection_at
-                    if prioritized is not None
-                    else state.last_prioritized_detection_at
-                ),
+                last_prioritized_detection_at=prioritized_at,
+                prioritized_detection_taxa=prioritized_taxa,
             )
             return {
                 "display_update": "unchanged",
@@ -344,11 +391,8 @@ def run_display_cycle(
             shuffle_bag_remaining=shuffle_bag_remaining,
             shuffle_bag_seen=shuffle_bag_seen,
             last_sha256=actual_hash,
-            last_prioritized_detection_at=(
-                selected.latest_detection_at
-                if prioritized is not None
-                else state.last_prioritized_detection_at
-            ),
+            last_prioritized_detection_at=prioritized_at,
+            prioritized_detection_taxa=prioritized_taxa,
         )
         return {
             "display_update": "sent",

--- a/src/inky_bird_frame/display_node.py
+++ b/src/inky_bird_frame/display_node.py
@@ -9,6 +9,7 @@ import random
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 from urllib.parse import quote
@@ -20,7 +21,7 @@ from .errors import CatalogError
 from .http import get_bytes, get_json, write_bytes_atomic
 from .selection import select_catalog_entry, select_shuffle_bag_entry
 
-DISPLAY_STATE_SCHEMA_VERSION = 2
+DISPLAY_STATE_SCHEMA_VERSION = 3
 
 
 @dataclass(frozen=True)
@@ -31,6 +32,7 @@ class DisplayState:
     shuffle_remaining: tuple[int, ...] = ()
     shuffle_bag_remaining: tuple[int, ...] = ()
     shuffle_bag_seen: tuple[int, ...] = ()
+    last_prioritized_detection_at: str | None = None
 
 
 @contextmanager
@@ -83,12 +85,15 @@ def parse_catalog_entries(payload: object) -> list[CatalogEntry]:
             raise CatalogError(f"Controller catalog has duplicate taxon ID: {taxon_id}")
         taxon_ids.add(taxon_id)
         observation_count = raw.get("observation_count", 1)
+        latest_detection_at = raw.get("latest_detection_at")
         if (
             not isinstance(observation_count, int)
             or isinstance(observation_count, bool)
             or observation_count < 0
         ):
             raise CatalogError("Controller catalog entry has invalid observation count")
+        if latest_detection_at is not None:
+            _detection_datetime(latest_detection_at, "controller catalog")
         entries.append(
             CatalogEntry(
                 taxon_id=taxon_id,
@@ -101,11 +106,43 @@ def parse_catalog_entries(payload: object) -> list[CatalogEntry]:
                 display_sha256=cast(str, strings["display_sha256"]),
                 approved_at=cast(str, strings["approved_at"]),
                 observation_count=observation_count,
+                latest_detection_at=cast(str | None, latest_detection_at),
             )
         )
     if not entries:
         raise CatalogError("Controller catalog has no approved species")
     return entries
+
+
+def _detection_datetime(value: object, source: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise CatalogError(f"Invalid latest detection timestamp in {source}")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise CatalogError(f"Invalid latest detection timestamp in {source}") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CatalogError(f"Latest detection timestamp must include a timezone in {source}")
+    return parsed.astimezone(UTC)
+
+
+def _latest_unseen_detection(
+    entries: list[CatalogEntry], last_prioritized_at: str | None
+) -> CatalogEntry | None:
+    watermark = (
+        _detection_datetime(last_prioritized_at, "display-node state")
+        if last_prioritized_at is not None
+        else None
+    )
+    candidates = [
+        (_detection_datetime(entry.latest_detection_at, "controller catalog"), entry)
+        for entry in entries
+        if entry.latest_detection_at is not None
+    ]
+    unseen = [item for item in candidates if watermark is None or item[0] > watermark]
+    if not unseen:
+        return None
+    return max(unseen, key=lambda item: (item[0], -item[1].taxon_id))[1]
 
 
 def _state_taxon_ids(raw: object, path: Path) -> tuple[int, ...]:
@@ -131,7 +168,7 @@ def _read_state(path: Path) -> DisplayState:
     if (
         not isinstance(schema_version, int)
         or isinstance(schema_version, bool)
-        or schema_version not in {1, DISPLAY_STATE_SCHEMA_VERSION}
+        or schema_version not in {1, 2, DISPLAY_STATE_SCHEMA_VERSION}
     ):
         raise CatalogError(f"Invalid display-node state: {path}")
     if schema_version == DISPLAY_STATE_SCHEMA_VERSION and any(
@@ -143,6 +180,7 @@ def _read_state(path: Path) -> DisplayState:
             "shuffle_remaining",
             "shuffle_bag_remaining",
             "shuffle_bag_seen",
+            "last_prioritized_detection_at",
         )
     ):
         raise CatalogError(f"Invalid display-node state: {path}")
@@ -152,6 +190,7 @@ def _read_state(path: Path) -> DisplayState:
     shuffle_remaining = _state_taxon_ids(raw.get("shuffle_remaining", []), path)
     shuffle_bag_remaining = _state_taxon_ids(raw.get("shuffle_bag_remaining", []), path)
     shuffle_bag_seen = _state_taxon_ids(raw.get("shuffle_bag_seen", []), path)
+    last_prioritized_detection_at = raw.get("last_prioritized_detection_at")
     if (
         not isinstance(next_index, int)
         or isinstance(next_index, bool)
@@ -166,8 +205,14 @@ def _read_state(path: Path) -> DisplayState:
             )
         )
         or set(shuffle_bag_remaining) & set(shuffle_bag_seen)
+        or (
+            last_prioritized_detection_at is not None
+            and not isinstance(last_prioritized_detection_at, str)
+        )
     ):
         raise CatalogError(f"Invalid display-node state: {path}")
+    if isinstance(last_prioritized_detection_at, str):
+        _detection_datetime(last_prioritized_detection_at, "display-node state")
     return DisplayState(
         next_index=next_index,
         last_sha256=last_sha256,
@@ -175,6 +220,7 @@ def _read_state(path: Path) -> DisplayState:
         shuffle_remaining=shuffle_remaining,
         shuffle_bag_remaining=shuffle_bag_remaining,
         shuffle_bag_seen=shuffle_bag_seen,
+        last_prioritized_detection_at=last_prioritized_detection_at,
     )
 
 
@@ -187,6 +233,7 @@ def _write_state(
     shuffle_bag_remaining: list[int],
     shuffle_bag_seen: list[int],
     last_sha256: str,
+    last_prioritized_detection_at: str | None,
 ) -> None:
     write_json_atomic(
         path,
@@ -198,6 +245,7 @@ def _write_state(
             "shuffle_remaining": shuffle_remaining,
             "shuffle_bag_remaining": shuffle_bag_remaining,
             "shuffle_bag_seen": shuffle_bag_seen,
+            "last_prioritized_detection_at": last_prioritized_detection_at,
         },
     )
 
@@ -216,7 +264,29 @@ def run_display_cycle(
         shuffle_remaining = list(state.shuffle_remaining)
         shuffle_bag_remaining = list(state.shuffle_bag_remaining)
         shuffle_bag_seen = list(state.shuffle_bag_seen)
-        if config.rotation_mode is RotationMode.SHUFFLE_BAG:
+        prioritized = (
+            _latest_unseen_detection(entries, state.last_prioritized_detection_at)
+            if config.prioritize_latest_detection
+            else None
+        )
+        if prioritized is not None:
+            selected = prioritized
+            following_index = state.next_index
+            if config.rotation_mode is RotationMode.SEQUENTIAL:
+                next_entry = entries[state.next_index % len(entries)]
+                if next_entry.taxon_id == selected.taxon_id:
+                    following_index = (state.next_index + 1) % len(entries)
+            elif config.rotation_mode is RotationMode.SHUFFLE:
+                shuffle_remaining = [
+                    taxon_id for taxon_id in shuffle_remaining if taxon_id != selected.taxon_id
+                ]
+            elif config.rotation_mode is RotationMode.SHUFFLE_BAG:
+                shuffle_bag_remaining = [
+                    taxon_id for taxon_id in shuffle_bag_remaining if taxon_id != selected.taxon_id
+                ]
+                if selected.taxon_id not in shuffle_bag_seen:
+                    shuffle_bag_seen.append(selected.taxon_id)
+        elif config.rotation_mode is RotationMode.SHUFFLE_BAG:
             selected, shuffle_bag_remaining, shuffle_bag_seen = select_shuffle_bag_entry(
                 entries,
                 last_taxon_id=state.last_taxon_id,
@@ -243,11 +313,17 @@ def run_display_cycle(
                 shuffle_bag_remaining=shuffle_bag_remaining,
                 shuffle_bag_seen=shuffle_bag_seen,
                 last_sha256=state.last_sha256,
+                last_prioritized_detection_at=(
+                    selected.latest_detection_at
+                    if prioritized is not None
+                    else state.last_prioritized_detection_at
+                ),
             )
             return {
                 "display_update": "unchanged",
                 "taxon_id": selected.taxon_id,
                 "common_name": selected.common_name,
+                "selection_reason": ("latest_detection" if prioritized is not None else "rotation"),
             }
 
         encoded_path = quote(selected.display_path, safe="/")
@@ -268,6 +344,11 @@ def run_display_cycle(
             shuffle_bag_remaining=shuffle_bag_remaining,
             shuffle_bag_seen=shuffle_bag_seen,
             last_sha256=actual_hash,
+            last_prioritized_detection_at=(
+                selected.latest_detection_at
+                if prioritized is not None
+                else state.last_prioritized_detection_at
+            ),
         )
         return {
             "display_update": "sent",
@@ -275,4 +356,5 @@ def run_display_cycle(
             "common_name": selected.common_name,
             "display_size": display_size,
             "sha256": actual_hash,
+            "selection_reason": "latest_detection" if prioritized is not None else "rotation",
         }

--- a/tests/test_birds.py
+++ b/tests/test_birds.py
@@ -373,6 +373,24 @@ class BirdWeatherTests(unittest.TestCase):
         with self.assertRaisesRegex(DataSourceError, "not successful"):
             parse_birdweather_species({"success": False})
 
+    def test_parse_species_rejects_invalid_detection_timestamp(self) -> None:
+        payload = {
+            "success": True,
+            "species": [
+                {
+                    "id": 42,
+                    "commonName": "Eastern Bluebird",
+                    "scientificName": "Sialia sialis",
+                    "classification": "avian",
+                    "detections": {"total": 7},
+                    "latestDetectionAt": "not-a-timestamp",
+                }
+            ],
+        }
+
+        with self.assertRaisesRegex(DataSourceError, "usable avian species"):
+            parse_birdweather_species(payload)
+
     @patch("inky_bird_frame.birds.get_json", return_value={"success": True, "species": []})
     def test_fetch_species_bounds_window_and_redacts_token(self, get_json: MagicMock) -> None:
         fetch_birdweather_species(
@@ -398,7 +416,7 @@ class BirdWeatherTests(unittest.TestCase):
             7,
             "2026-07-12T08:15:00-04:00",
         )
-        match = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 1, "eBird")
+        match = BirdSpecies(12942, "Eastern Bluebird", "Sialia canonicalis", 1, "eBird")
         with TemporaryDirectory() as temporary:
             cache = Path(temporary) / "crosswalk.json"
             with patch("inky_bird_frame.birds.fetch_inaturalist_taxon_match", return_value=match):
@@ -406,8 +424,10 @@ class BirdWeatherTests(unittest.TestCase):
 
         self.assertEqual(unresolved, [])
         self.assertEqual(species[0].taxon_id, 12942)
+        self.assertEqual(species[0].scientific_name, "Sialia canonicalis")
         self.assertEqual(species[0].observation_count, 7)
         self.assertEqual(species[0].sources, ("BirdWeather",))
+        self.assertEqual(species[0].latest_detection_at, detection.latest_detection_at)
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,6 +67,7 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(config.controller.max_generation_attempts, 3)
         self.assertEqual(config.display_node.controller_url, "http://controller.test:8793")
         self.assertEqual(config.display_node.rotation_mode, RotationMode.WEIGHTED)
+        self.assertTrue(config.display_node.prioritize_latest_detection)
         self.assertTrue(config.public_catalog.enabled)
         self.assertEqual(
             config.public_catalog.checkout_dir,
@@ -343,6 +344,18 @@ class ConfigTests(unittest.TestCase):
             config = load_config(path)
 
         self.assertEqual(config.display_node.rotation_mode, RotationMode.SHUFFLE_BAG)
+
+    def test_can_disable_latest_detection_priority(self) -> None:
+        configured = CONFIG.replace(
+            'rotation_mode = "weighted"',
+            'rotation_mode = "weighted"\nprioritize_latest_detection = false',
+        )
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(configured)
+            config = load_config(path)
+
+        self.assertFalse(config.display_node.prioritize_latest_detection)
 
     def test_loads_research_queue_and_notification_settings(self) -> None:
         configured = (

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -492,7 +492,14 @@ class ControllerTests(unittest.TestCase):
     def test_refresh_writes_only_observed_approved_species_to_private_active_catalog(
         self,
     ) -> None:
-        observed = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 9, "iNaturalist")
+        observed = BirdSpecies(
+            12942,
+            "Eastern Bluebird",
+            "Sialia sialis",
+            9,
+            "BirdWeather",
+            latest_detection_at="2026-07-13T08:10:00-04:00",
+        )
         unapproved = BirdSpecies(
             7513, "Carolina Wren", "Thryothorus ludovicianus", 4, "iNaturalist"
         )
@@ -529,9 +536,11 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(result["active_approved_count"], 1)
         self.assertEqual(active["species"][0]["taxon_id"], 12942)
         self.assertEqual(active["species"][0]["observation_count"], 9)
+        self.assertEqual(active["species"][0]["latest_detection_at"], "2026-07-13T08:10:00-04:00")
         self.assertNotIn("zip_code", active)
         self.assertEqual(len(snapshot["species"]), 2)
-        self.assertEqual(snapshot["species"][0]["source"], "iNaturalist")
+        self.assertEqual(snapshot["species"][0]["source"], "BirdWeather")
+        self.assertEqual(snapshot["species"][0]["latest_detection_at"], "2026-07-13T08:10:00-04:00")
 
     def test_refresh_preserves_approved_catalog_order(self) -> None:
         first = BirdSpecies(1, "Alpha Bird", "Alpha avis", 2, "iNaturalist")

--- a/tests/test_display_node.py
+++ b/tests/test_display_node.py
@@ -291,6 +291,56 @@ class DisplayNodeTests(unittest.TestCase):
         self.assertEqual((first["taxon_id"], first["selection_reason"]), (1, "latest_detection"))
         self.assertEqual((second["taxon_id"], second["selection_reason"]), (2, "rotation"))
 
+    def test_equal_latest_detection_timestamps_are_each_prioritized(self) -> None:
+        images = {1: b"one", 2: b"two", 3: b"three"}
+        payload = catalog_payload(images)
+        species = payload["species"]
+        assert isinstance(species, list)
+        species[0]["latest_detection_at"] = "2026-07-13T08:10:00-04:00"
+        species[1]["latest_detection_at"] = "2026-07-13T12:10:00+00:00"
+        with TemporaryDirectory() as temporary:
+            state_path = Path(temporary) / "state.json"
+            config = DisplayNodeConfig("http://controller.test", Path(temporary))
+            with (
+                patch("inky_bird_frame.display_node.get_json", return_value=payload),
+                patch("inky_bird_frame.display_node.get_bytes", side_effect=asset_response(images)),
+                patch("inky_bird_frame.display_node.show_on_inky", return_value=(1600, 1200)),
+            ):
+                first = run_display_cycle(config)
+                second = run_display_cycle(config)
+                third = run_display_cycle(config)
+                state = json.loads(state_path.read_text())
+
+        self.assertEqual((first["taxon_id"], first["selection_reason"]), (1, "latest_detection"))
+        self.assertEqual((second["taxon_id"], second["selection_reason"]), (2, "latest_detection"))
+        self.assertEqual(third["selection_reason"], "rotation")
+        self.assertEqual(state["prioritized_detection_taxa"], [1, 2])
+
+    def test_latest_detection_seeds_empty_shuffle_without_selected_taxon(self) -> None:
+        images = {1: b"one", 2: b"two", 3: b"three"}
+        payload = catalog_payload(images)
+        species = payload["species"]
+        assert isinstance(species, list)
+        species[1]["latest_detection_at"] = "2026-07-13T08:10:00-04:00"
+        with TemporaryDirectory() as temporary:
+            state_path = Path(temporary) / "state.json"
+            config = DisplayNodeConfig(
+                "http://controller.test", Path(temporary), RotationMode.SHUFFLE
+            )
+            with (
+                patch("inky_bird_frame.display_node.get_json", return_value=payload),
+                patch("inky_bird_frame.display_node.get_bytes", side_effect=asset_response(images)),
+                patch("inky_bird_frame.display_node.show_on_inky", return_value=(1600, 1200)),
+            ):
+                first = run_display_cycle(config, rng=random.Random(3))
+                state = json.loads(state_path.read_text())
+                second = run_display_cycle(config, rng=random.Random(3))
+                third = run_display_cycle(config, rng=random.Random(3))
+
+        self.assertEqual((first["taxon_id"], first["selection_reason"]), (2, "latest_detection"))
+        self.assertCountEqual(state["shuffle_remaining"], [1, 3])
+        self.assertNotIn(2, {second["taxon_id"], third["taxon_id"]})
+
     def test_latest_detection_failure_does_not_consume_watermark(self) -> None:
         images = {1: b"one", 2: b"two"}
         payload = catalog_payload(images)

--- a/tests/test_display_node.py
+++ b/tests/test_display_node.py
@@ -128,7 +128,7 @@ class DisplayNodeTests(unittest.TestCase):
 
         self.assertEqual(unchanged["display_update"], "unchanged")
         self.assertEqual(updated["taxon_id"], 2)
-        self.assertEqual(state["schema_version"], 2)
+        self.assertEqual(state["schema_version"], 3)
         get_bytes.assert_called_once()
 
     def test_shuffle_bag_persists_across_cycles_without_replacement(self) -> None:
@@ -150,7 +150,7 @@ class DisplayNodeTests(unittest.TestCase):
                 state = json.loads((Path(temporary) / "state.json").read_text())
 
         self.assertNotEqual(first["taxon_id"], second["taxon_id"])
-        self.assertEqual(state["schema_version"], 2)
+        self.assertEqual(state["schema_version"], 3)
         self.assertEqual(len(state["shuffle_bag_seen"]), 2)
         self.assertEqual(len(state["shuffle_bag_remaining"]), 1)
 
@@ -228,10 +228,10 @@ class DisplayNodeTests(unittest.TestCase):
             state_path.write_text(json.dumps({"next_index": 1, "shuffle_remaining": [2]}))
             legacy = _read_state(state_path)
 
-            state_path.write_text(json.dumps({"schema_version": 3}))
+            state_path.write_text(json.dumps({"schema_version": 4}))
             with self.assertRaises(CatalogError):
                 _read_state(state_path)
-            state_path.write_text(json.dumps({"schema_version": 2}))
+            state_path.write_text(json.dumps({"schema_version": 3}))
             with self.assertRaises(CatalogError):
                 _read_state(state_path)
             state_path.write_text(json.dumps({"shuffle_bag_remaining": [1, 1]}))
@@ -246,6 +246,137 @@ class DisplayNodeTests(unittest.TestCase):
 
         self.assertEqual(legacy.next_index, 1)
         self.assertEqual(legacy.shuffle_remaining, (2,))
+
+    def test_latest_detection_preempts_rotation_once_then_newer_detection_preempts(self) -> None:
+        images = {1: b"one", 2: b"two", 3: b"three"}
+        payload = catalog_payload(images)
+        species = payload["species"]
+        assert isinstance(species, list)
+        species[1]["latest_detection_at"] = "2026-07-13T08:00:00-04:00"
+        species[2]["latest_detection_at"] = "2026-07-13T08:05:00-04:00"
+        with TemporaryDirectory() as temporary:
+            config = DisplayNodeConfig("http://controller.test", Path(temporary))
+            with (
+                patch("inky_bird_frame.display_node.get_json", return_value=payload),
+                patch("inky_bird_frame.display_node.get_bytes", side_effect=asset_response(images)),
+                patch("inky_bird_frame.display_node.show_on_inky", return_value=(1600, 1200)),
+            ):
+                first = run_display_cycle(config)
+                second = run_display_cycle(config)
+                species[1]["latest_detection_at"] = "2026-07-13T08:10:00-04:00"
+                third = run_display_cycle(config)
+                state = json.loads((Path(temporary) / "state.json").read_text())
+
+        self.assertEqual((first["taxon_id"], first["selection_reason"]), (3, "latest_detection"))
+        self.assertEqual((second["taxon_id"], second["selection_reason"]), (1, "rotation"))
+        self.assertEqual((third["taxon_id"], third["selection_reason"]), (2, "latest_detection"))
+        self.assertEqual(state["last_prioritized_detection_at"], "2026-07-13T08:10:00-04:00")
+
+    def test_latest_detection_does_not_repeat_when_it_is_next_in_sequence(self) -> None:
+        images = {1: b"one", 2: b"two"}
+        payload = catalog_payload(images)
+        species = payload["species"]
+        assert isinstance(species, list)
+        species[0]["latest_detection_at"] = "2026-07-13T08:10:00-04:00"
+        with TemporaryDirectory() as temporary:
+            config = DisplayNodeConfig("http://controller.test", Path(temporary))
+            with (
+                patch("inky_bird_frame.display_node.get_json", return_value=payload),
+                patch("inky_bird_frame.display_node.get_bytes", side_effect=asset_response(images)),
+                patch("inky_bird_frame.display_node.show_on_inky", return_value=(1600, 1200)),
+            ):
+                first = run_display_cycle(config)
+                second = run_display_cycle(config)
+
+        self.assertEqual((first["taxon_id"], first["selection_reason"]), (1, "latest_detection"))
+        self.assertEqual((second["taxon_id"], second["selection_reason"]), (2, "rotation"))
+
+    def test_latest_detection_failure_does_not_consume_watermark(self) -> None:
+        images = {1: b"one", 2: b"two"}
+        payload = catalog_payload(images)
+        species = payload["species"]
+        assert isinstance(species, list)
+        species[1]["latest_detection_at"] = "2026-07-13T08:10:00-04:00"
+        with TemporaryDirectory() as temporary:
+            state_path = Path(temporary) / "state.json"
+            config = DisplayNodeConfig("http://controller.test", Path(temporary))
+            with (
+                patch("inky_bird_frame.display_node.get_json", return_value=payload),
+                patch("inky_bird_frame.display_node.get_bytes", side_effect=asset_response(images)),
+                patch(
+                    "inky_bird_frame.display_node.show_on_inky", side_effect=OSError("panel failed")
+                ),
+                self.assertRaisesRegex(OSError, "panel failed"),
+            ):
+                run_display_cycle(config)
+
+            self.assertFalse(state_path.exists())
+
+    def test_latest_detection_counts_as_shown_in_shuffle_bag(self) -> None:
+        images = {1: b"one", 2: b"two", 3: b"three"}
+        payload = catalog_payload(images)
+        species = payload["species"]
+        assert isinstance(species, list)
+        species[2]["latest_detection_at"] = "2026-07-13T08:10:00-04:00"
+        initial_state = {
+            "schema_version": 2,
+            "next_index": 0,
+            "last_sha256": hashlib.sha256(images[1]).hexdigest(),
+            "last_taxon_id": 1,
+            "shuffle_remaining": [],
+            "shuffle_bag_remaining": [2, 3],
+            "shuffle_bag_seen": [1],
+        }
+        with TemporaryDirectory() as temporary:
+            state_path = Path(temporary) / "state.json"
+            state_path.write_text(json.dumps(initial_state))
+            config = DisplayNodeConfig(
+                "http://controller.test", Path(temporary), RotationMode.SHUFFLE_BAG
+            )
+            with (
+                patch("inky_bird_frame.display_node.get_json", return_value=payload),
+                patch("inky_bird_frame.display_node.get_bytes", side_effect=asset_response(images)),
+                patch("inky_bird_frame.display_node.show_on_inky", return_value=(1600, 1200)),
+            ):
+                result = run_display_cycle(config, rng=random.Random(1))
+                state = json.loads(state_path.read_text())
+
+        self.assertEqual((result["taxon_id"], result["selection_reason"]), (3, "latest_detection"))
+        self.assertEqual(state["shuffle_bag_remaining"], [2])
+        self.assertEqual(state["shuffle_bag_seen"], [1, 3])
+
+    def test_latest_detection_priority_can_be_disabled(self) -> None:
+        images = {1: b"one", 2: b"two"}
+        payload = catalog_payload(images)
+        species = payload["species"]
+        assert isinstance(species, list)
+        species[1]["latest_detection_at"] = "2026-07-13T08:10:00-04:00"
+        with TemporaryDirectory() as temporary:
+            config = DisplayNodeConfig(
+                "http://controller.test",
+                Path(temporary),
+                prioritize_latest_detection=False,
+            )
+            with (
+                patch("inky_bird_frame.display_node.get_json", return_value=payload),
+                patch("inky_bird_frame.display_node.get_bytes", side_effect=asset_response(images)),
+                patch("inky_bird_frame.display_node.show_on_inky", return_value=(1600, 1200)),
+            ):
+                result = run_display_cycle(config)
+
+        self.assertEqual((result["taxon_id"], result["selection_reason"]), (1, "rotation"))
+
+    def test_rejects_invalid_or_timezone_free_detection_timestamps(self) -> None:
+        payload = catalog_payload({1: b"one"})
+        species = payload["species"]
+        assert isinstance(species, list)
+        species[0]["latest_detection_at"] = "not-a-timestamp"
+        with self.assertRaisesRegex(CatalogError, "latest detection timestamp"):
+            parse_catalog_entries(payload)
+
+        species[0]["latest_detection_at"] = "2026-07-13T08:10:00"
+        with self.assertRaisesRegex(CatalogError, "timezone"):
+            parse_catalog_entries(payload)
 
     def test_rejects_duplicate_or_empty_catalogs(self) -> None:
         payload = catalog_payload({1: b"one"})


### PR DESCRIPTION
## Summary
- preserve validated BirdWeather detection timestamps in the private active catalog
- show the newest unconsumed detection once before normal rotation
- persist a durable watermark and reconcile sequential, shuffle, and shuffle-bag state
- keep the public catalog location-neutral and make prioritization configurable

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest` (243 passed, 4 subtests)
- `uv run inky-bird-frame catalog validate --catalog catalog`
- `actionlint`
