### PR TITLE
Harden crash recovery, health checks, and failure visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,10 @@ Every approved species lives under `catalog/species/<taxon-id>-<slug>/`:
 - `display.png`: hardware-ready `1600x1200` image
 - `manifest.json`: facts, research and review sources, reference provenance,
   quality scores, generation metadata, and SHA-256 checksums
+- `profile.json`: factual species profile matching the manifest, when produced
+  by the current pipeline
+- `quality-review.json`: sourced review matching the manifest, when produced by
+  the current pipeline
 
 Downloaded source photographs, run logs, pending work, rejected work, and
 display state stay under ignored runtime storage. Reference licenses and source

--- a/config.example.toml
+++ b/config.example.toml
@@ -108,7 +108,7 @@ max_delivery_attempts = 20
 
 # Keep real service URLs only in your private config.toml. Choose url or url_env, not both.
 # Events: discovery, generation_approved, terminal_error, degraded, recovered,
-# publication_error, publication_recovered.
+# publication_error, publication_recovered, display_stale, display_recovered.
 
 # [[notifications.destinations]]
 # name = "pushover"

--- a/deploy/install-controller.sh
+++ b/deploy/install-controller.sh
@@ -295,12 +295,10 @@ if [ -f "${catalog_publish_plist}" ]; then
 fi
 
 launchctl bootout "gui/${uid}/com.inky-bird-frame.serve" 2>/dev/null || true
-launchctl bootout "gui/${uid}/com.inky-bird-frame.controller-cycle" 2>/dev/null || true
 launchctl bootout "gui/${uid}/com.inky-bird-frame.refresh" 2>/dev/null || true
 launchctl bootout "gui/${uid}/com.inky-bird-frame.generate" 2>/dev/null || true
 launchctl bootout "gui/${uid}/com.inky-bird-frame.catalog-publish" 2>/dev/null || true
 launchctl bootout "gui/${uid}/com.inky-bird-frame.notifications" 2>/dev/null || true
-rm -f "${legacy_cycle_plist}"
 launchctl bootstrap "gui/${uid}" "${serve_plist}"
 launchctl bootstrap "gui/${uid}" "${refresh_plist}"
 launchctl bootstrap "gui/${uid}" "${generation_plist}"
@@ -321,6 +319,10 @@ if [ -f "${notifications_plist}" ]; then
 fi
 
 installation_complete=true
+# Remove the legacy single-agent layout only after the new agents verified,
+# so a failed upgrade leaves the previous controller runnable.
+launchctl bootout "gui/${uid}/com.inky-bird-frame.controller-cycle" 2>/dev/null || true
+rm -f "${legacy_cycle_plist}"
 echo "Controller installed from ${root} into ${app_dir}."
 echo "Configuration: ${config_path}"
 echo "Logs: ${log_dir}"

--- a/deploy/install-controller.sh
+++ b/deploy/install-controller.sh
@@ -90,13 +90,36 @@ uid=$(id -u)
 plist_backup_dir=$(mktemp -d "${support_dir}/launchd-restore.XXXXXX")
 previously_loaded_labels=()
 installation_complete=false
+was_previously_loaded() {
+  local target=$1
+  local loaded
+  if [ "${#previously_loaded_labels[@]}" -gt 0 ]; then
+    for loaded in "${previously_loaded_labels[@]}"; do
+      if [ "${loaded}" = "${target}" ]; then
+        return 0
+      fi
+    done
+  fi
+  return 1
+}
+
 cleanup() {
   status=$?
   trap - EXIT
-  if [ "${installation_complete}" != true ] \
-    && [ "${#previously_loaded_labels[@]}" -gt 0 ]; then
-    for label in "${previously_loaded_labels[@]}"; do
-      restore_previous_agent "${label}"
+  if [ "${installation_complete}" != true ]; then
+    for label in serve refresh generate catalog-publish notifications; do
+      if was_previously_loaded "${label}"; then
+        restore_previous_agent "${label}"
+      else
+        # Not running before this install: undo any half-installed agent.
+        launchctl bootout "gui/${uid}/com.inky-bird-frame.${label}" 2>/dev/null || true
+        if [ -f "${plist_backup_dir}/com.inky-bird-frame.${label}.plist" ]; then
+          cp "${plist_backup_dir}/com.inky-bird-frame.${label}.plist" \
+            "${agents_dir}/com.inky-bird-frame.${label}.plist" || true
+        else
+          rm -f "${agents_dir}/com.inky-bird-frame.${label}.plist"
+        fi
+      fi
     done
   fi
   rm -rf "${plist_backup_dir}"

--- a/deploy/install-controller.sh
+++ b/deploy/install-controller.sh
@@ -48,6 +48,24 @@ restore_catalog_publisher_schedule() {
   rmdir "${recovery_dir}"
 }
 
+restore_previous_agent() {
+  local label=$1
+  local plist="${agents_dir}/com.inky-bird-frame.${label}.plist"
+  local backup="${plist_backup_dir}/com.inky-bird-frame.${label}.plist"
+  if launchctl print "gui/${uid}/com.inky-bird-frame.${label}" >/dev/null 2>&1; then
+    return 0
+  fi
+  if [ ! -f "${backup}" ]; then
+    return 0
+  fi
+  cp "${backup}" "${plist}" || return 0
+  if [ "${label}" = "catalog-publish" ]; then
+    restore_catalog_publisher_schedule "${uid}" || true
+  else
+    launchctl bootstrap "gui/${uid}" "${plist}" || true
+  fi
+}
+
 if [ ! -f "${config_path}" ]; then
   echo "Controller configuration is missing: ${config_path}" >&2
   exit 1
@@ -68,6 +86,34 @@ if [ "${root}" != "${app_dir}" ]; then
 fi
 
 "${uv_bin}" sync --project "${app_dir}" --python "${python_version}" --extra controller --locked
+
+uid=$(id -u)
+plist_backup_dir=$(mktemp -d "${support_dir}/launchd-restore.XXXXXX")
+previously_loaded_labels=()
+installation_complete=false
+cleanup() {
+  status=$?
+  trap - EXIT
+  if [ "${installation_complete}" != true ] \
+    && [ "${#previously_loaded_labels[@]}" -gt 0 ]; then
+    for label in "${previously_loaded_labels[@]}"; do
+      restore_previous_agent "${label}"
+    done
+  fi
+  rm -rf "${plist_backup_dir}"
+  exit "${status}"
+}
+trap cleanup EXIT
+
+for label in serve refresh generate catalog-publish notifications; do
+  if launchctl print "gui/${uid}/com.inky-bird-frame.${label}" >/dev/null 2>&1; then
+    previously_loaded_labels+=("${label}")
+  fi
+  plist="${agents_dir}/com.inky-bird-frame.${label}.plist"
+  if [ -f "${plist}" ]; then
+    cp "${plist}" "${plist_backup_dir}/"
+  fi
+done
 
 "${app_dir}/.venv/bin/python" - \
   "${serve_plist}" "${refresh_plist}" "${generation_plist}" "${catalog_publish_plist}" \
@@ -211,7 +257,6 @@ else:
     notifications_path.unlink(missing_ok=True)
 PY
 
-uid=$(id -u)
 if [ -f "${catalog_publish_plist}" ]; then
   publisher_was_loaded=false
   if launchctl print "gui/${uid}/com.inky-bird-frame.catalog-publish" >/dev/null 2>&1; then
@@ -253,6 +298,7 @@ if [ -f "${notifications_plist}" ]; then
   launchctl print "gui/${uid}/com.inky-bird-frame.notifications" >/dev/null
 fi
 
+installation_complete=true
 echo "Controller installed from ${root} into ${app_dir}."
 echo "Configuration: ${config_path}"
 echo "Logs: ${log_dir}"

--- a/deploy/install-controller.sh
+++ b/deploy/install-controller.sh
@@ -52,12 +52,11 @@ restore_previous_agent() {
   local label=$1
   local plist="${agents_dir}/com.inky-bird-frame.${label}.plist"
   local backup="${plist_backup_dir}/com.inky-bird-frame.${label}.plist"
-  if launchctl print "gui/${uid}/com.inky-bird-frame.${label}" >/dev/null 2>&1; then
-    return 0
-  fi
   if [ ! -f "${backup}" ]; then
     return 0
   fi
+  # A loaded label here is the failed replacement; put the saved agent back.
+  launchctl bootout "gui/${uid}/com.inky-bird-frame.${label}" 2>/dev/null || true
   cp "${backup}" "${plist}" || return 0
   if [ "${label}" = "catalog-publish" ]; then
     restore_catalog_publisher_schedule "${uid}" || true

--- a/deploy/uninstall-controller-systemd.sh
+++ b/deploy/uninstall-controller-systemd.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(uname -s)" != "Linux" ] || ! command -v systemctl >/dev/null 2>&1; then
+  echo "Controller uninstaller requires Linux with systemd." >&2
+  exit 1
+fi
+
+app_dir=${INKY_BIRD_APP_DIR:-"${HOME}/Services/inky-bird-frame"}
+support_dir=${INKY_BIRD_SUPPORT_DIR:-"${HOME}/.config/inky-bird-frame"}
+config_path=${INKY_BIRD_CONFIG_PATH:-"${support_dir}/config.toml"}
+
+if ! sudo -v; then
+  echo "Administrator access is required to remove system services." >&2
+  exit 1
+fi
+
+for name in refresh generate catalog-publish notifications; do
+  timer="inky-bird-frame-${name}.timer"
+  service="inky-bird-frame-${name}.service"
+  sudo systemctl disable --now "${timer}" 2>/dev/null || true
+  echo "Stopped and disabled ${timer}."
+  sudo systemctl stop "${service}" 2>/dev/null || true
+  echo "Stopped ${service}."
+done
+sudo systemctl disable --now inky-bird-frame-controller.service 2>/dev/null || true
+echo "Stopped and disabled inky-bird-frame-controller.service."
+
+for name in controller refresh generate catalog-publish notifications; do
+  for unit in "inky-bird-frame-${name}.service" "inky-bird-frame-${name}.timer"; do
+    if [ -f "/etc/systemd/system/${unit}" ]; then
+      sudo rm -f "/etc/systemd/system/${unit}"
+      echo "Removed /etc/systemd/system/${unit}."
+    fi
+  done
+done
+sudo systemctl daemon-reload
+echo "Reloaded the systemd unit configuration."
+
+echo "Controller services uninstalled."
+echo "Intentionally left in place:"
+echo "  Application runtime and managed catalog: ${app_dir}"
+echo "  Configuration: ${config_path}"
+echo "  Support data: ${support_dir}"
+echo "  Workspace, state, and catalog directories configured in ${config_path}"
+echo "Remove those paths manually if you no longer need the controller data."

--- a/deploy/uninstall-controller.sh
+++ b/deploy/uninstall-controller.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "Controller uninstaller currently supports macOS." >&2
+  exit 1
+fi
+
+app_dir=${INKY_BIRD_APP_DIR:-"${HOME}/Services/inky-bird-frame"}
+support_dir=${INKY_BIRD_SUPPORT_DIR:-"${HOME}/Library/Application Support/Inky Bird Frame"}
+config_path=${INKY_BIRD_CONFIG_PATH:-"${support_dir}/config.toml"}
+agents_dir="${HOME}/Library/LaunchAgents"
+uid=$(id -u)
+
+for label in serve refresh generate catalog-publish notifications; do
+  agent="com.inky-bird-frame.${label}"
+  plist="${agents_dir}/${agent}.plist"
+  if launchctl print "gui/${uid}/${agent}" >/dev/null 2>&1; then
+    launchctl bootout "gui/${uid}/${agent}"
+    echo "Booted out LaunchAgent: ${agent}"
+  else
+    echo "LaunchAgent is not loaded: ${agent}"
+  fi
+  if [ -f "${plist}" ]; then
+    rm -f "${plist}"
+    echo "Removed plist: ${plist}"
+  else
+    echo "Plist is not installed: ${plist}"
+  fi
+done
+
+echo "Controller LaunchAgents uninstalled."
+echo "Intentionally left in place:"
+echo "  Application runtime and managed catalog: ${app_dir}"
+echo "  Configuration: ${config_path}"
+echo "  Logs and support data: ${support_dir}"
+echo "  Workspace, state, and catalog directories configured in ${config_path}"
+echo "Remove those paths manually if you no longer need the controller data."

--- a/deploy/uninstall-controller.sh
+++ b/deploy/uninstall-controller.sh
@@ -12,7 +12,8 @@ config_path=${INKY_BIRD_CONFIG_PATH:-"${support_dir}/config.toml"}
 agents_dir="${HOME}/Library/LaunchAgents"
 uid=$(id -u)
 
-for label in serve refresh generate catalog-publish notifications; do
+# controller-cycle is the legacy single-agent layout replaced by the labels below.
+for label in serve refresh generate catalog-publish notifications controller-cycle; do
   agent="com.inky-bird-frame.${label}"
   plist="${agents_dir}/${agent}.plist"
   if launchctl print "gui/${uid}/${agent}" >/dev/null 2>&1; then

--- a/deploy/uninstall-display-local.sh
+++ b/deploy/uninstall-display-local.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(uname -s)" != "Linux" ] || ! command -v systemctl >/dev/null 2>&1; then
+  echo "Display uninstaller requires Linux with systemd." >&2
+  exit 1
+fi
+
+app_dir=${INKY_BIRD_APP_DIR:-"${HOME}/Services/inky-bird-frame"}
+support_dir=${INKY_BIRD_SUPPORT_DIR:-"${HOME}/.config/inky-bird-frame"}
+config_path=${INKY_BIRD_CONFIG_PATH:-"${support_dir}/config.toml"}
+venv=${INKY_BIRD_DISPLAY_VENV:-"${HOME}/.virtualenvs/pimoroni"}
+noninteractive_sudo=${INKY_BIRD_NONINTERACTIVE_SUDO:-false}
+
+sudo_command=(sudo)
+case "${noninteractive_sudo}" in
+  true)
+    sudo_command+=(-n)
+    ;;
+  false)
+    if ! sudo -v; then
+      echo "Administrator access is required to remove the display service." >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "INKY_BIRD_NONINTERACTIVE_SUDO must be true or false." >&2
+    exit 1
+    ;;
+esac
+
+"${sudo_command[@]}" systemctl disable --now inky-bird-frame-display.timer 2>/dev/null || true
+echo "Stopped and disabled inky-bird-frame-display.timer."
+"${sudo_command[@]}" systemctl stop inky-bird-frame-display.service 2>/dev/null || true
+echo "Stopped inky-bird-frame-display.service."
+
+for unit in inky-bird-frame-display.service inky-bird-frame-display.timer; do
+  if [ -f "/etc/systemd/system/${unit}" ]; then
+    "${sudo_command[@]}" rm -f "/etc/systemd/system/${unit}"
+    echo "Removed /etc/systemd/system/${unit}."
+  fi
+done
+"${sudo_command[@]}" systemctl daemon-reload
+echo "Reloaded the systemd unit configuration."
+
+echo "Display node services uninstalled."
+echo "Intentionally left in place:"
+echo "  Application runtime and catalog copy: ${app_dir}"
+echo "  Configuration: ${config_path}"
+echo "  Pimoroni Python environment: ${venv}"
+echo "  Display state directory configured in ${config_path}"
+echo "Remove those paths manually if you no longer need the display data."

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,8 +63,10 @@ The controller also exposes a read-only HTTP catalog:
 `/health` reports approved and active species counts from the last built
 catalog index and never rebuilds it, so a health check answers cheaply at any
 catalog size. The server also records the time of the last `/v1/catalog`
-fetch in `display-last-fetch.json` under `state_dir`; the notifications cycle
-uses it to raise the display-staleness events described in
+fetch in `display-last-fetch.json` and of the last display-reported completed
+update (`GET /v1/display-success`) in `display-last-success.json`, both under
+`state_dir`; the notifications cycle uses them to raise the display-staleness
+events described in
 [`notifications.md`](notifications.md#events-and-noise-controls).
 
 Native installations use launchd or systemd to schedule the controller's

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,8 +60,17 @@ The controller also exposes a read-only HTTP catalog:
 - `GET /v1/catalog`
 - `GET /v1/assets/<catalog-relative-path>`
 
+`/health` reports approved and active species counts from the last built
+catalog index and never rebuilds it, so a health check answers cheaply at any
+catalog size. The server also records the time of the last `/v1/catalog`
+fetch in `display-last-fetch.json` under `state_dir`; the notifications cycle
+uses it to raise the display-staleness events described in
+[`notifications.md`](notifications.md#events-and-noise-controls).
+
 Native installations use launchd or systemd to schedule the controller's
-one-shot commands. Docker installations run the same commands through one
+one-shot commands. Generated systemd serve and display units carry basic
+sandboxing directives such as `NoNewPrivileges` and `PrivateTmp`. Docker
+installations run the same commands through one
 serial scheduler process. A scheduler job failure is isolated to that job and
 its next interval; generation remains disabled after scheduler startup until a
 refresh succeeds. The HTTP server runs without Codex or GitHub authentication,
@@ -140,8 +149,9 @@ controller state.
 
 Reference acquisition accepts only iNaturalist research-grade photos marked
 CC0 or CC BY, uses distinct observers, records attribution and source URLs, and
-requires an 800-pixel minimum edge. Reference bitmaps stay in ignored controller
-state and are not redistributed in the catalog.
+requires an 800-pixel minimum edge. Outbound fetches accept only HTTP(S) URLs
+and enforce a bounded response size. Reference bitmaps stay in ignored
+controller state and are not redistributed in the catalog.
 
 ## Deterministic and generative work
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -21,6 +21,14 @@ The controller and scheduler use the same commands as a native installation.
 One failed scheduled job is logged and retried later without stopping the HTTP
 service or unrelated jobs.
 
+`bootstrap` runs `catalog sync --source-catalog /app/catalog --catalog
+/data/catalog --state-dir /data/var/controller`. The sync is add-only: it
+validates the bundled public catalog, copies only species missing from the
+persistent catalog, rebuilds the index, and holds the controller state lock so
+it cannot overwrite an approved plate or race a running cycle. The
+[operations guide](operations.md#copy-species-between-catalogs) describes the
+command in general.
+
 ## Before you begin
 
 You need:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,6 +72,11 @@ Do not expose the configured controller port to the public internet. The
 built-in server is an unauthenticated, read-only LAN service. Use a VPN or an
 authenticated TLS reverse proxy if traffic must cross an untrusted network.
 
+The example configuration sets `controller.bind_host = "0.0.0.0"`, which
+listens on every interface of the controller host. On a multi-homed
+controller, set `bind_host` to the specific LAN address the display uses so
+the service is not offered on other networks.
+
 ## 1. Install the controller
 
 Choose the macOS or Linux path below. Keep the source checkout. Future updates
@@ -232,7 +237,9 @@ curl --fail --silent "http://127.0.0.1:8793/health"
 The health response must have `"ok": true`. `approved_species` is the reusable
 catalog size. `active_species` is the approved subset currently observed in the
 configured window and radius. It may initially be zero in a region whose birds
-have not been generated yet.
+have not been generated yet. Both counts are read from the last built catalog
+index rather than a fresh catalog scan, so the endpoint stays fast as the
+catalog grows.
 
 ## 2. Prepare the display Pi
 
@@ -461,16 +468,28 @@ points the Pimoroni environment at the managed runtime. The
 explicit source directory ensures each update installs the checkout that was
 just pulled rather than the previous managed copy.
 
+When the controller and display are updated separately, update display nodes
+first. The active catalog wire format is `schema_version: 1`, and a display
+node refuses a catalog with a newer schema version: the cycle fails closed
+and the panel keeps its last image until the display is updated.
+
 Docker controller updates pull a published image and recreate the services. See
 the [Docker update instructions](docker.md#update) for version pinning and
 rollback.
 
 ## Uninstall
 
-Uninstalling services does not delete configuration, catalogs, generated art,
-or display state.
+From the source checkout, run the uninstall script that matches the role and
+platform. Each script removes the installed services and timers but preserves
+private configuration, controller state, catalogs, and generated art:
 
-On a systemd controller:
+```bash
+./deploy/uninstall-controller.sh           # macOS controller
+./deploy/uninstall-controller-systemd.sh   # Linux controller
+./deploy/uninstall-display-local.sh        # display node
+```
+
+The equivalent manual removal follows. On a systemd controller:
 
 ```bash
 for unit in \

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -68,10 +68,10 @@ against completed updates: `display_stale` is raised when no update has
 completed for three times `schedule.rotation_minutes` (minimum 60 minutes),
 and also when a current display node keeps fetching the catalog without ever
 completing an update, so a panel that fails before its first success is still
-detected. Display nodes that predate success reporting are recognized by
-their fetches and fall back to fetch age, so upgrading the controller first
-does not raise false alerts. `display_recovered` is sent once updates
-resume.
+detected. Only display nodes refresh these signals; other catalog readers
+never mask a silent display. Display nodes that predate success reporting
+write no heartbeat and are not monitored until they are updated, so update
+display nodes first. `display_recovered` is sent once updates resume.
 
 Routine successes do not notify. Transient failures notify only after
 `degradation_failure_threshold` consecutive failures or

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -63,11 +63,12 @@ Each destination has its own `events` list:
 The controller's HTTP server records the display's most recent catalog fetch
 in `display-last-fetch.json` and, when the display reports a completed update
 through `GET /v1/display-success`, the completion time in
-`display-last-success.json`, both under `state_dir`. The notifications cycle
-prefers the completed-update signal, so a node that still fetches the catalog
-but can no longer drive the panel is detected. It raises `display_stale` when
-no signal has been seen for three times `schedule.rotation_minutes`, with a
-minimum of 60 minutes, and sends `display_recovered` once updates resume.
+`display-last-success.json`, both under `state_dir`. Staleness is measured
+against completed updates: `display_stale` is raised when no update has
+completed for three times `schedule.rotation_minutes` (minimum 60 minutes),
+and also when a node keeps fetching the catalog without ever completing an
+update, so a panel that fails before its first success is still detected.
+`display_recovered` is sent once updates resume.
 
 Routine successes do not notify. Transient failures notify only after
 `degradation_failure_threshold` consecutive failures or

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -57,6 +57,14 @@ Each destination has its own `events` list:
 | `recovered` | A previously reported transient degradation succeeds again |
 | `publication_error` | Public catalog publication crosses the degradation threshold |
 | `publication_recovered` | Public catalog publication succeeds after a reported degradation |
+| `display_stale` | No display node has fetched the active catalog for three rotation intervals, with a 60-minute minimum |
+| `display_recovered` | Display catalog fetches resume after a `display_stale` notice |
+
+The controller's HTTP server records the display's most recent catalog fetch
+in `display-last-fetch.json` under `state_dir`. The notifications cycle raises
+`display_stale` when no fetch has been seen for three times
+`schedule.rotation_minutes`, with a minimum of 60 minutes, and sends
+`display_recovered` once fetches resume.
 
 Routine successes do not notify. Transient failures notify only after
 `degradation_failure_threshold` consecutive failures or

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -66,9 +66,12 @@ through `GET /v1/display-success`, the completion time in
 `display-last-success.json`, both under `state_dir`. Staleness is measured
 against completed updates: `display_stale` is raised when no update has
 completed for three times `schedule.rotation_minutes` (minimum 60 minutes),
-and also when a node keeps fetching the catalog without ever completing an
-update, so a panel that fails before its first success is still detected.
-`display_recovered` is sent once updates resume.
+and also when a current display node keeps fetching the catalog without ever
+completing an update, so a panel that fails before its first success is still
+detected. Display nodes that predate success reporting are recognized by
+their fetches and fall back to fetch age, so upgrading the controller first
+does not raise false alerts. `display_recovered` is sent once updates
+resume.
 
 Routine successes do not notify. Transient failures notify only after
 `degradation_failure_threshold` consecutive failures or

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -61,10 +61,13 @@ Each destination has its own `events` list:
 | `display_recovered` | Display catalog fetches resume after a `display_stale` notice |
 
 The controller's HTTP server records the display's most recent catalog fetch
-in `display-last-fetch.json` under `state_dir`. The notifications cycle raises
-`display_stale` when no fetch has been seen for three times
-`schedule.rotation_minutes`, with a minimum of 60 minutes, and sends
-`display_recovered` once fetches resume.
+in `display-last-fetch.json` and, when the display reports a completed update
+through `GET /v1/display-success`, the completion time in
+`display-last-success.json`, both under `state_dir`. The notifications cycle
+prefers the completed-update signal, so a node that still fetches the catalog
+but can no longer drive the panel is detected. It raises `display_stale` when
+no signal has been seen for three times `schedule.rotation_minutes`, with a
+minimum of 60 minutes, and sends `display_recovered` once updates resume.
 
 Routine successes do not notify. Transient failures notify only after
 `degradation_failure_threshold` consecutive failures or

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -117,6 +117,39 @@ is used unless `--radius-km` is provided. Repeating a seed
 is idempotent: approved, terminal, and already queued taxa are not added again.
 Current observations remain ahead of seed-only taxa during generation.
 
+## Run a combined cycle
+
+`refresh` and `generate` are the scheduled one-shot commands.
+`controller-cycle` runs one observation refresh followed by one generation
+cycle in a single invocation and reports the combined JSON result:
+
+```bash
+inky-bird-frame controller-cycle --config /path/to/config.toml
+```
+
+Use it for a manual end-to-end pass. Scheduled installations keep the separate
+`refresh` and `generate` commands so each job retains its own interval and
+failure notifications; `controller-cycle` does not send the per-command
+notifications those commands emit.
+
+## Copy species between catalogs
+
+`catalog sync` copies every species missing from one catalog into another and
+rebuilds the destination index:
+
+```bash
+inky-bird-frame catalog sync --source-catalog /path/to/source \
+  --catalog /path/to/destination
+```
+
+The command is add-only. It validates both catalogs, refuses a destination
+taxon that conflicts with its immutable source version, and reports published
+and already-present taxa. Pass `--state-dir` with the controller state
+directory when the destination is a live controller catalog, so the copy holds
+the same lock as generation. The Docker bootstrap service uses this command to
+copy the image's bundled catalog into persistent storage; see the
+[Docker controller guide](docker.md#what-runs).
+
 ## Catalog publication
 
 Clone this project repository into a controller-only checkout. Install GitHub
@@ -195,6 +228,22 @@ Enable catalog publication to preserve accepted plates for other installations.
 Each generated image receives an auditable catalog-only PR, while application
 code continues through the full review and CI policy.
 
+## Display a personal image
+
+`prepare-image` fits any image onto the supported plate geometry without
+Codex:
+
+```bash
+inky-bird-frame prepare-image /path/to/image.jpg --output-dir output
+```
+
+It centers the source on a paper-colored `1200x1600` portrait canvas and
+writes `<name>-portrait.png` plus a rotated `1600x1200` `<name>-display.png`
+into `--output-dir` (default `output`). Add `--display` to also send the
+prepared display asset to a locally attached Inky panel, or copy the file to
+the display node and use `display-image`. Prepared images are local output
+only; they never enter the approved catalog or rotation.
+
 ## Failure recovery
 
 - Network or source failure: inspect the refresh or generation log and JSON
@@ -212,6 +261,21 @@ code continues through the full review and CI policy.
   authentication, remote divergence, or the reported validation problem, then
   rerun `catalog-publish`. Local approval and display rotation continue while
   public publication is unavailable.
+
+## Runtime state retention
+
+`runs/`, `failed/`, and `rejected/` under the controller `state_dir` grow
+without automatic pruning so failed and rejected work stays available for
+inspection. Check them first when investigating a generation failure. Entries
+are safe to delete once they have been reviewed.
+
+## Log retention
+
+On systemd hosts the services log JSON to journald and rely on the
+distribution's default journal rotation. Set `SystemMaxUse=` in
+`/etc/systemd/journald.conf` and restart `systemd-journald` to enforce a hard
+size cap. macOS LaunchAgents write to log files under the managed support
+directory instead.
 
 See [`notifications.md`](notifications.md) for provider setup, event filtering,
 durable delivery, noise controls, testing, and redacted status commands.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -85,6 +85,20 @@ A multi-provider refresh reports each provider independently and continues when
 at least one configured provider is healthy. A refresh failure does not remove
 the existing active catalog.
 
+### TLS or certificate errors right after boot
+
+Raspberry Pi computers have no battery-backed real-time clock. After a power
+loss, the clock is wrong until NTP synchronizes, so outbound HTTPS calls can
+fail certificate validity checks during the first minutes after boot. These
+errors clear on their own once the clock is correct.
+
+```bash
+timedatectl
+```
+
+Wait for `System clock synchronized: yes` before treating a certificate
+failure as a persistent problem.
+
 ### Generation fails or keeps retrying
 
 ```bash

--- a/src/inky_bird_frame/birds.py
+++ b/src/inky_bird_frame/birds.py
@@ -10,12 +10,11 @@ from dataclasses import dataclass, replace
 from datetime import UTC, date, datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 from typing import Final
 from urllib.parse import quote, urlencode
 
 from .errors import DataSourceError, TaxonomyMatchError
-from .http import get_json
+from .http import get_json, write_json_atomic
 
 
 @dataclass(frozen=True)
@@ -625,21 +624,7 @@ def _read_taxonomy_crosswalk(path: Path) -> dict[str, dict[str, object]]:
 
 
 def _write_taxonomy_crosswalk(path: Path, entries: dict[str, dict[str, object]]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with NamedTemporaryFile(
-        "w",
-        dir=path.parent,
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-        delete=False,
-    ) as handle:
-        json.dump({"schema_version": 1, "entries": entries}, handle, indent=2, sort_keys=True)
-        handle.write("\n")
-        temporary = Path(handle.name)
-    try:
-        temporary.replace(path)
-    finally:
-        temporary.unlink(missing_ok=True)
+    write_json_atomic(path, {"schema_version": 1, "entries": entries})
 
 
 def parse_inaturalist_taxon(payload: object) -> TaxonContext:

--- a/src/inky_bird_frame/birds.py
+++ b/src/inky_bird_frame/birds.py
@@ -15,6 +15,7 @@ from urllib.parse import quote, urlencode
 
 from .errors import DataSourceError, TaxonomyMatchError
 from .http import get_json, write_json_atomic
+from .timeutil import parse_utc_timestamp
 
 
 @dataclass(frozen=True)
@@ -595,15 +596,7 @@ def _taxonomy_crosswalk_lock(cache_path: Path) -> Iterator[None]:
 
 
 def _parse_cache_datetime(value: object) -> datetime | None:
-    if not isinstance(value, str):
-        return None
-    try:
-        parsed = datetime.fromisoformat(value)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return None
-    return parsed.astimezone(UTC)
+    return parse_utc_timestamp(value)
 
 
 def _read_taxonomy_crosswalk(path: Path) -> dict[str, dict[str, object]]:

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -274,13 +274,54 @@ def is_bounded_generation(generation: object) -> bool:
     )
 
 
+def clear_catalog_staging(catalog_dir: Path, name: str | None = None) -> None:
+    target = catalog_dir / ".staging" if name is None else catalog_dir / ".staging" / name
+    if target.is_symlink() or target.is_file():
+        target.unlink()
+    elif target.is_dir():
+        shutil.rmtree(target)
+
+
+def _asset_checksums(manifest: dict[str, object]) -> tuple[str, str] | None:
+    assets = manifest.get("assets")
+    if not isinstance(assets, dict):
+        return None
+    portrait = assets.get("portrait")
+    display = assets.get("display")
+    if not isinstance(portrait, dict) or not isinstance(display, dict):
+        return None
+    portrait_hash = portrait.get("sha256")
+    display_hash = display.get("sha256")
+    if not isinstance(portrait_hash, str) or not isinstance(display_hash, str):
+        return None
+    return portrait_hash, display_hash
+
+
+def _is_completed_approval(manifest: dict[str, object], destination: Path) -> bool:
+    existing_path = destination / "manifest.json"
+    if not existing_path.is_file():
+        return False
+    try:
+        existing = read_json(existing_path)
+    except CatalogError:
+        return False
+    checksums = _asset_checksums(manifest)
+    return (
+        isinstance(existing, dict)
+        and existing.get("status") == "approved"
+        and existing.get("taxon_id") == manifest.get("taxon_id")
+        and checksums is not None
+        and _asset_checksums(existing) == checksums
+    )
+
+
 def approve_candidate(state_dir: Path, catalog_dir: Path, taxon_id: int) -> CatalogEntry:
     source = find_taxon_directory(state_dir / "pending", taxon_id)
     if source is None:
         raise CatalogError(f"No pending candidate exists for taxon {taxon_id}")
     manifest_path = source / "manifest.json"
     manifest = read_json(manifest_path)
-    if not isinstance(manifest, dict) or manifest.get("status") != "pending":
+    if not isinstance(manifest, dict) or manifest.get("status") not in ("pending", "approved"):
         raise CatalogError(f"Candidate manifest is not pending: {manifest_path}")
     review = manifest.get("quality_review")
     if not isinstance(review, dict) or review.get("passed") is not True:
@@ -290,17 +331,24 @@ def approve_candidate(state_dir: Path, catalog_dir: Path, taxon_id: int) -> Cata
     if not isinstance(slug, str):
         raise CatalogError("Candidate manifest has no slug")
     destination = catalog_dir / "species" / f"{taxon_id}-{slug}"
+    clear_catalog_staging(catalog_dir, destination.name)
     if destination.exists():
-        raise CatalogError(
-            f"Taxon {taxon_id} is already approved; use an explicit replacement workflow"
-        )
+        if not _is_completed_approval(manifest, destination):
+            raise CatalogError(
+                f"Taxon {taxon_id} is already approved; use an explicit replacement workflow"
+            )
+        shutil.rmtree(source)
+        entries = rebuild_catalog_index(catalog_dir)
+        return next(entry for entry in entries if entry.taxon_id == taxon_id)
 
     approved_manifest = dict(manifest)
     approved_manifest["status"] = "approved"
     approved_manifest["approved_at"] = utc_now()
-    write_json_atomic(manifest_path, approved_manifest)
+    staged = catalog_dir / ".staging" / destination.name
+    shutil.copytree(source, staged)
+    write_json_atomic(staged / "manifest.json", approved_manifest)
     destination.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(source, destination)
+    staged.rename(destination)
     shutil.rmtree(source)
     entries = rebuild_catalog_index(catalog_dir)
     return next(entry for entry in entries if entry.taxon_id == taxon_id)

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -11,11 +11,11 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 from typing import cast
 
 from .birds import BirdSpecies
 from .errors import CatalogError
+from .http import write_json_atomic
 from .images import slugify
 from .models import QualityReview, ReferencePhoto, SpeciesProfileData
 
@@ -76,24 +76,6 @@ def sha256_file(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
-
-
-def write_json_atomic(path: Path, value: object) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with NamedTemporaryFile(
-        "w",
-        encoding="utf-8",
-        dir=path.parent,
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-        delete=False,
-    ) as handle:
-        handle.write(json.dumps(value, indent=2, sort_keys=True) + "\n")
-        temporary = Path(handle.name)
-    try:
-        temporary.replace(path)
-    finally:
-        temporary.unlink(missing_ok=True)
 
 
 def read_json(path: Path) -> object:

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -282,37 +282,62 @@ def clear_catalog_staging(catalog_dir: Path, name: str | None = None) -> None:
         shutil.rmtree(target)
 
 
-def _asset_checksums(manifest: dict[str, object]) -> tuple[str, str] | None:
+def _asset_manifest_entries(
+    manifest: dict[str, object],
+) -> tuple[tuple[str, str], tuple[str, str]] | None:
     assets = manifest.get("assets")
     if not isinstance(assets, dict):
         return None
-    portrait = assets.get("portrait")
-    display = assets.get("display")
-    if not isinstance(portrait, dict) or not isinstance(display, dict):
-        return None
-    portrait_hash = portrait.get("sha256")
-    display_hash = display.get("sha256")
-    if not isinstance(portrait_hash, str) or not isinstance(display_hash, str):
-        return None
-    return portrait_hash, display_hash
+    entries: list[tuple[str, str]] = []
+    for name in ("portrait", "display"):
+        asset = assets.get(name)
+        if not isinstance(asset, dict):
+            return None
+        filename = asset.get("filename")
+        digest = asset.get("sha256")
+        if not isinstance(filename, str) or not isinstance(digest, str):
+            return None
+        entries.append((filename, digest))
+    return entries[0], entries[1]
 
 
-def _is_completed_approval(manifest: dict[str, object], destination: Path) -> bool:
+def _asset_checksums(manifest: dict[str, object]) -> tuple[str, str] | None:
+    entries = _asset_manifest_entries(manifest)
+    if entries is None:
+        return None
+    return entries[0][1], entries[1][1]
+
+
+def _existing_destination_manifest(destination: Path) -> dict[str, object] | None:
     existing_path = destination / "manifest.json"
     if not existing_path.is_file():
-        return False
+        return None
     try:
         existing = read_json(existing_path)
     except CatalogError:
-        return False
+        return None
+    return existing if isinstance(existing, dict) else None
+
+
+def _same_candidate(manifest: dict[str, object], existing: dict[str, object]) -> bool:
     checksums = _asset_checksums(manifest)
     return (
-        isinstance(existing, dict)
-        and existing.get("status") == "approved"
+        existing.get("status") == "approved"
         and existing.get("taxon_id") == manifest.get("taxon_id")
         and checksums is not None
         and _asset_checksums(existing) == checksums
     )
+
+
+def _destination_assets_intact(existing: dict[str, object], destination: Path) -> bool:
+    entries = _asset_manifest_entries(existing)
+    if entries is None:
+        return False
+    for filename, digest in entries:
+        asset_path = destination / filename
+        if not asset_path.is_file() or sha256_file(asset_path) != digest:
+            return False
+    return True
 
 
 def approve_candidate(state_dir: Path, catalog_dir: Path, taxon_id: int) -> CatalogEntry:
@@ -333,13 +358,17 @@ def approve_candidate(state_dir: Path, catalog_dir: Path, taxon_id: int) -> Cata
     destination = catalog_dir / "species" / f"{taxon_id}-{slug}"
     clear_catalog_staging(catalog_dir, destination.name)
     if destination.exists():
-        if not _is_completed_approval(manifest, destination):
+        existing = _existing_destination_manifest(destination)
+        if existing is None or not _same_candidate(manifest, existing):
             raise CatalogError(
                 f"Taxon {taxon_id} is already approved; use an explicit replacement workflow"
             )
-        shutil.rmtree(source)
-        entries = rebuild_catalog_index(catalog_dir)
-        return next(entry for entry in entries if entry.taxon_id == taxon_id)
+        if _destination_assets_intact(existing, destination):
+            shutil.rmtree(source)
+            entries = rebuild_catalog_index(catalog_dir)
+            return next(entry for entry in entries if entry.taxon_id == taxon_id)
+        # Same candidate but an incomplete copy: discard it and approve again.
+        shutil.rmtree(destination)
 
     approved_manifest = dict(manifest)
     approved_manifest["status"] = "approved"

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -7,7 +7,7 @@ import hashlib
 import json
 import shutil
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -275,11 +275,15 @@ def is_bounded_generation(generation: object) -> bool:
 
 
 def clear_catalog_staging(catalog_dir: Path, name: str | None = None) -> None:
-    target = catalog_dir / ".staging" if name is None else catalog_dir / ".staging" / name
+    staging = catalog_dir / ".staging"
+    target = staging if name is None else staging / name
     if target.is_symlink() or target.is_file():
         target.unlink()
     elif target.is_dir():
         shutil.rmtree(target)
+    if name is not None:
+        with suppress(OSError):
+            staging.rmdir()
 
 
 def _asset_manifest_entries(
@@ -383,6 +387,9 @@ def approve_candidate(state_dir: Path, catalog_dir: Path, taxon_id: int) -> Cata
     write_json_atomic(staged / "manifest.json", approved_manifest)
     destination.parent.mkdir(parents=True, exist_ok=True)
     staged.rename(destination)
+    # An empty .staging directory would fail the publish root allowlist.
+    with suppress(OSError):
+        staged.parent.rmdir()
     shutil.rmtree(source)
     entries = rebuild_catalog_index(catalog_dir)
     return next(entry for entry in entries if entry.taxon_id == taxon_id)

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -286,32 +286,6 @@ def clear_catalog_staging(catalog_dir: Path, name: str | None = None) -> None:
             staging.rmdir()
 
 
-def _asset_manifest_entries(
-    manifest: dict[str, object],
-) -> tuple[tuple[str, str], tuple[str, str]] | None:
-    assets = manifest.get("assets")
-    if not isinstance(assets, dict):
-        return None
-    entries: list[tuple[str, str]] = []
-    for name in ("portrait", "display"):
-        asset = assets.get(name)
-        if not isinstance(asset, dict):
-            return None
-        filename = asset.get("filename")
-        digest = asset.get("sha256")
-        if not isinstance(filename, str) or not isinstance(digest, str):
-            return None
-        entries.append((filename, digest))
-    return entries[0], entries[1]
-
-
-def _asset_checksums(manifest: dict[str, object]) -> tuple[str, str] | None:
-    entries = _asset_manifest_entries(manifest)
-    if entries is None:
-        return None
-    return entries[0][1], entries[1][1]
-
-
 def _existing_destination_manifest(destination: Path) -> dict[str, object] | None:
     existing_path = destination / "manifest.json"
     if not existing_path.is_file():
@@ -324,13 +298,13 @@ def _existing_destination_manifest(destination: Path) -> dict[str, object] | Non
 
 
 def _same_candidate(manifest: dict[str, object], existing: dict[str, object]) -> bool:
-    checksums = _asset_checksums(manifest)
-    return (
-        existing.get("status") == "approved"
-        and existing.get("taxon_id") == manifest.get("taxon_id")
-        and checksums is not None
-        and _asset_checksums(existing) == checksums
-    )
+    # Crash debris is a byte-for-byte copy of the pending candidate apart from
+    # the approval fields; anything else must go through explicit replacement
+    # so an intentional correction is never silently discarded.
+    ignored = ("status", "approved_at")
+    pending_view = {key: value for key, value in manifest.items() if key not in ignored}
+    existing_view = {key: value for key, value in existing.items() if key not in ignored}
+    return existing.get("status") == "approved" and pending_view == existing_view
 
 
 def _valid_destination_entry(destination: Path, catalog_dir: Path) -> bool:

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -83,7 +83,7 @@ def read_json(path: Path) -> object:
         return cast(object, json.loads(path.read_text()))
     except FileNotFoundError as exc:
         raise CatalogError(f"Catalog file not found: {path}") from exc
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
         raise CatalogError(f"Invalid JSON in catalog file: {path}") from exc
 
 
@@ -359,16 +359,21 @@ def approve_candidate(state_dir: Path, catalog_dir: Path, taxon_id: int) -> Cata
     clear_catalog_staging(catalog_dir, destination.name)
     if destination.exists():
         existing = _existing_destination_manifest(destination)
-        if existing is None or not _same_candidate(manifest, existing):
+        if existing is None:
+            # No readable manifest is never a valid approval, only debris from
+            # an interrupted legacy copy: discard it and approve again.
+            shutil.rmtree(destination)
+        elif not _same_candidate(manifest, existing):
             raise CatalogError(
                 f"Taxon {taxon_id} is already approved; use an explicit replacement workflow"
             )
-        if _destination_assets_intact(existing, destination):
+        elif _destination_assets_intact(existing, destination):
             shutil.rmtree(source)
             entries = rebuild_catalog_index(catalog_dir)
             return next(entry for entry in entries if entry.taxon_id == taxon_id)
-        # Same candidate but an incomplete copy: discard it and approve again.
-        shutil.rmtree(destination)
+        else:
+            # Same candidate but an incomplete copy: discard it and approve again.
+            shutil.rmtree(destination)
 
     approved_manifest = dict(manifest)
     approved_manifest["status"] = "approved"

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -333,14 +333,13 @@ def _same_candidate(manifest: dict[str, object], existing: dict[str, object]) ->
     )
 
 
-def _destination_assets_intact(existing: dict[str, object], destination: Path) -> bool:
-    entries = _asset_manifest_entries(existing)
-    if entries is None:
+def _valid_destination_entry(destination: Path, catalog_dir: Path) -> bool:
+    # Full manifest-entry validation covers required fields and asset
+    # checksums, so the pending copy is only dropped for a complete approval.
+    try:
+        _manifest_entry(destination / "manifest.json", catalog_dir)
+    except (CatalogError, OSError):
         return False
-    for filename, digest in entries:
-        asset_path = destination / filename
-        if not asset_path.is_file() or sha256_file(asset_path) != digest:
-            return False
     return True
 
 
@@ -371,7 +370,7 @@ def approve_candidate(state_dir: Path, catalog_dir: Path, taxon_id: int) -> Cata
             raise CatalogError(
                 f"Taxon {taxon_id} is already approved; use an explicit replacement workflow"
             )
-        elif _destination_assets_intact(existing, destination):
+        elif _valid_destination_entry(destination, catalog_dir):
             shutil.rmtree(source)
             entries = rebuild_catalog_index(catalog_dir)
             return next(entry for entry in entries if entry.taxon_id == taxon_id)

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -359,6 +359,10 @@ def retry_command(args: argparse.Namespace) -> int:
         cleared_cached_profile = profile_cache.exists()
         if cleared_cached_profile:
             sources.append(profile_cache)
+        reference_cache = config.controller.state_dir / "references" / str(args.taxon_id)
+        cleared_cached_references = reference_cache.exists()
+        if cleared_cached_references:
+            sources.append(reference_cache)
         archive = config.controller.state_dir / "archive"
         archive.mkdir(parents=True, exist_ok=True)
         moved: list[str] = []
@@ -378,6 +382,7 @@ def retry_command(args: argparse.Namespace) -> int:
             "archived": moved,
             "cleared_deferred_retry": deferred,
             "cleared_cached_profile": cleared_cached_profile,
+            "cleared_cached_references": cleared_cached_references,
         }
     )
     return 0

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -44,6 +44,7 @@ from .errors import InkyBirdFrameError
 from .images import prepare_uploaded_image
 from .installation import InstallationRole, doctor, setup
 from .notifications import (
+    check_display_heartbeat,
     dispatch_notifications,
     notification_status,
     requeue_dead_letters,
@@ -562,7 +563,9 @@ def notifications_test_command(args: argparse.Namespace) -> int:
 
 
 def notifications_dispatch_command(args: argparse.Namespace) -> int:
-    print_result(dispatch_notifications(_config(args)))
+    config = _config(args)
+    display_heartbeat = check_display_heartbeat(config)
+    print_result({**dispatch_notifications(config), "display_heartbeat": display_heartbeat})
     return 0
 
 

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -64,6 +64,8 @@ class NotificationEvent(StrEnum):
     RECOVERED = "recovered"
     PUBLICATION_ERROR = "publication_error"
     PUBLICATION_RECOVERED = "publication_recovered"
+    DISPLAY_STALE = "display_stale"
+    DISPLAY_RECOVERED = "display_recovered"
 
 
 ALL_NOTIFICATION_EVENTS = tuple(NotificationEvent)
@@ -209,10 +211,14 @@ def _string(section: dict[str, object], name: str) -> str:
     return value.strip()
 
 
-def _integer(section: dict[str, object], name: str, *, minimum: int = 1) -> int:
+def _integer(
+    section: dict[str, object], name: str, *, minimum: int = 1, maximum: int | None = None
+) -> int:
     value = section.get(name)
     if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
         raise ConfigurationError(f"{name} must be an integer greater than or equal to {minimum}")
+    if maximum is not None and value > maximum:
+        raise ConfigurationError(f"{name} must be an integer less than or equal to {maximum}")
     return value
 
 
@@ -518,7 +524,7 @@ def load_config(path: Path, *, load_secrets: bool = True) -> AppConfig:
             state_dir=_path(_string(controller, "state_dir"), base_dir),
             codex_path=_executable_path(_string(controller, "codex_path"), base_dir),
             bind_host=_string(controller, "bind_host"),
-            port=_integer(controller, "port"),
+            port=_integer(controller, "port", maximum=65535),
             references_per_species=_integer(controller, "references_per_species"),
             generations_per_cycle=_integer(controller, "generations_per_cycle"),
             max_generation_attempts=_optional_integer(

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -31,6 +31,7 @@ from .catalog import (
     approved_taxon_ids,
     candidate_directory,
     catalog_state_lock,
+    clear_catalog_staging,
     find_taxon_directory,
     has_passing_sourced_review,
     is_bounded_generation,
@@ -57,6 +58,7 @@ from .prompts import PROMPT_VERSION
 from .references import download_references, fetch_reference_candidates
 from .research import ResearchBudget
 from .retry import RetryStore
+from .timeutil import parse_utc_timestamp
 
 
 @dataclass(frozen=True)
@@ -576,12 +578,9 @@ def _read_discovery_snapshot(config: AppConfig) -> DiscoverySnapshot:
         or not isinstance(species_raw, list)
     ):
         raise CatalogError(f"Invalid discovery state: {path}")
-    try:
-        refreshed = datetime.fromisoformat(refreshed_at)
-    except ValueError as exc:
-        raise CatalogError(f"Invalid discovery timestamp: {path}") from exc
-    if refreshed.tzinfo is None:
-        raise CatalogError(f"Discovery timestamp has no timezone: {path}")
+    refreshed = parse_utc_timestamp(refreshed_at)
+    if refreshed is None:
+        raise CatalogError(f"Invalid discovery timestamp: {path}")
 
     species = _parse_species_list(species_raw, path)
     return DiscoverySnapshot(refreshed, place_name, state, species)
@@ -835,6 +834,7 @@ def record_failure(state_dir: Path, species: BirdSpecies, error: InkyBirdFrameEr
 
 def approve_passing_candidates(config: AppConfig) -> list[dict[str, object]]:
     published: list[dict[str, object]] = []
+    clear_catalog_staging(config.controller.catalog_dir)
     pending_root = config.controller.state_dir / "pending"
     for manifest_path in sorted(pending_root.glob("*/manifest.json")):
         try:
@@ -955,8 +955,20 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                         "terminal": True,
                     }
                 )
-            except (CatalogError, MissingDependencyError):
+            except MissingDependencyError:
                 raise
+            except CatalogError as exc:
+                retry_store.clear(species.taxon_id)
+                failure_path = record_failure(config.controller.state_dir, species, exc)
+                failures.append(
+                    {
+                        "taxon_id": species.taxon_id,
+                        "common_name": species.common_name,
+                        "error": str(exc),
+                        "failure": str(failure_path),
+                        "terminal": True,
+                    }
+                )
             except InkyBirdFrameError as exc:
                 retry = retry_store.record_failure(
                     species.taxon_id,

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -35,8 +35,8 @@ from .catalog import (
     has_passing_sourced_review,
     is_bounded_generation,
     rebuild_catalog_index,
+    utc_now,
     write_candidate_manifest,
-    write_json_atomic,
 )
 from .codex_runner import CodexRunner, parse_species_profile
 from .config import AppConfig, DiscoveryProvider, discovery_source_label
@@ -50,6 +50,7 @@ from .errors import (
     QualityReviewError,
 )
 from .geo import ZipLocation, lookup_us_zip
+from .http import write_json_atomic
 from .images import prepare_generated_plate
 from .models import ReferencePhoto, SpeciesProfileData
 from .prompts import PROMPT_VERSION
@@ -411,7 +412,7 @@ def _write_generation_queue(config: AppConfig, species: list[BirdSpecies]) -> No
         _generation_queue_path(config),
         {
             "schema_version": 2,
-            "updated_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+            "updated_at": utc_now(),
             "species": [_species_payload(item) for item in species],
         },
     )
@@ -500,7 +501,7 @@ def _write_active_catalog(config: AppConfig, species_list: list[BirdSpecies]) ->
         _active_catalog_path(config),
         {
             "schema_version": 1,
-            "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+            "generated_at": utc_now(),
             "species": active,
         },
     )
@@ -821,7 +822,7 @@ def record_failure(state_dir: Path, species: BirdSpecies, error: InkyBirdFrameEr
         {
             "schema_version": 1,
             "status": "failed",
-            "failed_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+            "failed_at": utc_now(),
             "taxon_id": species.taxon_id,
             "common_name": species.common_name,
             "scientific_name": species.scientific_name,

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -673,7 +673,7 @@ def load_or_create_profile(
     if cached:
         try:
             raw = json.loads(cache_path.read_text())
-        except json.JSONDecodeError as exc:
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
             raise SpeciesStateError(f"Invalid cached species profile: {cache_path}") from exc
         try:
             profile = parse_species_profile(raw, config.research.allowed_domains)

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -49,6 +49,7 @@ from .errors import (
     InsufficientReferencesError,
     MissingDependencyError,
     QualityReviewError,
+    SpeciesStateError,
 )
 from .geo import ZipLocation, lookup_us_zip
 from .http import write_json_atomic
@@ -625,15 +626,15 @@ def load_or_fetch_references(config: AppConfig, species: BirdSpecies) -> list[Re
         try:
             raw = json.loads(manifest_path.read_text())
         except json.JSONDecodeError as exc:
-            raise CatalogError(f"Invalid reference manifest: {manifest_path}") from exc
+            raise SpeciesStateError(f"Invalid reference manifest: {manifest_path}") from exc
         if not isinstance(raw, dict) or not isinstance(raw.get("references"), list):
-            raise CatalogError(f"Invalid reference manifest: {manifest_path}")
+            raise SpeciesStateError(f"Invalid reference manifest: {manifest_path}")
         references = [_reference_from_dict(item) for item in raw["references"]]
         missing = [
             item.filename for item in references if not (directory / item.filename).is_file()
         ]
         if missing:
-            raise CatalogError(f"Reference files are missing: {', '.join(missing)}")
+            raise SpeciesStateError(f"Reference files are missing: {', '.join(missing)}")
         return references
 
     candidates = fetch_reference_candidates(
@@ -673,11 +674,11 @@ def load_or_create_profile(
         try:
             raw = json.loads(cache_path.read_text())
         except json.JSONDecodeError as exc:
-            raise CatalogError(f"Invalid cached species profile: {cache_path}") from exc
+            raise SpeciesStateError(f"Invalid cached species profile: {cache_path}") from exc
         try:
             profile = parse_species_profile(raw, config.research.allowed_domains)
         except GenerationError as exc:
-            raise CatalogError(f"Invalid cached species profile: {cache_path}") from exc
+            raise SpeciesStateError(f"Invalid cached species profile: {cache_path}") from exc
     else:
         if not config.research.enabled:
             raise GenerationError(
@@ -703,7 +704,7 @@ def load_or_create_profile(
         or profile["common_name"] != species.common_name
         or profile["scientific_name"] != species.scientific_name
     ):
-        raise CatalogError(
+        raise SpeciesStateError(
             f"Cached species profile identity does not match taxon {species.taxon_id}"
         )
     write_json_atomic(output_path, profile)
@@ -957,7 +958,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 )
             except MissingDependencyError:
                 raise
-            except CatalogError as exc:
+            except SpeciesStateError as exc:
                 retry_store.clear(species.taxon_id)
                 failure_path = record_failure(config.controller.state_dir, species, exc)
                 failures.append(
@@ -969,6 +970,8 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                         "terminal": True,
                     }
                 )
+            except CatalogError:
+                raise
             except InkyBirdFrameError as exc:
                 retry = retry_store.record_failure(
                     species.taxon_id,

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -629,7 +629,10 @@ def load_or_fetch_references(config: AppConfig, species: BirdSpecies) -> list[Re
             raise SpeciesStateError(f"Invalid reference manifest: {manifest_path}") from exc
         if not isinstance(raw, dict) or not isinstance(raw.get("references"), list):
             raise SpeciesStateError(f"Invalid reference manifest: {manifest_path}")
-        references = [_reference_from_dict(item) for item in raw["references"]]
+        try:
+            references = [_reference_from_dict(item) for item in raw["references"]]
+        except CatalogError as exc:
+            raise SpeciesStateError(f"Invalid reference manifest: {manifest_path}") from exc
         missing = [
             item.filename for item in references if not (directory / item.filename).is_file()
         ]

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -625,7 +625,7 @@ def load_or_fetch_references(config: AppConfig, species: BirdSpecies) -> list[Re
     if manifest_path.is_file():
         try:
             raw = json.loads(manifest_path.read_text())
-        except json.JSONDecodeError as exc:
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
             raise SpeciesStateError(f"Invalid reference manifest: {manifest_path}") from exc
         if not isinstance(raw, dict) or not isinstance(raw.get("references"), list):
             raise SpeciesStateError(f"Invalid reference manifest: {manifest_path}")

--- a/src/inky_bird_frame/display_node.py
+++ b/src/inky_bird_frame/display_node.py
@@ -7,9 +7,9 @@ import hashlib
 import json
 import random
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import cast
 from urllib.parse import quote
@@ -20,6 +20,7 @@ from .display import show_on_inky
 from .errors import CatalogError
 from .http import get_bytes, get_json, write_bytes_atomic, write_json_atomic
 from .selection import select_catalog_entry, select_shuffle_bag_entry
+from .timeutil import parse_utc_timestamp
 
 DISPLAY_STATE_SCHEMA_VERSION = 3
 
@@ -116,15 +117,10 @@ def parse_catalog_entries(payload: object) -> list[CatalogEntry]:
 
 
 def _detection_datetime(value: object, source: str) -> datetime:
-    if not isinstance(value, str) or not value:
+    parsed = parse_utc_timestamp(value)
+    if parsed is None:
         raise CatalogError(f"Invalid latest detection timestamp in {source}")
-    try:
-        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError as exc:
-        raise CatalogError(f"Invalid latest detection timestamp in {source}") from exc
-    if parsed.tzinfo is None or parsed.utcoffset() is None:
-        raise CatalogError(f"Latest detection timestamp must include a timezone in {source}")
-    return parsed.astimezone(UTC)
+    return parsed
 
 
 def _latest_unseen_detection(
@@ -285,6 +281,13 @@ def _advanced_priority_state(state: DisplayState, selected: CatalogEntry) -> tup
     return watermark, taxa
 
 
+def _evict_stale_cache_entries(current_image_path: Path, taxon_id: int) -> None:
+    for stale in current_image_path.parent.glob(f"{taxon_id}-*.png"):
+        if stale != current_image_path:
+            with suppress(OSError):
+                stale.unlink(missing_ok=True)
+
+
 def run_display_cycle(
     config: DisplayNodeConfig,
     *,
@@ -292,10 +295,12 @@ def run_display_cycle(
     rng: random.Random | random.SystemRandom | None = None,
 ) -> dict[str, object]:
     with exclusive_display_cycle_lock(config.state_dir):
-        catalog_payload = get_json(f"{config.controller_url}/v1/catalog", 20.0)
-        entries = parse_catalog_entries(catalog_payload)
+        # Validate local state before fetching so a wedged node stops
+        # refreshing the controller-side heartbeat and staleness alerts fire.
         state_path = config.state_dir / "state.json"
         state = _read_state(state_path)
+        catalog_payload = get_json(f"{config.controller_url}/v1/catalog", 20.0)
+        entries = parse_catalog_entries(catalog_payload)
         shuffle_remaining = list(state.shuffle_remaining)
         shuffle_bag_remaining = list(state.shuffle_bag_remaining)
         shuffle_bag_seen = list(state.shuffle_bag_seen)
@@ -394,6 +399,7 @@ def run_display_cycle(
             last_prioritized_detection_at=prioritized_at,
             prioritized_detection_taxa=prioritized_taxa,
         )
+        _evict_stale_cache_entries(image_path, selected.taxon_id)
         return {
             "display_update": "sent",
             "taxon_id": selected.taxon_id,

--- a/src/inky_bird_frame/display_node.py
+++ b/src/inky_bird_frame/display_node.py
@@ -377,6 +377,10 @@ def run_display_cycle(
                 last_prioritized_detection_at=prioritized_at,
                 prioritized_detection_taxa=prioritized_taxa,
             )
+            # An unchanged selection means state.last_sha256 matches, and that
+            # is only ever recorded after a successful panel update, so the
+            # current plate is verifiably on the panel; without this report a
+            # single-species catalog would go stale despite being correct.
             _report_display_success(config.controller_url)
             return {
                 "display_update": "unchanged",

--- a/src/inky_bird_frame/display_node.py
+++ b/src/inky_bird_frame/display_node.py
@@ -14,11 +14,11 @@ from pathlib import Path
 from typing import cast
 from urllib.parse import quote
 
-from .catalog import CatalogEntry, write_json_atomic
+from .catalog import CatalogEntry
 from .config import DisplayNodeConfig, RotationMode
 from .display import show_on_inky
 from .errors import CatalogError
-from .http import get_bytes, get_json, write_bytes_atomic
+from .http import get_bytes, get_json, write_bytes_atomic, write_json_atomic
 from .selection import select_catalog_entry, select_shuffle_bag_entry
 
 DISPLAY_STATE_SCHEMA_VERSION = 3

--- a/src/inky_bird_frame/display_node.py
+++ b/src/inky_bird_frame/display_node.py
@@ -17,7 +17,7 @@ from urllib.parse import quote
 from .catalog import CatalogEntry
 from .config import DisplayNodeConfig, RotationMode
 from .display import show_on_inky
-from .errors import CatalogError
+from .errors import CatalogError, DataSourceError
 from .http import get_bytes, get_json, write_bytes_atomic, write_json_atomic
 from .selection import select_catalog_entry, select_shuffle_bag_entry
 from .timeutil import parse_utc_timestamp
@@ -288,6 +288,12 @@ def _evict_stale_cache_entries(current_image_path: Path, taxon_id: int) -> None:
                 stale.unlink(missing_ok=True)
 
 
+def _report_display_success(controller_url: str) -> None:
+    # Best-effort: the update already succeeded; an older controller returns 404.
+    with suppress(DataSourceError):
+        get_json(f"{controller_url}/v1/display-success", 10.0)
+
+
 def run_display_cycle(
     config: DisplayNodeConfig,
     *,
@@ -371,6 +377,7 @@ def run_display_cycle(
                 last_prioritized_detection_at=prioritized_at,
                 prioritized_detection_taxa=prioritized_taxa,
             )
+            _report_display_success(config.controller_url)
             return {
                 "display_update": "unchanged",
                 "taxon_id": selected.taxon_id,
@@ -400,6 +407,7 @@ def run_display_cycle(
             prioritized_detection_taxa=prioritized_taxa,
         )
         _evict_stale_cache_entries(image_path, selected.taxon_id)
+        _report_display_success(config.controller_url)
         return {
             "display_update": "sent",
             "taxon_id": selected.taxon_id,

--- a/src/inky_bird_frame/display_node.py
+++ b/src/inky_bird_frame/display_node.py
@@ -305,7 +305,7 @@ def run_display_cycle(
         # refreshing the controller-side heartbeat and staleness alerts fire.
         state_path = config.state_dir / "state.json"
         state = _read_state(state_path)
-        catalog_payload = get_json(f"{config.controller_url}/v1/catalog", 20.0)
+        catalog_payload = get_json(f"{config.controller_url}/v1/catalog?reports_success=1", 20.0)
         entries = parse_catalog_entries(catalog_payload)
         shuffle_remaining = list(state.shuffle_remaining)
         shuffle_bag_remaining = list(state.shuffle_bag_remaining)

--- a/src/inky_bird_frame/errors.py
+++ b/src/inky_bird_frame/errors.py
@@ -37,6 +37,10 @@ class CatalogError(InkyBirdFrameError):
     """Raised when catalog data is missing, invalid, or inconsistent."""
 
 
+class SpeciesStateError(CatalogError):
+    """Raised when cached state for a single species is invalid."""
+
+
 class CatalogPublishError(InkyBirdFrameError):
     """Raised when an approved catalog cannot be published safely."""
 

--- a/src/inky_bird_frame/http.py
+++ b/src/inky_bird_frame/http.py
@@ -3,14 +3,37 @@
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import Mapping
+from http.client import HTTPResponse
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import cast
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
 
 from .errors import DataSourceError
+
+MAX_JSON_BYTES = 8 * 1024 * 1024
+MAX_ASSET_BYTES = 64 * 1024 * 1024
+
+
+def _read_capped(response: HTTPResponse, limit: int, display_url: str) -> bytes:
+    declared = response.headers.get("Content-Length")
+    if declared is not None and declared.isdigit() and int(declared) > limit:
+        raise DataSourceError(f"Response from {display_url} exceeds {limit} bytes")
+    body = response.read(limit + 1)
+    if len(body) > limit:
+        raise DataSourceError(f"Response from {display_url} exceeds {limit} bytes")
+    return body
+
+
+def _checked_request(url: str, headers: Mapping[str, str]) -> Request:
+    scheme = urlsplit(url).scheme
+    if scheme not in ("http", "https"):
+        raise DataSourceError(f"Refusing to fetch non-HTTP URL scheme: {scheme or 'none'}")
+    return Request(url, headers=dict(headers))
 
 
 def get_json(
@@ -23,11 +46,11 @@ def get_json(
     request_headers = {"User-Agent": "inky-bird-frame/0.1"}
     if headers is not None:
         request_headers.update(headers)
-    request = Request(url, headers=request_headers)
     display_url = error_label or url
+    request = _checked_request(url, request_headers)
     try:
         with urlopen(request, timeout=timeout_seconds) as response:
-            body = response.read()
+            body = _read_capped(cast(HTTPResponse, response), MAX_JSON_BYTES, display_url)
     except HTTPError as exc:
         raise DataSourceError(f"HTTP {exc.code} from {display_url}") from exc
     except URLError as exc:
@@ -42,10 +65,10 @@ def get_json(
 
 
 def get_bytes(url: str, timeout_seconds: float = 30.0) -> bytes:
-    request = Request(url, headers={"User-Agent": "inky-bird-frame/0.1"})
+    request = _checked_request(url, {"User-Agent": "inky-bird-frame/0.1"})
     try:
         with urlopen(request, timeout=timeout_seconds) as response:
-            return cast(bytes, response.read())
+            return _read_capped(cast(HTTPResponse, response), MAX_ASSET_BYTES, url)
     except HTTPError as exc:
         raise DataSourceError(f"HTTP {exc.code} from {url}") from exc
     except URLError as exc:
@@ -64,8 +87,14 @@ def write_bytes_atomic(path: Path, content: bytes) -> None:
         delete=False,
     ) as handle:
         handle.write(content)
+        handle.flush()
+        os.fsync(handle.fileno())
         temporary = Path(handle.name)
     try:
         temporary.replace(path)
     finally:
         temporary.unlink(missing_ok=True)
+
+
+def write_json_atomic(path: Path, value: object) -> None:
+    write_bytes_atomic(path, (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8"))

--- a/src/inky_bird_frame/http.py
+++ b/src/inky_bird_frame/http.py
@@ -77,6 +77,21 @@ def get_bytes(url: str, timeout_seconds: float = 30.0) -> bytes:
         raise DataSourceError(f"Timed out reading {url}") from exc
 
 
+def _fsync_directory(directory: Path) -> None:
+    # Rename durability needs the parent directory synced; skip filesystems
+    # that cannot fsync a directory handle rather than failing the write.
+    try:
+        fd = os.open(directory, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
 def write_bytes_atomic(path: Path, content: bytes) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with NamedTemporaryFile(
@@ -92,6 +107,7 @@ def write_bytes_atomic(path: Path, content: bytes) -> None:
         temporary = Path(handle.name)
     try:
         temporary.replace(path)
+        _fsync_directory(path.parent)
     finally:
         temporary.unlink(missing_ok=True)
 

--- a/src/inky_bird_frame/http.py
+++ b/src/inky_bird_frame/http.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import json
 import os
 from collections.abc import Mapping
-from http.client import HTTPResponse
+from http.client import HTTPMessage, HTTPResponse
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import cast
+from typing import IO, cast
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit
-from urllib.request import Request, urlopen
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 from .errors import DataSourceError
 
@@ -36,6 +36,25 @@ def _checked_request(url: str, headers: Mapping[str, str]) -> Request:
     return Request(url, headers=dict(headers))
 
 
+class _HTTPOnlyRedirectHandler(HTTPRedirectHandler):
+    # urllib otherwise follows redirects onto FTP, bypassing the scheme check.
+    def redirect_request(
+        self,
+        req: Request,
+        fp: IO[bytes],
+        code: int,
+        msg: str,
+        headers: HTTPMessage,
+        newurl: str,
+    ) -> Request | None:
+        if urlsplit(newurl).scheme not in ("http", "https"):
+            raise DataSourceError(f"Refusing redirect to non-HTTP URL scheme: {newurl}")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+_OPENER = build_opener(_HTTPOnlyRedirectHandler)
+
+
 def get_json(
     url: str,
     timeout_seconds: float = 10.0,
@@ -49,7 +68,7 @@ def get_json(
     display_url = error_label or url
     request = _checked_request(url, request_headers)
     try:
-        with urlopen(request, timeout=timeout_seconds) as response:
+        with _OPENER.open(request, timeout=timeout_seconds) as response:
             body = _read_capped(cast(HTTPResponse, response), MAX_JSON_BYTES, display_url)
     except HTTPError as exc:
         raise DataSourceError(f"HTTP {exc.code} from {display_url}") from exc
@@ -67,7 +86,7 @@ def get_json(
 def get_bytes(url: str, timeout_seconds: float = 30.0) -> bytes:
     request = _checked_request(url, {"User-Agent": "inky-bird-frame/0.1"})
     try:
-        with urlopen(request, timeout=timeout_seconds) as response:
+        with _OPENER.open(request, timeout=timeout_seconds) as response:
             return _read_capped(cast(HTTPResponse, response), MAX_ASSET_BYTES, url)
     except HTTPError as exc:
         raise DataSourceError(f"HTTP {exc.code} from {url}") from exc

--- a/src/inky_bird_frame/installation.py
+++ b/src/inky_bird_frame/installation.py
@@ -28,6 +28,19 @@ SYSTEMD_DEFAULT_EXECUTABLE_PATH = (
     "/sbin",
     "/bin",
 )
+# Sandboxing for units that never run Codex. The Codex-driven oneshot units
+# (refresh, generate, catalog-publish, notifications) build their own
+# bubblewrap user-namespace sandbox and must stay unconstrained. Services live
+# in the user's home and the display node needs SPI/GPIO devices, so
+# ProtectSystem/ProtectHome and device restrictions are intentionally omitted.
+SYSTEMD_SERVICE_HARDENING = (
+    "NoNewPrivileges=true\n"
+    "PrivateTmp=true\n"
+    "ProtectKernelTunables=true\n"
+    "ProtectKernelModules=true\n"
+    "ProtectControlGroups=true\n"
+    "RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX\n"
+)
 
 
 class InstallationRole(StrEnum):
@@ -146,7 +159,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-{common}ExecStart={command("serve", "--config", str(config_path))}
+{common}{SYSTEMD_SERVICE_HARDENING}ExecStart={command("serve", "--config", str(config_path))}
 Restart=on-failure
 RestartSec=10s
 
@@ -225,7 +238,7 @@ Type=oneshot
 User={user}
 WorkingDirectory={_systemd_literal(str(app_dir))}
 Environment=PYTHONUNBUFFERED=1
-ExecStart={exec_start}
+{SYSTEMD_SERVICE_HARDENING}ExecStart={exec_start}
 TimeoutStartSec=15min
 """
     timer = f"""[Unit]

--- a/src/inky_bird_frame/notifications.py
+++ b/src/inky_bird_frame/notifications.py
@@ -64,6 +64,10 @@ def display_heartbeat_path(config: AppConfig) -> Path:
     return config.controller.state_dir / "display-last-fetch.json"
 
 
+def display_success_path(config: AppConfig) -> Path:
+    return config.controller.state_dir / "display-last-success.json"
+
+
 def display_stale_threshold(config: AppConfig) -> timedelta:
     # Three missed rotations, floored so short rotations survive controller downtime.
     return timedelta(minutes=max(3 * config.schedule.rotation_minutes, 60))
@@ -396,21 +400,33 @@ def safe_record_recovery(
 
 def check_display_heartbeat(config: AppConfig, *, now: datetime | None = None) -> dict[str, object]:
     current = (now or datetime.now(UTC)).astimezone(UTC).replace(microsecond=0)
-    fetched_at, warning = _read_display_heartbeat(display_heartbeat_path(config))
-    if fetched_at is None:
+    # Completed display updates are the strongest signal; nodes that predate
+    # the success report fall back to their catalog fetches.
+    seen_at, warning = _read_display_heartbeat(display_success_path(config), "succeeded_at")
+    signal = "display-update"
+    if seen_at is None:
+        seen_at, fetch_warning = _read_display_heartbeat(
+            display_heartbeat_path(config), "fetched_at"
+        )
+        signal = "catalog-fetch"
+        warning = warning or fetch_warning
+    if seen_at is None:
         missing: dict[str, object] = {"checked": False, "stale": None}
         if warning is not None:
             missing["warning"] = warning
         return missing
     threshold = display_stale_threshold(config)
-    stale = current - fetched_at > threshold
+    stale = current - seen_at > threshold
     if stale:
+        described = (
+            "completed a display update" if signal == "display-update" else "fetched the catalog"
+        )
         notice = safe_record_degradation(
             config,
             key="display-heartbeat",
             title="Display updates are stale",
             body=(
-                f"The display node last fetched the catalog at {fetched_at.isoformat()}. "
+                f"The display node last {described} at {seen_at.isoformat()}. "
                 "The frame may be showing an old plate; check its power and network."
             ),
             event=NotificationEvent.DISPLAY_STALE,
@@ -424,13 +440,17 @@ def check_display_heartbeat(config: AppConfig, *, now: datetime | None = None) -
             body="The display node is fetching the catalog again.",
             event=NotificationEvent.DISPLAY_RECOVERED,
         )
-    return {
+    result: dict[str, object] = {
         "checked": True,
         "stale": stale,
-        "fetched_at": fetched_at.isoformat(),
+        "signal": signal,
+        "seen_at": seen_at.isoformat(),
         "threshold_minutes": int(threshold.total_seconds() // 60),
         "notice": notice,
     }
+    if warning is not None:
+        result["warning"] = warning
+    return result
 
 
 def requeue_dead_letters(config: AppConfig, *, now: datetime | None = None) -> int:
@@ -689,20 +709,20 @@ def _health_datetime(value: object) -> datetime | None:
     return parse_utc_timestamp(value)
 
 
-def _read_display_heartbeat(path: Path) -> tuple[datetime | None, str | None]:
+def _read_display_heartbeat(path: Path, field: str) -> tuple[datetime | None, str | None]:
     # A missing file is a valid no-signal state; a corrupt file is reported, never fatal.
     if not path.exists():
         return None, None
     try:
         raw = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return None, f"Invalid display heartbeat: {path}"
     if not isinstance(raw, dict) or raw.get("schema_version") != 1:
         return None, f"Unsupported display heartbeat: {path}"
-    fetched_at = _health_datetime(raw.get("fetched_at"))
-    if fetched_at is None:
+    seen_at = _health_datetime(raw.get(field))
+    if seen_at is None:
         return None, f"Invalid display heartbeat timestamp: {path}"
-    return fetched_at, None
+    return seen_at, None
 
 
 def _read_health(path: Path) -> dict[str, dict[str, object]]:

--- a/src/inky_bird_frame/notifications.py
+++ b/src/inky_bird_frame/notifications.py
@@ -400,9 +400,10 @@ def safe_record_recovery(
 
 def check_display_heartbeat(config: AppConfig, *, now: datetime | None = None) -> dict[str, object]:
     current = (now or datetime.now(UTC)).astimezone(UTC).replace(microsecond=0)
-    success_path = display_success_path(config)
-    success_at, success_warning, _ = _read_display_heartbeat(success_path, "succeeded_at")
-    fetched_at, fetch_warning, reports_success = _read_display_heartbeat(
+    success_at, success_warning = _read_display_heartbeat(
+        display_success_path(config), "succeeded_at"
+    )
+    fetched_at, fetch_warning = _read_display_heartbeat(
         display_heartbeat_path(config), "fetched_at"
     )
     warning = success_warning or fetch_warning
@@ -418,22 +419,15 @@ def check_display_heartbeat(config: AppConfig, *, now: datetime | None = None) -
         stale = current - success_at > threshold
         described = f"completed a display update at {success_at.isoformat()}"
     else:
+        # Only display nodes write the fetch heartbeat, so fetches without a
+        # completed update mean every cycle fails after the catalog download;
+        # the incident failure threshold absorbs the window between a node's
+        # first fetch and its first success.
         assert fetched_at is not None
         signal = "catalog-fetch"
         seen_at = fetched_at
-        if reports_success or success_path.exists():
-            # A node that declares success reporting, or an unreadable success
-            # record, means every cycle fails after the catalog download; the
-            # incident failure threshold absorbs the window between a node's
-            # first fetch and its first success.
-            stale = True
-            described = (
-                f"fetched the catalog at {fetched_at.isoformat()} but never completed an update"
-            )
-        else:
-            # Displays that predate success reporting only signal fetches.
-            stale = current - fetched_at > threshold
-            described = f"fetched the catalog at {fetched_at.isoformat()}"
+        stale = True
+        described = f"fetched the catalog at {fetched_at.isoformat()} but never completed an update"
     if stale:
         notice = safe_record_degradation(
             config,
@@ -723,21 +717,20 @@ def _health_datetime(value: object) -> datetime | None:
     return parse_utc_timestamp(value)
 
 
-def _read_display_heartbeat(path: Path, field: str) -> tuple[datetime | None, str | None, bool]:
+def _read_display_heartbeat(path: Path, field: str) -> tuple[datetime | None, str | None]:
     # A missing file is a valid no-signal state; a corrupt file is reported, never fatal.
     if not path.exists():
-        return None, None, False
+        return None, None
     try:
         raw = json.loads(path.read_text())
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return None, f"Invalid display heartbeat: {path}", False
+        return None, f"Invalid display heartbeat: {path}"
     if not isinstance(raw, dict) or raw.get("schema_version") != 1:
-        return None, f"Unsupported display heartbeat: {path}", False
-    reports_success = raw.get("reports_success") is True
+        return None, f"Unsupported display heartbeat: {path}"
     seen_at = _health_datetime(raw.get(field))
     if seen_at is None:
-        return None, f"Invalid display heartbeat timestamp: {path}", reports_success
-    return seen_at, None, reports_success
+        return None, f"Invalid display heartbeat timestamp: {path}"
+    return seen_at, None
 
 
 def _read_health(path: Path) -> dict[str, dict[str, object]]:

--- a/src/inky_bird_frame/notifications.py
+++ b/src/inky_bird_frame/notifications.py
@@ -400,34 +400,41 @@ def safe_record_recovery(
 
 def check_display_heartbeat(config: AppConfig, *, now: datetime | None = None) -> dict[str, object]:
     current = (now or datetime.now(UTC)).astimezone(UTC).replace(microsecond=0)
-    # Completed display updates are the strongest signal; nodes that predate
-    # the success report fall back to their catalog fetches.
-    seen_at, warning = _read_display_heartbeat(display_success_path(config), "succeeded_at")
-    signal = "display-update"
-    if seen_at is None:
-        seen_at, fetch_warning = _read_display_heartbeat(
-            display_heartbeat_path(config), "fetched_at"
-        )
-        signal = "catalog-fetch"
-        warning = warning or fetch_warning
-    if seen_at is None:
+    success_at, success_warning = _read_display_heartbeat(
+        display_success_path(config), "succeeded_at"
+    )
+    fetched_at, fetch_warning = _read_display_heartbeat(
+        display_heartbeat_path(config), "fetched_at"
+    )
+    warning = success_warning or fetch_warning
+    if success_at is None and fetched_at is None:
         missing: dict[str, object] = {"checked": False, "stale": None}
         if warning is not None:
             missing["warning"] = warning
         return missing
     threshold = display_stale_threshold(config)
-    stale = current - seen_at > threshold
+    if success_at is not None:
+        signal = "display-update"
+        seen_at = success_at
+        stale = current - success_at > threshold
+        described = f"completed a display update at {success_at.isoformat()}"
+    else:
+        # Fetches without a single completed update mean every cycle fails
+        # after the catalog download; the incident failure threshold absorbs
+        # the window between a node's first fetch and its first success.
+        assert fetched_at is not None
+        signal = "catalog-fetch"
+        seen_at = fetched_at
+        stale = True
+        described = f"fetched the catalog at {fetched_at.isoformat()} but never completed an update"
     if stale:
-        described = (
-            "completed a display update" if signal == "display-update" else "fetched the catalog"
-        )
         notice = safe_record_degradation(
             config,
             key="display-heartbeat",
             title="Display updates are stale",
             body=(
-                f"The display node last {described} at {seen_at.isoformat()}. "
-                "The frame may be showing an old plate; check its power and network."
+                f"The display node last {described}. The frame may be showing "
+                "an old plate; check its power, network, and panel."
             ),
             event=NotificationEvent.DISPLAY_STALE,
             now=current,

--- a/src/inky_bird_frame/notifications.py
+++ b/src/inky_bird_frame/notifications.py
@@ -14,9 +14,9 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 from uuid import uuid4
 
-from .catalog import write_json_atomic
 from .config import AppConfig, NotificationDestination, NotificationEvent
 from .errors import CatalogError, ConfigurationError, MissingDependencyError
+from .http import write_json_atomic
 
 if TYPE_CHECKING:
     import apprise

--- a/src/inky_bird_frame/notifications.py
+++ b/src/inky_bird_frame/notifications.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 from .config import AppConfig, NotificationDestination, NotificationEvent
 from .errors import CatalogError, ConfigurationError, MissingDependencyError
 from .http import write_json_atomic
+from .timeutil import parse_utc_timestamp
 
 if TYPE_CHECKING:
     import apprise
@@ -57,6 +58,15 @@ class NotificationState:
 
 def notification_state_path(config: AppConfig) -> Path:
     return config.controller.state_dir / "notifications.json"
+
+
+def display_heartbeat_path(config: AppConfig) -> Path:
+    return config.controller.state_dir / "display-last-fetch.json"
+
+
+def display_stale_threshold(config: AppConfig) -> timedelta:
+    # Three missed rotations, floored so short rotations survive controller downtime.
+    return timedelta(minutes=max(3 * config.schedule.rotation_minutes, 60))
 
 
 def _new_notifier() -> apprise.Apprise:
@@ -349,6 +359,7 @@ def safe_record_degradation(
     title: str,
     body: str,
     event: NotificationEvent = NotificationEvent.DEGRADED,
+    now: datetime | None = None,
 ) -> dict[str, object]:
     try:
         return record_degradation(
@@ -357,6 +368,7 @@ def safe_record_degradation(
             title=title,
             body=body,
             event=event,
+            now=now,
         )
     except Exception as exc:
         return {"queued": False, "error_type": type(exc).__name__}
@@ -380,6 +392,45 @@ def safe_record_recovery(
         )
     except Exception as exc:
         return {"queued": False, "error_type": type(exc).__name__}
+
+
+def check_display_heartbeat(config: AppConfig, *, now: datetime | None = None) -> dict[str, object]:
+    current = (now or datetime.now(UTC)).astimezone(UTC).replace(microsecond=0)
+    fetched_at, warning = _read_display_heartbeat(display_heartbeat_path(config))
+    if fetched_at is None:
+        missing: dict[str, object] = {"checked": False, "stale": None}
+        if warning is not None:
+            missing["warning"] = warning
+        return missing
+    threshold = display_stale_threshold(config)
+    stale = current - fetched_at > threshold
+    if stale:
+        notice = safe_record_degradation(
+            config,
+            key="display-heartbeat",
+            title="Display updates are stale",
+            body=(
+                f"The display node last fetched the catalog at {fetched_at.isoformat()}. "
+                "The frame may be showing an old plate; check its power and network."
+            ),
+            event=NotificationEvent.DISPLAY_STALE,
+            now=current,
+        )
+    else:
+        notice = safe_record_recovery(
+            config,
+            key="display-heartbeat",
+            title="Display updates recovered",
+            body="The display node is fetching the catalog again.",
+            event=NotificationEvent.DISPLAY_RECOVERED,
+        )
+    return {
+        "checked": True,
+        "stale": stale,
+        "fetched_at": fetched_at.isoformat(),
+        "threshold_minutes": int(threshold.total_seconds() // 60),
+        "notice": notice,
+    }
 
 
 def requeue_dead_letters(config: AppConfig, *, now: datetime | None = None) -> int:
@@ -635,13 +686,23 @@ def _required_datetime(value: object, source: Path) -> datetime:
 
 
 def _health_datetime(value: object) -> datetime | None:
-    if not isinstance(value, str):
-        return None
+    return parse_utc_timestamp(value)
+
+
+def _read_display_heartbeat(path: Path) -> tuple[datetime | None, str | None]:
+    # A missing file is a valid no-signal state; a corrupt file is reported, never fatal.
+    if not path.exists():
+        return None, None
     try:
-        parsed = datetime.fromisoformat(value)
-    except ValueError:
-        return None
-    return parsed.astimezone(UTC) if parsed.tzinfo is not None else None
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None, f"Invalid display heartbeat: {path}"
+    if not isinstance(raw, dict) or raw.get("schema_version") != 1:
+        return None, f"Unsupported display heartbeat: {path}"
+    fetched_at = _health_datetime(raw.get("fetched_at"))
+    if fetched_at is None:
+        return None, f"Invalid display heartbeat timestamp: {path}"
+    return fetched_at, None
 
 
 def _read_health(path: Path) -> dict[str, dict[str, object]]:

--- a/src/inky_bird_frame/notifications.py
+++ b/src/inky_bird_frame/notifications.py
@@ -400,10 +400,9 @@ def safe_record_recovery(
 
 def check_display_heartbeat(config: AppConfig, *, now: datetime | None = None) -> dict[str, object]:
     current = (now or datetime.now(UTC)).astimezone(UTC).replace(microsecond=0)
-    success_at, success_warning = _read_display_heartbeat(
-        display_success_path(config), "succeeded_at"
-    )
-    fetched_at, fetch_warning = _read_display_heartbeat(
+    success_path = display_success_path(config)
+    success_at, success_warning, _ = _read_display_heartbeat(success_path, "succeeded_at")
+    fetched_at, fetch_warning, reports_success = _read_display_heartbeat(
         display_heartbeat_path(config), "fetched_at"
     )
     warning = success_warning or fetch_warning
@@ -419,14 +418,22 @@ def check_display_heartbeat(config: AppConfig, *, now: datetime | None = None) -
         stale = current - success_at > threshold
         described = f"completed a display update at {success_at.isoformat()}"
     else:
-        # Fetches without a single completed update mean every cycle fails
-        # after the catalog download; the incident failure threshold absorbs
-        # the window between a node's first fetch and its first success.
         assert fetched_at is not None
         signal = "catalog-fetch"
         seen_at = fetched_at
-        stale = True
-        described = f"fetched the catalog at {fetched_at.isoformat()} but never completed an update"
+        if reports_success or success_path.exists():
+            # A node that declares success reporting, or an unreadable success
+            # record, means every cycle fails after the catalog download; the
+            # incident failure threshold absorbs the window between a node's
+            # first fetch and its first success.
+            stale = True
+            described = (
+                f"fetched the catalog at {fetched_at.isoformat()} but never completed an update"
+            )
+        else:
+            # Displays that predate success reporting only signal fetches.
+            stale = current - fetched_at > threshold
+            described = f"fetched the catalog at {fetched_at.isoformat()}"
     if stale:
         notice = safe_record_degradation(
             config,
@@ -716,20 +723,21 @@ def _health_datetime(value: object) -> datetime | None:
     return parse_utc_timestamp(value)
 
 
-def _read_display_heartbeat(path: Path, field: str) -> tuple[datetime | None, str | None]:
+def _read_display_heartbeat(path: Path, field: str) -> tuple[datetime | None, str | None, bool]:
     # A missing file is a valid no-signal state; a corrupt file is reported, never fatal.
     if not path.exists():
-        return None, None
+        return None, None, False
     try:
         raw = json.loads(path.read_text())
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return None, f"Invalid display heartbeat: {path}"
+        return None, f"Invalid display heartbeat: {path}", False
     if not isinstance(raw, dict) or raw.get("schema_version") != 1:
-        return None, f"Unsupported display heartbeat: {path}"
+        return None, f"Unsupported display heartbeat: {path}", False
+    reports_success = raw.get("reports_success") is True
     seen_at = _health_datetime(raw.get(field))
     if seen_at is None:
-        return None, f"Invalid display heartbeat timestamp: {path}"
-    return seen_at, None
+        return None, f"Invalid display heartbeat timestamp: {path}", reports_success
+    return seen_at, None, reports_success
 
 
 def _read_health(path: Path) -> dict[str, dict[str, object]]:

--- a/src/inky_bird_frame/publisher.py
+++ b/src/inky_bird_frame/publisher.py
@@ -20,6 +20,7 @@ from .catalog import (
     CatalogEntry,
     catalog_index_data,
     catalog_state_lock,
+    clear_catalog_staging,
     has_passing_sourced_review,
     is_bounded_generation,
     read_catalog_entries,
@@ -605,6 +606,8 @@ def run_catalog_publish(config: AppConfig, *, dry_run: bool = False) -> dict[str
         with TemporaryDirectory(prefix="publish-", dir=work_parent) as temporary:
             source_snapshot = Path(temporary) / "source-catalog"
             with catalog_state_lock(config.controller.state_dir):
+                # Approval staging debris would fail the snapshot root check.
+                clear_catalog_staging(config.controller.catalog_dir)
                 try:
                     shutil.copytree(
                         config.controller.catalog_dir,

--- a/src/inky_bird_frame/research.py
+++ b/src/inky_bird_frame/research.py
@@ -6,8 +6,8 @@ import json
 from datetime import UTC, date, datetime
 from pathlib import Path
 
-from .catalog import write_json_atomic
 from .errors import CatalogError, GenerationError
+from .http import write_json_atomic
 
 
 class ResearchBudget:

--- a/src/inky_bird_frame/retry.py
+++ b/src/inky_bird_frame/retry.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from .catalog import utc_now
 from .errors import CatalogError
 from .http import write_json_atomic
+from .timeutil import parse_utc_timestamp
 
 
 @dataclass(frozen=True)
@@ -134,15 +135,10 @@ class RetryStore:
 
 
 def _parse_datetime(value: object, source: Path) -> datetime:
-    if not isinstance(value, str):
+    parsed = parse_utc_timestamp(value)
+    if parsed is None:
         raise CatalogError(f"Invalid retry timestamp: {source}")
-    try:
-        parsed = datetime.fromisoformat(value)
-    except ValueError as exc:
-        raise CatalogError(f"Invalid retry timestamp: {source}") from exc
-    if parsed.tzinfo is None:
-        raise CatalogError(f"Retry timestamp has no timezone: {source}")
-    return parsed.astimezone(UTC)
+    return parsed
 
 
 def _parse_record(raw: object, source: Path) -> RetryRecord:

--- a/src/inky_bird_frame/retry.py
+++ b/src/inky_bird_frame/retry.py
@@ -7,8 +7,9 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-from .catalog import write_json_atomic
+from .catalog import utc_now
 from .errors import CatalogError
+from .http import write_json_atomic
 
 
 @dataclass(frozen=True)
@@ -123,7 +124,7 @@ class RetryStore:
             self.path,
             {
                 "schema_version": 1,
-                "updated_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+                "updated_at": utc_now(),
                 "records": [
                     record.as_dict()
                     for record in sorted(self._records.values(), key=lambda item: item.taxon_id)

--- a/src/inky_bird_frame/selection.py
+++ b/src/inky_bird_frame/selection.py
@@ -4,17 +4,8 @@ from __future__ import annotations
 
 import random
 
-from .birds import BirdSpecies
 from .catalog import CatalogEntry
 from .config import RotationMode
-
-
-def select_rotating_species(species: list[BirdSpecies], step: int = 0) -> BirdSpecies:
-    if not species:
-        raise ValueError("species list must not be empty")
-    if step < 0:
-        raise ValueError("step must be zero or greater")
-    return species[step % len(species)]
 
 
 def select_catalog_entry(

--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from urllib.parse import unquote, urlsplit
+from urllib.parse import parse_qs, unquote, urlsplit
 
 from .catalog import read_json, rebuild_catalog_index, utc_now
 from .config import ControllerConfig
@@ -76,7 +76,7 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
             self._send_json(HTTPStatus.OK, payload)
             # Only display nodes send the marker; a curl or monitor fetch must
             # not refresh the liveness signal.
-            if "reports_success=1" in split.query:
+            if parse_qs(split.query).get("reports_success") == ["1"]:
                 with suppress(OSError):
                     write_json_atomic(
                         self.state_dir / "display-last-fetch.json",

--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -79,6 +79,14 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
                     {"schema_version": 1, "fetched_at": utc_now()},
                 )
             return
+        if request_path == "/v1/display-success":
+            self._send_json(HTTPStatus.OK, {"ok": True, "schema_version": 1})
+            with suppress(OSError):
+                write_json_atomic(
+                    self.state_dir / "display-last-success.json",
+                    {"schema_version": 1, "succeeded_at": utc_now()},
+                )
+            return
         prefix = "/v1/assets/"
         if request_path.startswith(prefix):
             relative = Path(unquote(request_path.removeprefix(prefix)))

--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -74,15 +74,14 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
                 )
                 return
             self._send_json(HTTPStatus.OK, payload)
-            with suppress(OSError):
-                write_json_atomic(
-                    self.state_dir / "display-last-fetch.json",
-                    {
-                        "schema_version": 1,
-                        "fetched_at": utc_now(),
-                        "reports_success": "reports_success=1" in split.query,
-                    },
-                )
+            # Only display nodes send the marker; a curl or monitor fetch must
+            # not refresh the liveness signal.
+            if "reports_success=1" in split.query:
+                with suppress(OSError):
+                    write_json_atomic(
+                        self.state_dir / "display-last-fetch.json",
+                        {"schema_version": 1, "fetched_at": utc_now()},
+                    )
             return
         if request_path == "/v1/display-success":
             self._send_json(HTTPStatus.OK, {"ok": True, "schema_version": 1})

--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -108,12 +108,16 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
         )
 
 
+def rebuild_index_logging_failures(catalog_dir: Path) -> None:
+    try:
+        rebuild_catalog_index(catalog_dir)
+    except (CatalogError, OSError) as exc:
+        print(json.dumps({"event": "catalog_index_rebuild_failed", "error": str(exc)}))
+
+
 def serve_catalog(config: ControllerConfig) -> None:
     config.catalog_dir.mkdir(parents=True, exist_ok=True)
-    try:
-        rebuild_catalog_index(config.catalog_dir)
-    except CatalogError as exc:
-        print(json.dumps({"event": "catalog_index_rebuild_failed", "error": str(exc)}))
+    rebuild_index_logging_failures(config.catalog_dir)
     handler = type(
         "ConfiguredCatalogRequestHandler",
         (CatalogRequestHandler,),

--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -92,7 +92,11 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
             relative = Path(unquote(request_path.removeprefix(prefix)))
             root = self.catalog_dir.resolve()
             candidate = (root / relative).resolve()
-            if not candidate.is_relative_to(root) or not candidate.is_file():
+            if (
+                any(part.startswith(".") for part in relative.parts)
+                or not candidate.is_relative_to(root)
+                or not candidate.is_file()
+            ):
                 self._send_json(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not found"})
                 return
             self._send_file(candidate)

--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -4,18 +4,32 @@ from __future__ import annotations
 
 import json
 import mimetypes
+from contextlib import suppress
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import unquote, urlsplit
 
-from .catalog import read_json, rebuild_catalog_index
+from .catalog import read_json, rebuild_catalog_index, utc_now
 from .config import ControllerConfig
+from .errors import CatalogError
+from .http import write_json_atomic
+
+
+def _species_count(path: Path) -> int:
+    try:
+        value = read_json(path)
+    except CatalogError:
+        return 0
+    if isinstance(value, dict) and isinstance(value.get("species"), list):
+        return len(value["species"])
+    return 0
 
 
 class CatalogRequestHandler(BaseHTTPRequestHandler):
     catalog_dir: Path
     active_catalog_path: Path
+    state_dir: Path
 
     def _send_json(self, status: HTTPStatus, payload: object) -> None:
         body = json.dumps(payload, sort_keys=True).encode()
@@ -39,30 +53,31 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
         request_path = urlsplit(self.path).path
         if request_path == "/health":
-            entries = rebuild_catalog_index(self.catalog_dir)
-            active_count = 0
-            if self.active_catalog_path.is_file():
-                active = read_json(self.active_catalog_path)
-                if isinstance(active, dict) and isinstance(active.get("species"), list):
-                    active_count = len(active["species"])
             self._send_json(
                 HTTPStatus.OK,
                 {
                     "ok": True,
-                    "approved_species": len(entries),
-                    "active_species": active_count,
+                    "approved_species": _species_count(self.catalog_dir / "index.json"),
+                    "active_species": _species_count(self.active_catalog_path),
                     "schema_version": 1,
                 },
             )
             return
         if request_path == "/v1/catalog":
-            if not self.active_catalog_path.is_file():
+            try:
+                payload = read_json(self.active_catalog_path)
+            except CatalogError:
                 self._send_json(
                     HTTPStatus.SERVICE_UNAVAILABLE,
                     {"ok": False, "error": "active catalog unavailable", "schema_version": 1},
                 )
                 return
-            self._send_json(HTTPStatus.OK, read_json(self.active_catalog_path))
+            self._send_json(HTTPStatus.OK, payload)
+            with suppress(OSError):
+                write_json_atomic(
+                    self.state_dir / "display-last-fetch.json",
+                    {"schema_version": 1, "fetched_at": utc_now()},
+                )
             return
         prefix = "/v1/assets/"
         if request_path.startswith(prefix):
@@ -87,13 +102,17 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
 
 def serve_catalog(config: ControllerConfig) -> None:
     config.catalog_dir.mkdir(parents=True, exist_ok=True)
-    rebuild_catalog_index(config.catalog_dir)
+    try:
+        rebuild_catalog_index(config.catalog_dir)
+    except CatalogError as exc:
+        print(json.dumps({"event": "catalog_index_rebuild_failed", "error": str(exc)}))
     handler = type(
         "ConfiguredCatalogRequestHandler",
         (CatalogRequestHandler,),
         {
             "catalog_dir": config.catalog_dir,
             "active_catalog_path": config.state_dir / "active-catalog.json",
+            "state_dir": config.state_dir,
         },
     )
     server = ThreadingHTTPServer((config.bind_host, config.port), handler)

--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -51,7 +51,8 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
-        request_path = urlsplit(self.path).path
+        split = urlsplit(self.path)
+        request_path = split.path
         if request_path == "/health":
             self._send_json(
                 HTTPStatus.OK,
@@ -76,7 +77,11 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
             with suppress(OSError):
                 write_json_atomic(
                     self.state_dir / "display-last-fetch.json",
-                    {"schema_version": 1, "fetched_at": utc_now()},
+                    {
+                        "schema_version": 1,
+                        "fetched_at": utc_now(),
+                        "reports_success": "reports_success=1" in split.query,
+                    },
                 )
             return
         if request_path == "/v1/display-success":

--- a/src/inky_bird_frame/timeutil.py
+++ b/src/inky_bird_frame/timeutil.py
@@ -1,0 +1,18 @@
+"""Shared timestamp parsing for schema-versioned state files."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def parse_utc_timestamp(value: object) -> datetime | None:
+    """Parse an ISO-8601 timestamp, requiring a timezone; None when invalid."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        return None
+    return parsed.astimezone(UTC)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+"""Shared test hardening: no inherited git configuration, no outbound network."""
+
+from __future__ import annotations
+
+import os
+import socket
+from typing import Any
+
+# Keep tests hermetic against the developer's git configuration; global
+# url.<base>.insteadOf rewrites otherwise change `git remote get-url` output
+# inside publisher tests. Subprocesses inherit this environment.
+os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+os.environ["GIT_CONFIG_SYSTEM"] = os.devnull
+
+_LOOPBACK_HOSTS = ("localhost", "127.0.0.1", "::1")
+_original_connect = socket.socket.connect
+
+
+def _guarded_connect(self: socket.socket, address: Any) -> None:
+    if isinstance(address, tuple) and address:
+        host = address[0]
+        if isinstance(host, str) and host not in _LOOPBACK_HOSTS and not host.startswith("127."):
+            raise RuntimeError(f"Test attempted an outbound network connection to {host!r}")
+    _original_connect(self, address)
+
+
+socket.socket.connect = _guarded_connect  # type: ignore[method-assign, assignment]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -226,6 +226,33 @@ class CatalogTests(unittest.TestCase):
             with self.assertRaisesRegex(CatalogError, "Invalid JSON"):
                 read_json(path)
 
+    def test_destination_with_incomplete_manifest_fields_is_reapproved(self) -> None:
+        species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")
+        review = QualityReview(True, 4, 4, 4, 4, True, ())
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            state = root / "state"
+            catalog = root / "catalog"
+            candidate = make_candidate(state, species, review)
+            manifest = json.loads((candidate / "manifest.json").read_text())
+            manifest["status"] = "approved"
+            del manifest["scientific_name"]
+
+            destination = catalog / "species" / "7513-carolina-wren"
+            destination.mkdir(parents=True)
+            (destination / "manifest.json").write_text(json.dumps(manifest))
+            shutil.copy(candidate / "portrait.png", destination / "portrait.png")
+            shutil.copy(candidate / "display.png", destination / "display.png")
+
+            entry = approve_candidate(state, catalog, species.taxon_id)
+
+            self.assertEqual(entry.scientific_name, "Thryothorus ludovicianus")
+            self.assertFalse(candidate.exists())
+            self.assertEqual(
+                [item.taxon_id for item in read_catalog_entries(catalog)],
+                [species.taxon_id],
+            )
+
     def test_conflicting_destination_still_requires_explicit_replacement(self) -> None:
         species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")
         review = QualityReview(True, 4, 4, 4, 4, True, ())

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -12,9 +12,9 @@ from inky_bird_frame.catalog import (
     candidate_directory,
     rebuild_catalog_index,
     write_candidate_manifest,
-    write_json_atomic,
 )
 from inky_bird_frame.errors import CatalogError
+from inky_bird_frame.http import write_json_atomic
 from inky_bird_frame.models import QualityReview, SpeciesProfileData
 
 PROFILE = SpeciesProfileData(

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -12,6 +12,7 @@ from inky_bird_frame.catalog import (
     approve_candidate,
     candidate_directory,
     read_catalog_entries,
+    read_json,
     rebuild_catalog_index,
     write_candidate_manifest,
 )
@@ -180,6 +181,33 @@ class CatalogTests(unittest.TestCase):
                 [item.taxon_id for item in read_catalog_entries(catalog)],
                 [species.taxon_id],
             )
+
+    def test_destination_without_readable_manifest_is_discarded_and_reapproved(self) -> None:
+        species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")
+        review = QualityReview(True, 4, 4, 4, 4, True, ())
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            state = root / "state"
+            catalog = root / "catalog"
+            candidate = make_candidate(state, species, review)
+
+            # An old-flow crash before the manifest landed in the destination.
+            destination = catalog / "species" / "7513-carolina-wren"
+            destination.mkdir(parents=True)
+            (destination / "portrait.png").write_bytes(b"partial")
+
+            entry = approve_candidate(state, catalog, species.taxon_id)
+
+            self.assertEqual(entry.taxon_id, species.taxon_id)
+            self.assertFalse(candidate.exists())
+            self.assertEqual((destination / "display.png").read_bytes(), b"display")
+
+    def test_read_json_reports_non_utf8_corruption_as_catalog_error(self) -> None:
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "torn.json"
+            path.write_bytes(b'{"schema_version": 1, "species": [\xff\xfe')
+            with self.assertRaisesRegex(CatalogError, "Invalid JSON"):
+                read_json(path)
 
     def test_conflicting_destination_still_requires_explicit_replacement(self) -> None:
         species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -226,7 +226,7 @@ class CatalogTests(unittest.TestCase):
             with self.assertRaisesRegex(CatalogError, "Invalid JSON"):
                 read_json(path)
 
-    def test_destination_with_incomplete_manifest_fields_is_reapproved(self) -> None:
+    def test_destination_with_differing_manifest_preserves_pending_and_raises(self) -> None:
         species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")
         review = QualityReview(True, 4, 4, 4, 4, True, ())
         with TemporaryDirectory() as temporary:
@@ -236,7 +236,8 @@ class CatalogTests(unittest.TestCase):
             candidate = make_candidate(state, species, review)
             manifest = json.loads((candidate / "manifest.json").read_text())
             manifest["status"] = "approved"
-            del manifest["scientific_name"]
+            manifest["approved_at"] = "2026-07-10T00:00:00+00:00"
+            manifest["common_name"] = "Corrected Wren"
 
             destination = catalog / "species" / "7513-carolina-wren"
             destination.mkdir(parents=True)
@@ -244,14 +245,11 @@ class CatalogTests(unittest.TestCase):
             shutil.copy(candidate / "portrait.png", destination / "portrait.png")
             shutil.copy(candidate / "display.png", destination / "display.png")
 
-            entry = approve_candidate(state, catalog, species.taxon_id)
+            with self.assertRaisesRegex(CatalogError, "explicit replacement workflow"):
+                approve_candidate(state, catalog, species.taxon_id)
 
-            self.assertEqual(entry.scientific_name, "Thryothorus ludovicianus")
-            self.assertFalse(candidate.exists())
-            self.assertEqual(
-                [item.taxon_id for item in read_catalog_entries(catalog)],
-                [species.taxon_id],
-            )
+            self.assertTrue(candidate.exists())
+            self.assertTrue((destination / "manifest.json").exists())
 
     def test_conflicting_destination_still_requires_explicit_replacement(self) -> None:
         species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import unittest
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -10,6 +11,7 @@ from inky_bird_frame.birds import BirdSpecies
 from inky_bird_frame.catalog import (
     approve_candidate,
     candidate_directory,
+    read_catalog_entries,
     rebuild_catalog_index,
     write_candidate_manifest,
 )
@@ -32,6 +34,23 @@ PROFILE = SpeciesProfileData(
         {"title": "Source two", "url": "https://example.test/two"},
     ],
 )
+
+
+def make_candidate(state: Path, species: BirdSpecies, review: QualityReview) -> Path:
+    candidate = candidate_directory(state, species)
+    candidate.mkdir(parents=True)
+    (candidate / "portrait.png").write_bytes(b"portrait")
+    (candidate / "display.png").write_bytes(b"display")
+    write_candidate_manifest(
+        candidate,
+        species,
+        PROFILE,
+        [],
+        review,
+        generator="test",
+        prompt_version="test-v1",
+    )
+    return candidate
 
 
 class CatalogTests(unittest.TestCase):
@@ -88,6 +107,79 @@ class CatalogTests(unittest.TestCase):
             self.assertFalse(candidate.exists())
             with self.assertRaises(CatalogError):
                 approve_candidate(state, catalog, species.taxon_id)
+
+    def test_interrupted_approval_with_leftover_pending_candidate_completes(self) -> None:
+        species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")
+        review = QualityReview(True, 4, 4, 4, 4, True, ())
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            state = root / "state"
+            catalog = root / "catalog"
+            candidate = make_candidate(state, species, review)
+            backup = root / "backup"
+            shutil.copytree(candidate, backup)
+            approve_candidate(state, catalog, species.taxon_id)
+            shutil.copytree(backup, candidate)
+
+            entry = approve_candidate(state, catalog, species.taxon_id)
+
+            self.assertEqual(entry.taxon_id, species.taxon_id)
+            self.assertFalse(candidate.exists())
+            self.assertEqual(
+                [item.taxon_id for item in read_catalog_entries(catalog)],
+                [species.taxon_id],
+            )
+
+    def test_stale_staging_is_cleared_and_invisible_to_catalog_reads(self) -> None:
+        species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")
+        review = QualityReview(True, 4, 4, 4, 4, True, ())
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            state = root / "state"
+            catalog = root / "catalog"
+            make_candidate(state, species, review)
+            stale = catalog / ".staging" / "7513-carolina-wren"
+            stale.mkdir(parents=True)
+            (stale / "manifest.json").write_text("{not json")
+
+            self.assertEqual(read_catalog_entries(catalog), [])
+
+            entry = approve_candidate(state, catalog, species.taxon_id)
+
+            self.assertFalse(stale.exists())
+            self.assertEqual(entry.taxon_id, species.taxon_id)
+            self.assertEqual(
+                [item.taxon_id for item in read_catalog_entries(catalog)],
+                [species.taxon_id],
+            )
+
+    def test_conflicting_destination_still_requires_explicit_replacement(self) -> None:
+        species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")
+        review = QualityReview(True, 4, 4, 4, 4, True, ())
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            state = root / "state"
+            catalog = root / "catalog"
+            make_candidate(state, species, review)
+            approve_candidate(state, catalog, species.taxon_id)
+            candidate = candidate_directory(state, species)
+            candidate.mkdir(parents=True)
+            (candidate / "portrait.png").write_bytes(b"different portrait")
+            (candidate / "display.png").write_bytes(b"different display")
+            write_candidate_manifest(
+                candidate,
+                species,
+                PROFILE,
+                [],
+                review,
+                generator="test",
+                prompt_version="test-v1",
+            )
+
+            with self.assertRaisesRegex(CatalogError, "already approved"):
+                approve_candidate(state, catalog, species.taxon_id)
+
+            self.assertTrue(candidate.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -153,6 +153,34 @@ class CatalogTests(unittest.TestCase):
                 [species.taxon_id],
             )
 
+    def test_partial_destination_is_discarded_and_reapproved_from_pending(self) -> None:
+        species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")
+        review = QualityReview(True, 4, 4, 4, 4, True, ())
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            state = root / "state"
+            catalog = root / "catalog"
+            candidate = make_candidate(state, species, review)
+            manifest = json.loads((candidate / "manifest.json").read_text())
+            manifest["status"] = "approved"
+            manifest["approved_at"] = "2026-07-10T00:00:00+00:00"
+
+            # An old-flow crash mid-copy: manifest landed, display.png did not.
+            destination = catalog / "species" / "7513-carolina-wren"
+            destination.mkdir(parents=True)
+            (destination / "manifest.json").write_text(json.dumps(manifest))
+            (destination / "portrait.png").write_bytes(b"portrait")
+
+            entry = approve_candidate(state, catalog, species.taxon_id)
+
+            self.assertEqual(entry.taxon_id, species.taxon_id)
+            self.assertFalse(candidate.exists())
+            self.assertEqual((destination / "display.png").read_bytes(), b"display")
+            self.assertEqual(
+                [item.taxon_id for item in read_catalog_entries(catalog)],
+                [species.taxon_id],
+            )
+
     def test_conflicting_destination_still_requires_explicit_replacement(self) -> None:
         species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")
         review = QualityReview(True, 4, 4, 4, 4, True, ())

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -154,6 +154,23 @@ class CatalogTests(unittest.TestCase):
                 [species.taxon_id],
             )
 
+    def test_successful_approval_leaves_no_staging_directory(self) -> None:
+        species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")
+        review = QualityReview(True, 4, 4, 4, 4, True, ())
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            state = root / "state"
+            catalog = root / "catalog"
+            make_candidate(state, species, review)
+
+            approve_candidate(state, catalog, species.taxon_id)
+
+            self.assertFalse((catalog / ".staging").exists())
+            self.assertEqual(
+                sorted(path.name for path in catalog.iterdir()),
+                ["index.json", "species"],
+            )
+
     def test_partial_destination_is_discarded_and_reapproved_from_pending(self) -> None:
         species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")
         review = QualityReview(True, 4, 4, 4, 4, True, ())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -336,6 +336,9 @@ rotation_mode = "shuffle_bag"
             profile = state_dir / "profiles/42/profile.json"
             profile.parent.mkdir(parents=True)
             profile.write_text("{}")
+            references = state_dir / "references/42/references.json"
+            references.parent.mkdir(parents=True)
+            references.write_text("{}")
             config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
             output = io.StringIO()
 
@@ -343,10 +346,11 @@ rotation_mode = "shuffle_bag"
                 retry_command(Namespace(taxon_id=42))
 
             result = json.loads(output.getvalue())["data"]
-            profile_exists = profile.exists()
+            profile_exists = profile.exists() or references.exists()
             archived_profile_exists = (state_dir / "archive/42/profile.json").exists()
 
         self.assertTrue(result["cleared_cached_profile"])
+        self.assertTrue(result["cleared_cached_references"])
         self.assertFalse(profile_exists)
         self.assertTrue(archived_profile_exists)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@ from inky_bird_frame.cli import (
     config_install_command,
     generate_command,
     main,
+    notifications_dispatch_command,
     refresh_command,
     retry_command,
     seed_command,
@@ -182,6 +183,28 @@ class CliTests(unittest.TestCase):
         self.assertEqual(str(test.config), "instance.toml")
         self.assertEqual(str(dispatch.config), "instance.toml")
         self.assertEqual(str(retry.config), "instance.toml")
+
+    def test_notifications_dispatch_checks_display_heartbeat(self) -> None:
+        output = io.StringIO()
+        with (
+            patch("inky_bird_frame.cli._config"),
+            patch(
+                "inky_bird_frame.cli.dispatch_notifications",
+                return_value={"attempted": 0},
+            ) as dispatch,
+            patch(
+                "inky_bird_frame.cli.check_display_heartbeat",
+                return_value={"checked": False, "stale": None},
+            ) as check,
+            redirect_stdout(output),
+        ):
+            notifications_dispatch_command(Namespace())
+
+        payload = json.loads(output.getvalue())["data"]
+        self.assertEqual(check.call_count, 1)
+        self.assertEqual(dispatch.call_count, 1)
+        self.assertEqual(payload["display_heartbeat"], {"checked": False, "stale": None})
+        self.assertEqual(payload["attempted"], 0)
 
     def test_config_install_validates_and_atomically_writes_private_file(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -1,14 +1,189 @@
 from __future__ import annotations
 
+import json
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
-from inky_bird_frame.birds import BirdSpecies
+from inky_bird_frame.birds import BirdSpecies, TaxonContext
 from inky_bird_frame.codex_runner import CodexRunner, _parse_review, parse_species_profile
 from inky_bird_frame.errors import GenerationError
 from inky_bird_frame.models import SpeciesProfileData
+
+_CAPTURE_OUTPUT_ARGUMENT = """\
+out=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-o" ]; then
+    out="$arg"
+  fi
+  prev="$arg"
+done
+"""
+
+
+def _stub_executable(root: Path, body: str) -> Path:
+    stub = root / "codex"
+    stub.write_text(f"#!/bin/sh\n{body}\n")
+    stub.chmod(0o755)
+    return stub
+
+
+def _species() -> BirdSpecies:
+    return BirdSpecies(1, "Test Bird", "Avis test", 1, "test")
+
+
+def _context() -> TaxonContext:
+    return TaxonContext(
+        taxon_id=1,
+        common_name="Test Bird",
+        scientific_name="Avis test",
+        family="Testidae",
+        summary="A test bird.",
+        source_url="https://birds.example/taxa/1",
+    )
+
+
+def _profile() -> SpeciesProfileData:
+    return SpeciesProfileData(
+        taxon_id=1,
+        common_name="Test Bird",
+        scientific_name="Avis test",
+        family="Testidae",
+        measurements={"length": "1 in", "wingspan": "2 in", "weight": "3 oz"},
+        field_marks=["one", "two", "three", "four"],
+        habitat="Woods",
+        behavior="Perches",
+        palette=["red", "green", "blue"],
+        sources=[
+            {"title": "One", "url": "https://birds.example/one"},
+            {"title": "Two", "url": "https://field.example/two"},
+        ],
+    )
+
+
+class CodexRunnerSubprocessTests(unittest.TestCase):
+    def test_nonzero_exit_raises_and_still_writes_log(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            stub = _stub_executable(
+                root,
+                'echo "stub stdout marker"\necho "stub stderr marker" >&2\nexit 3',
+            )
+            runner = CodexRunner(stub, root)
+            log_path = root / "logs" / "plate.log"
+
+            with self.assertRaisesRegex(GenerationError, "Codex exited with status 3; see "):
+                runner.generate_plate(_species(), _profile(), [], [], root / "plate.png", log_path)
+
+            self.assertTrue(log_path.is_file())
+            log = log_path.read_text()
+            self.assertIn("stub stdout marker", log)
+            self.assertIn("stub stderr marker", log)
+
+    def test_timeout_raises_generation_error(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            stub = _stub_executable(root, "sleep 5")
+            runner = CodexRunner(stub, root, timeout_seconds=1)
+
+            with self.assertRaisesRegex(GenerationError, "Codex timed out after 1 second"):
+                runner.generate_plate(
+                    _species(), _profile(), [], [], root / "plate.png", root / "plate.log"
+                )
+
+    def test_structured_output_missing_file_raises(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            stub = _stub_executable(root, "exit 0")
+            runner = CodexRunner(stub, root)
+            plate_path = root / "plate.png"
+            plate_path.write_bytes(b"png")
+
+            with self.assertRaisesRegex(
+                GenerationError, "Codex did not write valid structured output"
+            ):
+                runner.review_plate(
+                    _species(),
+                    _profile(),
+                    [],
+                    plate_path,
+                    [],
+                    root / "review.json",
+                    root / "review.log",
+                    allowed_domains=("birds.example", "field.example"),
+                )
+
+    def test_structured_output_invalid_json_raises(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            stub = _stub_executable(root, f'{_CAPTURE_OUTPUT_ARGUMENT}printf "not json" > "$out"')
+            runner = CodexRunner(stub, root)
+
+            with self.assertRaisesRegex(
+                GenerationError, "Codex did not write valid structured output"
+            ):
+                runner.create_profile(
+                    _species(),
+                    _context(),
+                    [],
+                    [],
+                    root / "profile.json",
+                    root / "profile.log",
+                    allowed_domains=("birds.example", "field.example"),
+                )
+
+    def test_generate_plate_missing_image_raises(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            stub = _stub_executable(root, "exit 0")
+            runner = CodexRunner(stub, root)
+
+            with self.assertRaisesRegex(
+                GenerationError, "Codex did not create the requested plate"
+            ):
+                runner.generate_plate(
+                    _species(), _profile(), [], [], root / "plate.png", root / "plate.log"
+                )
+
+    def test_generate_plate_zero_byte_image_raises(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            stub = _stub_executable(root, "exit 0")
+            runner = CodexRunner(stub, root)
+            plate_path = root / "plate.png"
+            plate_path.touch()
+
+            with self.assertRaisesRegex(
+                GenerationError, "Codex did not create the requested plate"
+            ):
+                runner.generate_plate(
+                    _species(), _profile(), [], [], plate_path, root / "plate.log"
+                )
+
+    def test_create_profile_rejects_mismatched_taxon_identity(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            payload: dict[str, object] = dict(_profile())
+            payload["taxon_id"] = 999
+            payload_path = root / "payload.json"
+            payload_path.write_text(json.dumps(payload))
+            stub = _stub_executable(root, f'{_CAPTURE_OUTPUT_ARGUMENT}cp "{payload_path}" "$out"')
+            runner = CodexRunner(stub, root)
+
+            with self.assertRaisesRegex(
+                GenerationError, "Codex profile identity does not match the discovered taxon"
+            ):
+                runner.create_profile(
+                    _species(),
+                    _context(),
+                    [],
+                    [],
+                    root / "profile.json",
+                    root / "profile.log",
+                    allowed_domains=("birds.example", "field.example"),
+                )
 
 
 class CodexRunnerTests(unittest.TestCase):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -254,6 +254,25 @@ class ConfigTests(unittest.TestCase):
             with self.assertRaisesRegex(ConfigurationError, "must not exceed 100"):
                 load_config(path)
 
+    def test_rejects_controller_port_above_tcp_maximum(self) -> None:
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(CONFIG.replace("port = 8793", "port = 70000"))
+
+            with self.assertRaisesRegex(
+                ConfigurationError, "port must be an integer less than or equal to 65535"
+            ):
+                load_config(path)
+
+    def test_accepts_controller_port_at_tcp_maximum(self) -> None:
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(CONFIG.replace("port = 8793", "port = 65535"))
+
+            config = load_config(path)
+
+        self.assertEqual(config.controller.port, 65535)
+
     def test_rejects_invalid_zip(self) -> None:
         with TemporaryDirectory() as temporary:
             path = Path(temporary) / "config.toml"
@@ -403,6 +422,30 @@ insufficient_references_retry_minutes = 1440""",
         self.assertEqual(
             config.notifications.destinations[0].events,
             (NotificationEvent.GENERATION_APPROVED, NotificationEvent.TERMINAL_ERROR),
+        )
+
+    def test_notification_destinations_accept_display_heartbeat_events(self) -> None:
+        configured = (
+            CONFIG
+            + """
+
+[notifications]
+enabled = true
+
+[[notifications.destinations]]
+name = "pushover"
+url = "pover://user@token"
+events = ["display_stale", "display_recovered"]
+"""
+        )
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(configured)
+            config = load_config(path)
+
+        self.assertEqual(
+            config.notifications.destinations[0].events,
+            (NotificationEvent.DISPLAY_STALE, NotificationEvent.DISPLAY_RECOVERED),
         )
 
     def test_research_requires_two_distinct_allowed_domains(self) -> None:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -863,6 +863,12 @@ class ControllerTests(unittest.TestCase):
             self.assertTrue(failure_results[0]["terminal"])
 
     def test_corrupt_profile_cache_quarantines_species_and_cycle_continues(self) -> None:
+        self._assert_corrupt_profile_cache_is_quarantined(b"{}")
+
+    def test_non_utf8_profile_cache_quarantines_species_and_cycle_continues(self) -> None:
+        self._assert_corrupt_profile_cache_is_quarantined(b'{"taxon_id": 9083, "\xff\xfe')
+
+    def _assert_corrupt_profile_cache_is_quarantined(self, corrupt_payload: bytes) -> None:
         corrupt = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
         healthy = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 3, "test")
         location = ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0)
@@ -918,7 +924,7 @@ class ControllerTests(unittest.TestCase):
             config = load_config(config_path)
             profiles = config.controller.state_dir / "profiles"
             (profiles / "9083").mkdir(parents=True)
-            (profiles / "9083" / "profile.json").write_text("{}")
+            (profiles / "9083" / "profile.json").write_bytes(corrupt_payload)
             (profiles / "7513").mkdir(parents=True)
             (profiles / "7513" / "profile.json").write_text(json.dumps(wren_profile))
             with (

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -813,7 +813,7 @@ class ControllerTests(unittest.TestCase):
             self.assertEqual(first_failure["error"], "profile failed")
             self.assertFalse(first_failure["terminal"])
 
-    def test_catalog_failure_aborts_cycle_without_terminal_species_state(self) -> None:
+    def test_catalog_failure_is_terminal_for_species_without_aborting_cycle(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
         location = ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0)
         with TemporaryDirectory() as temporary:
@@ -828,12 +828,154 @@ class ControllerTests(unittest.TestCase):
                 patch("inky_bird_frame.controller.generate_candidate") as generate,
             ):
                 generate.side_effect = CatalogError("cached references are invalid")
-                with self.assertRaisesRegex(CatalogError, "cached references are invalid"):
-                    run_controller_cycle(config)
+                result = run_controller_cycle(config)
 
             failures = list((config.controller.state_dir / "failed").glob("9083-*"))
 
-        self.assertEqual(failures, [])
+        self.assertEqual(len(failures), 1)
+        failure_results = result["failures"]
+        self.assertIsInstance(failure_results, list)
+        if isinstance(failure_results, list):
+            self.assertEqual(failure_results[0]["error"], "cached references are invalid")
+            self.assertTrue(failure_results[0]["terminal"])
+
+    def test_corrupt_profile_cache_quarantines_species_and_cycle_continues(self) -> None:
+        corrupt = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        healthy = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 3, "test")
+        location = ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        review = QualityReview(
+            True,
+            5,
+            4,
+            5,
+            5,
+            True,
+            (),
+            (
+                {"title": "Cornell", "url": "https://www.allaboutbirds.org/example"},
+                {"title": "Audubon", "url": "https://www.audubon.org/example"},
+            ),
+        )
+        wren_profile = {
+            "taxon_id": 7513,
+            "common_name": "Carolina Wren",
+            "scientific_name": "Thryothorus ludovicianus",
+            "family": "Troglodytidae",
+            "measurements": {"length": "5.5 in", "wingspan": "11 in", "weight": "0.7 oz"},
+            "field_marks": ["white eyebrow", "rufous back", "barred wings", "upright tail"],
+            "habitat": "Brushy woodland",
+            "behavior": "Forages low in cover",
+            "palette": ["rufous", "cream", "umber"],
+            "sources": [
+                {"title": "Cornell", "url": "https://www.allaboutbirds.org/one"},
+                {"title": "Audubon", "url": "https://www.audubon.org/two"},
+            ],
+        }
+
+        class FakeRunner:
+            def __init__(self, _executable: Path, _workspace: Path) -> None:
+                pass
+
+            def generate_plate(self, *_args: object) -> Path:
+                output_path = _args[-3]
+                assert isinstance(output_path, Path)
+                output_path.write_bytes(b"generated")
+                return output_path
+
+            def review_plate(self, *_args: object, **_kwargs: object) -> QualityReview:
+                return review
+
+        def prepare(_source: Path, portrait: Path, display: Path) -> None:
+            portrait.write_bytes(b"portrait")
+            display.write_bytes(b"display")
+
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            profiles = config.controller.state_dir / "profiles"
+            (profiles / "9083").mkdir(parents=True)
+            (profiles / "9083" / "profile.json").write_text("{}")
+            (profiles / "7513").mkdir(parents=True)
+            (profiles / "7513" / "profile.json").write_text(json.dumps(wren_profile))
+            with (
+                patch(
+                    "inky_bird_frame.controller.discover_species",
+                    return_value=discovery_result(location, [corrupt, healthy]),
+                ),
+                patch("inky_bird_frame.controller.load_or_fetch_references", return_value=[]),
+                patch("inky_bird_frame.controller.CodexRunner", FakeRunner),
+                patch("inky_bird_frame.controller.prepare_generated_plate", side_effect=prepare),
+            ):
+                result = run_controller_cycle(config)
+
+            terminal_failures = list((config.controller.state_dir / "failed").glob("9083-*"))
+            published = (config.controller.catalog_dir / "species/7513-carolina-wren").is_dir()
+
+        self.assertEqual(len(terminal_failures), 1)
+        self.assertTrue(published)
+        failure_results = result["failures"]
+        self.assertIsInstance(failure_results, list)
+        if isinstance(failure_results, list):
+            self.assertEqual(failure_results[0]["taxon_id"], 9083)
+            self.assertTrue(failure_results[0]["terminal"])
+        generated = cast(list[dict[str, object]], result["generated"])
+        self.assertEqual([item["taxon_id"] for item in generated], [7513])
+
+    def test_cycle_recovers_legacy_orphan_approved_pending_candidate(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        location = ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        review = QualityReview(
+            True,
+            5,
+            4,
+            5,
+            5,
+            True,
+            (),
+            (
+                {"title": "Cornell", "url": "https://example.test/cornell"},
+                {"title": "ADW", "url": "https://example.test/adw"},
+            ),
+        )
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            candidate = candidate_directory(config.controller.state_dir, species)
+            candidate.mkdir(parents=True)
+            (candidate / "portrait.png").write_bytes(b"portrait")
+            (candidate / "display.png").write_bytes(b"display")
+            manifest_path = write_candidate_manifest(
+                candidate,
+                species,
+                PROFILE,
+                [],
+                review,
+                generator="test",
+                prompt_version=PROMPT_VERSION,
+                attempt=2,
+                max_attempts=3,
+            )
+            manifest = json.loads(manifest_path.read_text())
+            manifest["status"] = "approved"
+            manifest["approved_at"] = "2026-07-12T08:00:00+00:00"
+            manifest_path.write_text(json.dumps(manifest))
+            with patch(
+                "inky_bird_frame.controller.discover_species",
+                return_value=discovery_result(location, [species]),
+            ):
+                result = run_controller_cycle(config)
+
+            published = (config.controller.catalog_dir / "species/9083-northern-cardinal").is_dir()
+            orphan_remains = candidate.exists()
+
+        self.assertTrue(published)
+        self.assertFalse(orphan_remains)
+        published_pending = result["published_pending"]
+        self.assertIsInstance(published_pending, list)
+        if isinstance(published_pending, list):
+            self.assertEqual(len(published_pending), 1)
 
     def test_exhausted_quality_review_becomes_terminal(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -27,6 +27,7 @@ from inky_bird_frame.controller import (
     exclusive_refresh_lock,
     generate_candidate,
     load_or_create_profile,
+    load_or_fetch_references,
     run_controller_cycle,
     run_generation_cycle,
     run_refresh_cycle,
@@ -861,6 +862,19 @@ class ControllerTests(unittest.TestCase):
         if isinstance(failure_results, list):
             self.assertEqual(failure_results[0]["error"], "cached references are invalid")
             self.assertTrue(failure_results[0]["terminal"])
+
+    def test_non_utf8_reference_manifest_raises_species_state_error(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            manifest = config.controller.state_dir / "references" / "9083" / "references.json"
+            manifest.parent.mkdir(parents=True)
+            manifest.write_bytes(b'{"references": [\xff\xfe')
+
+            with self.assertRaisesRegex(SpeciesStateError, "Invalid reference manifest"):
+                load_or_fetch_references(config, species)
 
     def test_corrupt_profile_cache_quarantines_species_and_cycle_continues(self) -> None:
         self._assert_corrupt_profile_cache_is_quarantined(b"{}")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -37,6 +37,7 @@ from inky_bird_frame.errors import (
     GenerationError,
     InsufficientReferencesError,
     QualityReviewError,
+    SpeciesStateError,
 )
 from inky_bird_frame.geo import ZipLocation
 from inky_bird_frame.models import QualityReview, SpeciesProfileData
@@ -813,6 +814,28 @@ class ControllerTests(unittest.TestCase):
             self.assertEqual(first_failure["error"], "profile failed")
             self.assertFalse(first_failure["terminal"])
 
+    def test_catalog_wide_error_still_aborts_the_cycle(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        location = ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            with (
+                patch(
+                    "inky_bird_frame.controller.discover_species",
+                    return_value=discovery_result(location, [species]),
+                ),
+                patch(
+                    "inky_bird_frame.controller.generate_candidate",
+                    side_effect=CatalogError("Asset checksum mismatch: catalog corrupt"),
+                ),
+                self.assertRaisesRegex(CatalogError, "catalog corrupt"),
+            ):
+                run_controller_cycle(config)
+
+            self.assertEqual(list((config.controller.state_dir / "failed").glob("*")), [])
+
     def test_catalog_failure_is_terminal_for_species_without_aborting_cycle(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
         location = ZipLocation("12345", "Exampleville", "XY", 1.0, 2.0)
@@ -827,7 +850,7 @@ class ControllerTests(unittest.TestCase):
                 ),
                 patch("inky_bird_frame.controller.generate_candidate") as generate,
             ):
-                generate.side_effect = CatalogError("cached references are invalid")
+                generate.side_effect = SpeciesStateError("cached references are invalid")
                 result = run_controller_cycle(config)
 
             failures = list((config.controller.state_dir / "failed").glob("9083-*"))

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -863,6 +863,19 @@ class ControllerTests(unittest.TestCase):
             self.assertEqual(failure_results[0]["error"], "cached references are invalid")
             self.assertTrue(failure_results[0]["terminal"])
 
+    def test_malformed_reference_entry_raises_species_state_error(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            manifest = config.controller.state_dir / "references" / "9083" / "references.json"
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(json.dumps({"references": ["not-an-object"]}))
+
+            with self.assertRaisesRegex(SpeciesStateError, "Invalid reference manifest"):
+                load_or_fetch_references(config, species)
+
     def test_non_utf8_reference_manifest_raises_species_state_error(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
         with TemporaryDirectory() as temporary:

--- a/tests/test_deployment_scripts.py
+++ b/tests/test_deployment_scripts.py
@@ -86,6 +86,25 @@ def test_systemd_controller_installer_restarts_boot_persistent_services() -> Non
     assert "rebuild_catalog_index" not in script
 
 
+def test_macos_controller_installer_restores_previously_loaded_agents_on_failure() -> None:
+    script = (Path(__file__).resolve().parents[1] / "deploy" / "install-controller.sh").read_text()
+
+    backup = script.index('cp "${plist}" "${plist_backup_dir}/"')
+    plist_write = script.index("plistlib.dump(payload, handle, sort_keys=True)")
+    unconditional_bootout = script.index('launchctl bootout "gui/${uid}/com.inky-bird-frame.serve"')
+    bootstrap = script.index('launchctl bootstrap "gui/${uid}" "${serve_plist}"')
+    completion = script.index("installation_complete=true")
+
+    assert backup < plist_write < unconditional_bootout < bootstrap < completion
+    assert "trap cleanup EXIT" in script
+    assert 'if [ "${installation_complete}" != true ]' in script
+    assert 'previously_loaded_labels+=("${label}")' in script
+    assert 'restore_previous_agent "${label}"' in script
+    assert "for label in serve refresh generate catalog-publish notifications; do" in script
+    assert 'restore_catalog_publisher_schedule "${uid}" || true' in script
+    assert 'rm -rf "${plist_backup_dir}"' in script
+
+
 def test_local_display_installer_uses_configured_schedule_and_verifies_timer() -> None:
     script = (
         Path(__file__).resolve().parents[1] / "deploy" / "install-display-local.sh"
@@ -108,3 +127,53 @@ def test_remote_display_installer_selects_noninteractive_sudo() -> None:
     ).read_text()
 
     assert "INKY_BIRD_NONINTERACTIVE_SUDO=true" in script
+
+
+def test_macos_controller_uninstaller_removes_agents_and_preserves_data() -> None:
+    script = (
+        Path(__file__).resolve().parents[1] / "deploy" / "uninstall-controller.sh"
+    ).read_text()
+
+    assert "set -euo pipefail" in script
+    assert "for label in serve refresh generate catalog-publish notifications; do" in script
+    assert 'launchctl bootout "gui/${uid}/${agent}"' in script
+    assert 'rm -f "${plist}"' in script
+    assert "Intentionally left in place:" in script
+    assert "${HOME}/Services/inky-bird-frame" in script
+    assert "rm -rf" not in script
+    assert 'rm -f "${config_path}"' not in script
+
+
+def test_systemd_controller_uninstaller_removes_units_and_preserves_data() -> None:
+    script = (
+        Path(__file__).resolve().parents[1] / "deploy" / "uninstall-controller-systemd.sh"
+    ).read_text()
+
+    assert "set -euo pipefail" in script
+    assert "for name in refresh generate catalog-publish notifications; do" in script
+    assert 'sudo systemctl disable --now "${timer}"' in script
+    assert "sudo systemctl disable --now inky-bird-frame-controller.service" in script
+    assert "for name in controller refresh generate catalog-publish notifications; do" in script
+    assert 'sudo rm -f "/etc/systemd/system/${unit}"' in script
+    assert "sudo systemctl daemon-reload" in script
+    assert "Intentionally left in place:" in script
+    assert "rm -rf" not in script
+    assert 'rm -f "${config_path}"' not in script
+
+
+def test_local_display_uninstaller_removes_units_and_preserves_data() -> None:
+    script = (
+        Path(__file__).resolve().parents[1] / "deploy" / "uninstall-display-local.sh"
+    ).read_text()
+
+    assert "set -euo pipefail" in script
+    assert "noninteractive_sudo=${INKY_BIRD_NONINTERACTIVE_SUDO:-false}" in script
+    assert "sudo_command+=(-n)" in script
+    assert '"${sudo_command[@]}" systemctl disable --now inky-bird-frame-display.timer' in script
+    assert '"${sudo_command[@]}" systemctl stop inky-bird-frame-display.service' in script
+    assert '"${sudo_command[@]}" rm -f "/etc/systemd/system/${unit}"' in script
+    assert '"${sudo_command[@]}" systemctl daemon-reload' in script
+    assert "Intentionally left in place:" in script
+    assert "Pimoroni Python environment" in script
+    assert "rm -rf" not in script
+    assert 'rm -f "${config_path}"' not in script

--- a/tests/test_deployment_scripts.py
+++ b/tests/test_deployment_scripts.py
@@ -135,7 +135,10 @@ def test_macos_controller_uninstaller_removes_agents_and_preserves_data() -> Non
     ).read_text()
 
     assert "set -euo pipefail" in script
-    assert "for label in serve refresh generate catalog-publish notifications; do" in script
+    assert (
+        "for label in serve refresh generate catalog-publish notifications controller-cycle; do"
+        in script
+    )
     assert 'launchctl bootout "gui/${uid}/${agent}"' in script
     assert 'rm -f "${plist}"' in script
     assert "Intentionally left in place:" in script

--- a/tests/test_deployment_scripts.py
+++ b/tests/test_deployment_scripts.py
@@ -100,6 +100,10 @@ def test_macos_controller_installer_restores_previously_loaded_agents_on_failure
     assert 'if [ "${installation_complete}" != true ]' in script
     assert 'previously_loaded_labels+=("${label}")' in script
     assert 'restore_previous_agent "${label}"' in script
+    assert 'was_previously_loaded "${label}"' in script
+    assert script.index('if was_previously_loaded "${label}"') < script.index(
+        "# Not running before this install: undo any half-installed agent."
+    )
     assert "for label in serve refresh generate catalog-publish notifications; do" in script
     assert 'restore_catalog_publisher_schedule "${uid}" || true' in script
     assert 'rm -rf "${plist_backup_dir}"' in script

--- a/tests/test_display_node.py
+++ b/tests/test_display_node.py
@@ -131,6 +131,79 @@ class DisplayNodeTests(unittest.TestCase):
         self.assertEqual(state["schema_version"], 3)
         get_bytes.assert_called_once()
 
+    def test_checksum_mismatch_fails_without_display_or_state_advance(self) -> None:
+        payload = catalog_payload({1: b"one"})
+        with TemporaryDirectory() as temporary:
+            state_path = Path(temporary) / "state.json"
+            config = DisplayNodeConfig("http://controller.test", Path(temporary))
+            with (
+                patch("inky_bird_frame.display_node.get_json", return_value=payload),
+                patch("inky_bird_frame.display_node.get_bytes", return_value=b"tampered"),
+                patch("inky_bird_frame.display_node.show_on_inky") as show_on_inky,
+                self.assertRaisesRegex(CatalogError, "checksum mismatch"),
+            ):
+                run_display_cycle(config)
+
+            self.assertFalse(state_path.exists())
+        show_on_inky.assert_not_called()
+
+    def test_successful_cycle_evicts_stale_cache_for_same_taxon_only(self) -> None:
+        images = {1: b"one"}
+        payload = catalog_payload(images)
+        digest = hashlib.sha256(images[1]).hexdigest()
+        with TemporaryDirectory() as temporary:
+            cache_dir = Path(temporary) / "cache"
+            cache_dir.mkdir(parents=True)
+            stale = cache_dir / "1-oldhash00000.png"
+            stale.write_bytes(b"stale")
+            other_taxon = cache_dir / "13-otherhash00.png"
+            other_taxon.write_bytes(b"other")
+            config = DisplayNodeConfig("http://controller.test", Path(temporary))
+            with (
+                patch("inky_bird_frame.display_node.get_json", return_value=payload),
+                patch("inky_bird_frame.display_node.get_bytes", side_effect=asset_response(images)),
+                patch("inky_bird_frame.display_node.show_on_inky", return_value=(1600, 1200)),
+            ):
+                result = run_display_cycle(config)
+
+            self.assertEqual(result["display_update"], "sent")
+            self.assertFalse(stale.exists())
+            self.assertTrue(other_taxon.exists())
+            self.assertTrue((cache_dir / f"1-{digest[:12]}.png").exists())
+
+    def test_unicode_display_path_is_percent_encoded_in_asset_url(self) -> None:
+        image = b"unicode-plate"
+        payload = {
+            "schema_version": 1,
+            "species": [
+                {
+                    "taxon_id": 4711,
+                    "common_name": "Piopío",
+                    "scientific_name": "Turnagra capensis",
+                    "slug": "piopío",
+                    "portrait_path": "species/4711-piopío/portrait.png",
+                    "portrait_sha256": "b" * 64,
+                    "display_path": "species/4711-piopío/display.png",
+                    "display_sha256": hashlib.sha256(image).hexdigest(),
+                    "approved_at": "2026-07-09T00:00:00+00:00",
+                }
+            ],
+        }
+        with TemporaryDirectory() as temporary:
+            config = DisplayNodeConfig("http://controller.test", Path(temporary))
+            with (
+                patch("inky_bird_frame.display_node.get_json", return_value=payload),
+                patch("inky_bird_frame.display_node.get_bytes", return_value=image) as get_bytes,
+                patch("inky_bird_frame.display_node.show_on_inky", return_value=(1600, 1200)),
+            ):
+                result = run_display_cycle(config)
+
+        self.assertEqual(result["display_update"], "sent")
+        self.assertEqual(
+            get_bytes.call_args.args[0],
+            "http://controller.test/v1/assets/species/4711-piop%C3%ADo/display.png",
+        )
+
     def test_shuffle_bag_persists_across_cycles_without_replacement(self) -> None:
         images = {1: b"one", 2: b"two", 3: b"three"}
         payload = catalog_payload(images)
@@ -425,7 +498,7 @@ class DisplayNodeTests(unittest.TestCase):
             parse_catalog_entries(payload)
 
         species[0]["latest_detection_at"] = "2026-07-13T08:10:00"
-        with self.assertRaisesRegex(CatalogError, "timezone"):
+        with self.assertRaisesRegex(CatalogError, "latest detection timestamp"):
             parse_catalog_entries(payload)
 
     def test_rejects_duplicate_or_empty_catalogs(self) -> None:

--- a/tests/test_display_node.py
+++ b/tests/test_display_node.py
@@ -147,6 +147,45 @@ class DisplayNodeTests(unittest.TestCase):
             self.assertFalse(state_path.exists())
         show_on_inky.assert_not_called()
 
+    def test_successful_cycle_reports_display_success(self) -> None:
+        payload = catalog_payload({1: b"one"})
+        requested: list[str] = []
+
+        def fake_get_json(url: str, timeout: float) -> object:
+            requested.append(url)
+            return payload if url.endswith("/v1/catalog") else {"ok": True}
+
+        with TemporaryDirectory() as temporary:
+            config = DisplayNodeConfig("http://controller.test", Path(temporary))
+            with (
+                patch("inky_bird_frame.display_node.get_json", side_effect=fake_get_json),
+                patch("inky_bird_frame.display_node.get_bytes", return_value=b"one"),
+                patch("inky_bird_frame.display_node.show_on_inky", return_value=(1600, 1200)),
+            ):
+                run_display_cycle(config)
+
+        self.assertEqual(requested[-1], "http://controller.test/v1/display-success")
+
+    def test_failed_cycle_does_not_report_display_success(self) -> None:
+        payload = catalog_payload({1: b"one"})
+        requested: list[str] = []
+
+        def fake_get_json(url: str, timeout: float) -> object:
+            requested.append(url)
+            return payload
+
+        with TemporaryDirectory() as temporary:
+            config = DisplayNodeConfig("http://controller.test", Path(temporary))
+            with (
+                patch("inky_bird_frame.display_node.get_json", side_effect=fake_get_json),
+                patch("inky_bird_frame.display_node.get_bytes", return_value=b"tampered"),
+                patch("inky_bird_frame.display_node.show_on_inky"),
+                self.assertRaisesRegex(CatalogError, "checksum mismatch"),
+            ):
+                run_display_cycle(config)
+
+        self.assertEqual([url for url in requested if url.endswith("/v1/display-success")], [])
+
     def test_successful_cycle_evicts_stale_cache_for_same_taxon_only(self) -> None:
         images = {1: b"one"}
         payload = catalog_payload(images)

--- a/tests/test_display_node.py
+++ b/tests/test_display_node.py
@@ -153,7 +153,7 @@ class DisplayNodeTests(unittest.TestCase):
 
         def fake_get_json(url: str, timeout: float) -> object:
             requested.append(url)
-            return payload if url.endswith("/v1/catalog") else {"ok": True}
+            return payload if "/v1/catalog" in url else {"ok": True}
 
         with TemporaryDirectory() as temporary:
             config = DisplayNodeConfig("http://controller.test", Path(temporary))

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,12 +1,51 @@
 from __future__ import annotations
 
 import unittest
+from collections.abc import Iterator
+from contextlib import contextmanager
 from email.message import Message
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
 from unittest.mock import patch
 from urllib.error import HTTPError
 
+import inky_bird_frame.http
 from inky_bird_frame.errors import DataSourceError
-from inky_bird_frame.http import get_json
+from inky_bird_frame.http import get_bytes, get_json
+
+
+class _RedirectingHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        if self.path == "/ftp-redirect":
+            self.send_response(302)
+            self.send_header("Location", "ftp://127.0.0.1/pub/file.bin")
+            self.end_headers()
+            return
+        if self.path == "/http-redirect":
+            self.send_response(302)
+            self.send_header("Location", "/payload")
+            self.end_headers()
+            return
+        body = b"payload-bytes"
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, message_format: str, *args: object) -> None:
+        pass
+
+
+@contextmanager
+def _serving() -> Iterator[int]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _RedirectingHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_address[1]
+    finally:
+        server.shutdown()
+        server.server_close()
 
 
 class JsonHttpTests(unittest.TestCase):
@@ -15,13 +54,30 @@ class JsonHttpTests(unittest.TestCase):
         error = HTTPError(url, 401, "Unauthorized", Message(), None)
 
         with (
-            patch("inky_bird_frame.http.urlopen", side_effect=error),
+            patch.object(inky_bird_frame.http._OPENER, "open", side_effect=error),
             self.assertRaises(DataSourceError) as raised,
         ):
             get_json(url, error_label="BirdWeather API")
 
         self.assertEqual(str(raised.exception), "HTTP 401 from BirdWeather API")
         self.assertNotIn("private-token", str(raised.exception))
+
+    def test_rejects_non_http_url_scheme(self) -> None:
+        with self.assertRaisesRegex(DataSourceError, "non-HTTP URL scheme"):
+            get_bytes("file:///etc/hostname")
+
+    def test_rejects_redirect_to_non_http_scheme(self) -> None:
+        with (
+            _serving() as port,
+            self.assertRaisesRegex(DataSourceError, "Refusing redirect"),
+        ):
+            get_bytes(f"http://127.0.0.1:{port}/ftp-redirect")
+
+    def test_follows_same_scheme_redirects(self) -> None:
+        with _serving() as port:
+            body = get_bytes(f"http://127.0.0.1:{port}/http-redirect")
+
+        self.assertEqual(body, b"payload-bytes")
 
 
 if __name__ == "__main__":

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -9,6 +9,8 @@ class ImageHelperTests(unittest.TestCase):
     def test_slugify(self) -> None:
         self.assertEqual(slugify("Eastern Bluebird"), "eastern-bluebird")
         self.assertEqual(slugify("Sialia sialis!"), "sialia-sialis")
+        self.assertEqual(slugify("Anna's Hummingbird"), "anna-s-hummingbird")
+        self.assertEqual(slugify("Piopío"), "piopío")
 
     def test_canonical_assets_match_inky_panel(self) -> None:
         self.assertEqual(PORTRAIT_SIZE, (1200, 1600))

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -103,6 +103,21 @@ class InstallationTests(unittest.TestCase):
         )
         self.assertNotIn("inky-bird-frame-notifications.timer", units)
         self.assertNotIn("inky-bird-frame-catalog-publish.timer", units)
+        serve_unit = units["inky-bird-frame-controller.service"]
+        self.assertIn("NoNewPrivileges=true", serve_unit)
+        self.assertIn("PrivateTmp=true", serve_unit)
+        self.assertIn("ProtectKernelTunables=true", serve_unit)
+        self.assertIn("ProtectKernelModules=true", serve_unit)
+        self.assertIn("ProtectControlGroups=true", serve_unit)
+        self.assertIn("RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX", serve_unit)
+        self.assertNotIn("ProtectSystem=", serve_unit)
+        self.assertNotIn("ProtectHome=", serve_unit)
+        for codex_unit in ("inky-bird-frame-refresh.service", "inky-bird-frame-generate.service"):
+            self.assertNotIn("NoNewPrivileges=", units[codex_unit])
+            self.assertNotIn("PrivateTmp=", units[codex_unit])
+            self.assertNotIn("ProtectKernel", units[codex_unit])
+            self.assertNotIn("ProtectControlGroups=", units[codex_unit])
+            self.assertNotIn("RestrictAddressFamilies=", units[codex_unit])
 
     def test_display_systemd_units_use_startup_rotation_and_jitter_values(self) -> None:
         with TemporaryDirectory() as temporary:
@@ -137,6 +152,16 @@ display_startup_delay_seconds = 30
         self.assertIn("OnActiveSec=30s", timer)
         self.assertIn("OnUnitActiveSec=180s", timer)
         self.assertIn("RandomizedDelaySec=7s", timer)
+        self.assertIn("NoNewPrivileges=true", service)
+        self.assertIn("PrivateTmp=true", service)
+        self.assertIn("ProtectKernelTunables=true", service)
+        self.assertIn("ProtectKernelModules=true", service)
+        self.assertIn("ProtectControlGroups=true", service)
+        self.assertIn("RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX", service)
+        self.assertNotIn("ProtectSystem=", service)
+        self.assertNotIn("ProtectHome=", service)
+        self.assertNotIn("DevicePolicy=", service)
+        self.assertNotIn("PrivateDevices=", service)
 
     def test_display_health_url_preserves_controller_path_prefix(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -396,18 +396,10 @@ class DisplayHeartbeatTests(unittest.TestCase):
         path.write_text(DISPLAY_CONFIG.format(rotation_minutes=rotation_minutes))
         return load_config(path)
 
-    def _write_heartbeat(
-        self, config: AppConfig, fetched_at: datetime, *, reports_success: bool = True
-    ) -> None:
+    def _write_heartbeat(self, config: AppConfig, fetched_at: datetime) -> None:
         config.controller.state_dir.mkdir(parents=True, exist_ok=True)
         (config.controller.state_dir / "display-last-fetch.json").write_text(
-            json.dumps(
-                {
-                    "schema_version": 1,
-                    "fetched_at": fetched_at.isoformat(),
-                    "reports_success": reports_success,
-                }
-            )
+            json.dumps({"schema_version": 1, "fetched_at": fetched_at.isoformat()})
         )
 
     def _write_success(self, config: AppConfig, succeeded_at: datetime) -> None:
@@ -490,24 +482,6 @@ class DisplayHeartbeatTests(unittest.TestCase):
         self.assertTrue(result["checked"])
         self.assertFalse(result["stale"])
         notify.assert_not_called()
-
-    def test_legacy_display_without_success_reporting_uses_fetch_age(self) -> None:
-        now = datetime(2026, 7, 10, tzinfo=UTC)
-        with TemporaryDirectory() as temporary:
-            config = self._config(temporary)
-            self._write_heartbeat(config, now - timedelta(minutes=10), reports_success=False)
-            with patch("inky_bird_frame.notifications.safe_notify") as notify:
-                fresh = check_display_heartbeat(config, now=now)
-            self._write_heartbeat(config, now - timedelta(minutes=200), reports_success=False)
-            with patch(
-                "inky_bird_frame.notifications.safe_notify",
-                return_value={"queued": True},
-            ):
-                stale = check_display_heartbeat(config, now=now)
-
-        self.assertFalse(fresh["stale"])
-        notify.assert_not_called()
-        self.assertTrue(stale["stale"])
 
     def test_fetching_without_any_completed_update_alerts(self) -> None:
         now = datetime(2026, 7, 10, tzinfo=UTC)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -402,6 +402,71 @@ class DisplayHeartbeatTests(unittest.TestCase):
             json.dumps({"schema_version": 1, "fetched_at": fetched_at.isoformat()})
         )
 
+    def _write_success(self, config: AppConfig, succeeded_at: datetime) -> None:
+        config.controller.state_dir.mkdir(parents=True, exist_ok=True)
+        (config.controller.state_dir / "display-last-success.json").write_text(
+            json.dumps({"schema_version": 1, "succeeded_at": succeeded_at.isoformat()})
+        )
+
+    def test_stale_display_updates_alert_despite_fresh_fetches(self) -> None:
+        now = datetime(2026, 7, 10, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            config = self._config(temporary)
+            self._write_heartbeat(config, now - timedelta(minutes=5))
+            self._write_success(config, now - timedelta(minutes=200))
+            with patch(
+                "inky_bird_frame.notifications.safe_notify",
+                return_value={"queued": True},
+            ) as notify:
+                result = check_display_heartbeat(config, now=now)
+
+        self.assertTrue(result["stale"])
+        self.assertEqual(result["signal"], "display-update")
+        self.assertIs(notify.call_args.args[1], NotificationEvent.DISPLAY_STALE)
+
+    def test_fresh_display_update_overrides_stale_fetch_signal(self) -> None:
+        now = datetime(2026, 7, 10, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            config = self._config(temporary)
+            self._write_heartbeat(config, now - timedelta(minutes=200))
+            self._write_success(config, now - timedelta(minutes=10))
+            with patch("inky_bird_frame.notifications.safe_notify") as notify:
+                result = check_display_heartbeat(config, now=now)
+
+        self.assertFalse(result["stale"])
+        self.assertEqual(result["signal"], "display-update")
+        notify.assert_not_called()
+
+    def test_corrupt_success_file_falls_back_to_fetch_signal(self) -> None:
+        now = datetime(2026, 7, 10, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            config = self._config(temporary)
+            self._write_heartbeat(config, now - timedelta(minutes=10))
+            config.controller.state_dir.mkdir(parents=True, exist_ok=True)
+            (config.controller.state_dir / "display-last-success.json").write_bytes(
+                b'{"schema_version": 1, "succeeded_at": "2026-07-10T\xff'
+            )
+            with patch("inky_bird_frame.notifications.safe_notify") as notify:
+                result = check_display_heartbeat(config, now=now)
+
+        self.assertFalse(result["stale"])
+        self.assertEqual(result["signal"], "catalog-fetch")
+        self.assertIn("warning", result)
+        notify.assert_not_called()
+
+    def test_non_utf8_heartbeat_is_reported_not_fatal(self) -> None:
+        now = datetime(2026, 7, 10, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            config = self._config(temporary)
+            config.controller.state_dir.mkdir(parents=True, exist_ok=True)
+            (config.controller.state_dir / "display-last-fetch.json").write_bytes(
+                b'{"schema_version": 1, "fetched_at": "2026-\xff\xfe'
+            )
+            result = check_display_heartbeat(config, now=now)
+
+        self.assertFalse(result["checked"])
+        self.assertIn("warning", result)
+
     def test_fresh_heartbeat_does_not_alert(self) -> None:
         now = datetime(2026, 7, 10, tzinfo=UTC)
         with TemporaryDirectory() as temporary:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from inky_bird_frame.config import AppConfig, NotificationEvent, NotificationsConfig, load_config
 from inky_bird_frame.errors import ConfigurationError
 from inky_bird_frame.notifications import (
+    check_display_heartbeat,
     dispatch_notifications,
     enqueue_notification,
     notification_status,
@@ -60,6 +61,45 @@ events = ["terminal_error", "degraded", "recovered"]
 name = "second"
 url = "ntfy://example-topic"
 events = ["terminal_error"]
+"""
+
+DISPLAY_CONFIG = """
+[discovery]
+zip_code = "12345"
+radius_km = 8
+species_limit = 12
+window = "last-week"
+
+[controller]
+workspace_dir = "."
+catalog_dir = "catalog"
+state_dir = "state"
+codex_path = "/usr/bin/false"
+bind_host = "127.0.0.1"
+port = 8793
+references_per_species = 4
+generations_per_cycle = 1
+max_generation_attempts = 3
+
+[display_node]
+controller_url = "http://controller.test:8793"
+state_dir = "display"
+
+[schedule]
+rotation_minutes = {rotation_minutes}
+
+[notifications]
+enabled = true
+degradation_failure_threshold = 1
+degradation_window_minutes = 30
+cooldown_minutes = 360
+delivery_retry_minutes = 5
+max_delivery_attempts = 3
+
+[[notifications.destinations]]
+name = "first"
+url = "pover://user@token"
+events = ["display_stale", "display_recovered"]
 """
 
 
@@ -348,6 +388,123 @@ class NotificationTests(unittest.TestCase):
         ]
         self.assertEqual(len(recovery_keys), 2)
         self.assertEqual(len(set(recovery_keys)), 2)
+
+
+class DisplayHeartbeatTests(unittest.TestCase):
+    def _config(self, temporary: str, *, rotation_minutes: int = 30) -> AppConfig:
+        path = Path(temporary) / "config.toml"
+        path.write_text(DISPLAY_CONFIG.format(rotation_minutes=rotation_minutes))
+        return load_config(path)
+
+    def _write_heartbeat(self, config: AppConfig, fetched_at: datetime) -> None:
+        config.controller.state_dir.mkdir(parents=True, exist_ok=True)
+        (config.controller.state_dir / "display-last-fetch.json").write_text(
+            json.dumps({"schema_version": 1, "fetched_at": fetched_at.isoformat()})
+        )
+
+    def test_fresh_heartbeat_does_not_alert(self) -> None:
+        now = datetime(2026, 7, 10, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            config = self._config(temporary)
+            self._write_heartbeat(config, now - timedelta(minutes=10))
+            with patch("inky_bird_frame.notifications.safe_notify") as notify:
+                result = check_display_heartbeat(config, now=now)
+
+        self.assertTrue(result["checked"])
+        self.assertFalse(result["stale"])
+        notify.assert_not_called()
+
+    def test_stale_heartbeat_alerts_once_across_dispatch_runs(self) -> None:
+        now = datetime(2026, 7, 10, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            config = self._config(temporary)
+            self._write_heartbeat(config, now - timedelta(minutes=200))
+            with patch(
+                "inky_bird_frame.notifications.safe_notify",
+                return_value={"queued": True},
+            ) as notify:
+                first = check_display_heartbeat(config, now=now)
+                second = check_display_heartbeat(config, now=now + timedelta(minutes=5))
+
+        self.assertTrue(first["stale"])
+        self.assertTrue(second["stale"])
+        self.assertEqual(notify.call_count, 1)
+        self.assertIs(notify.call_args.args[1], NotificationEvent.DISPLAY_STALE)
+
+    def test_stale_alert_enqueues_display_stale_event(self) -> None:
+        now = datetime(2026, 7, 10, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            config = self._config(temporary)
+            self._write_heartbeat(config, now - timedelta(minutes=200))
+            check_display_heartbeat(config, now=now)
+            check_display_heartbeat(config, now=now + timedelta(minutes=5))
+            status = notification_status(config)
+            state = json.loads((config.controller.state_dir / "notifications.json").read_text())
+
+        self.assertEqual(status["pending"], 1)
+        self.assertEqual(state["pending"][0]["event"], "display_stale")
+
+    def test_recovery_after_stale_alert_notifies_once(self) -> None:
+        now = datetime(2026, 7, 10, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            config = self._config(temporary)
+            self._write_heartbeat(config, now - timedelta(minutes=200))
+            with patch(
+                "inky_bird_frame.notifications.safe_notify",
+                return_value={"queued": True},
+            ) as notify:
+                check_display_heartbeat(config, now=now)
+                self._write_heartbeat(config, now + timedelta(minutes=10))
+                recovered = check_display_heartbeat(config, now=now + timedelta(minutes=15))
+                repeated = check_display_heartbeat(config, now=now + timedelta(minutes=20))
+
+        self.assertFalse(recovered["stale"])
+        self.assertFalse(repeated["stale"])
+        events = [call.args[1] for call in notify.call_args_list]
+        self.assertEqual(
+            events, [NotificationEvent.DISPLAY_STALE, NotificationEvent.DISPLAY_RECOVERED]
+        )
+
+    def test_missing_heartbeat_stays_silent(self) -> None:
+        now = datetime(2026, 7, 10, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            config = self._config(temporary)
+            with patch("inky_bird_frame.notifications.safe_notify") as notify:
+                result = check_display_heartbeat(config, now=now)
+
+        self.assertEqual(result, {"checked": False, "stale": None})
+        notify.assert_not_called()
+
+    def test_corrupt_heartbeat_is_no_signal_with_warning(self) -> None:
+        now = datetime(2026, 7, 10, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            config = self._config(temporary)
+            config.controller.state_dir.mkdir(parents=True, exist_ok=True)
+            (config.controller.state_dir / "display-last-fetch.json").write_text("not json")
+            with patch("inky_bird_frame.notifications.safe_notify") as notify:
+                result = check_display_heartbeat(config, now=now)
+
+        self.assertFalse(result["checked"])
+        self.assertIn("Invalid display heartbeat", str(result["warning"]))
+        notify.assert_not_called()
+
+    def test_threshold_respects_sixty_minute_floor(self) -> None:
+        now = datetime(2026, 7, 10, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            config = self._config(temporary, rotation_minutes=5)
+            self._write_heartbeat(config, now - timedelta(minutes=50))
+            with patch(
+                "inky_bird_frame.notifications.safe_notify",
+                return_value={"queued": True},
+            ) as notify:
+                within_floor = check_display_heartbeat(config, now=now)
+                self._write_heartbeat(config, now - timedelta(minutes=61))
+                past_floor = check_display_heartbeat(config, now=now)
+
+        self.assertEqual(within_floor["threshold_minutes"], 60)
+        self.assertFalse(within_floor["stale"])
+        self.assertTrue(past_floor["stale"])
+        self.assertEqual(notify.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -437,7 +437,7 @@ class DisplayHeartbeatTests(unittest.TestCase):
         self.assertEqual(result["signal"], "display-update")
         notify.assert_not_called()
 
-    def test_corrupt_success_file_falls_back_to_fetch_signal(self) -> None:
+    def test_corrupt_success_file_treats_display_as_never_succeeded(self) -> None:
         now = datetime(2026, 7, 10, tzinfo=UTC)
         with TemporaryDirectory() as temporary:
             config = self._config(temporary)
@@ -446,13 +446,16 @@ class DisplayHeartbeatTests(unittest.TestCase):
             (config.controller.state_dir / "display-last-success.json").write_bytes(
                 b'{"schema_version": 1, "succeeded_at": "2026-07-10T\xff'
             )
-            with patch("inky_bird_frame.notifications.safe_notify") as notify:
+            with patch(
+                "inky_bird_frame.notifications.safe_notify",
+                return_value={"queued": True},
+            ) as notify:
                 result = check_display_heartbeat(config, now=now)
 
-        self.assertFalse(result["stale"])
+        self.assertTrue(result["stale"])
         self.assertEqual(result["signal"], "catalog-fetch")
         self.assertIn("warning", result)
-        notify.assert_not_called()
+        self.assertIs(notify.call_args.args[1], NotificationEvent.DISPLAY_STALE)
 
     def test_non_utf8_heartbeat_is_reported_not_fatal(self) -> None:
         now = datetime(2026, 7, 10, tzinfo=UTC)
@@ -472,12 +475,29 @@ class DisplayHeartbeatTests(unittest.TestCase):
         with TemporaryDirectory() as temporary:
             config = self._config(temporary)
             self._write_heartbeat(config, now - timedelta(minutes=10))
+            self._write_success(config, now - timedelta(minutes=10))
             with patch("inky_bird_frame.notifications.safe_notify") as notify:
                 result = check_display_heartbeat(config, now=now)
 
         self.assertTrue(result["checked"])
         self.assertFalse(result["stale"])
         notify.assert_not_called()
+
+    def test_fetching_without_any_completed_update_alerts(self) -> None:
+        now = datetime(2026, 7, 10, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            config = self._config(temporary)
+            self._write_heartbeat(config, now - timedelta(minutes=5))
+            with patch(
+                "inky_bird_frame.notifications.safe_notify",
+                return_value={"queued": True},
+            ) as notify:
+                result = check_display_heartbeat(config, now=now)
+
+        self.assertTrue(result["stale"])
+        self.assertEqual(result["signal"], "catalog-fetch")
+        self.assertIs(notify.call_args.args[1], NotificationEvent.DISPLAY_STALE)
+        self.assertIn("never completed an update", notify.call_args.kwargs["body"])
 
     def test_stale_heartbeat_alerts_once_across_dispatch_runs(self) -> None:
         now = datetime(2026, 7, 10, tzinfo=UTC)
@@ -519,7 +539,7 @@ class DisplayHeartbeatTests(unittest.TestCase):
                 return_value={"queued": True},
             ) as notify:
                 check_display_heartbeat(config, now=now)
-                self._write_heartbeat(config, now + timedelta(minutes=10))
+                self._write_success(config, now + timedelta(minutes=10))
                 recovered = check_display_heartbeat(config, now=now + timedelta(minutes=15))
                 repeated = check_display_heartbeat(config, now=now + timedelta(minutes=20))
 
@@ -557,13 +577,13 @@ class DisplayHeartbeatTests(unittest.TestCase):
         now = datetime(2026, 7, 10, tzinfo=UTC)
         with TemporaryDirectory() as temporary:
             config = self._config(temporary, rotation_minutes=5)
-            self._write_heartbeat(config, now - timedelta(minutes=50))
+            self._write_success(config, now - timedelta(minutes=50))
             with patch(
                 "inky_bird_frame.notifications.safe_notify",
                 return_value={"queued": True},
             ) as notify:
                 within_floor = check_display_heartbeat(config, now=now)
-                self._write_heartbeat(config, now - timedelta(minutes=61))
+                self._write_success(config, now - timedelta(minutes=61))
                 past_floor = check_display_heartbeat(config, now=now)
 
         self.assertEqual(within_floor["threshold_minutes"], 60)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -396,10 +396,18 @@ class DisplayHeartbeatTests(unittest.TestCase):
         path.write_text(DISPLAY_CONFIG.format(rotation_minutes=rotation_minutes))
         return load_config(path)
 
-    def _write_heartbeat(self, config: AppConfig, fetched_at: datetime) -> None:
+    def _write_heartbeat(
+        self, config: AppConfig, fetched_at: datetime, *, reports_success: bool = True
+    ) -> None:
         config.controller.state_dir.mkdir(parents=True, exist_ok=True)
         (config.controller.state_dir / "display-last-fetch.json").write_text(
-            json.dumps({"schema_version": 1, "fetched_at": fetched_at.isoformat()})
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "fetched_at": fetched_at.isoformat(),
+                    "reports_success": reports_success,
+                }
+            )
         )
 
     def _write_success(self, config: AppConfig, succeeded_at: datetime) -> None:
@@ -482,6 +490,24 @@ class DisplayHeartbeatTests(unittest.TestCase):
         self.assertTrue(result["checked"])
         self.assertFalse(result["stale"])
         notify.assert_not_called()
+
+    def test_legacy_display_without_success_reporting_uses_fetch_age(self) -> None:
+        now = datetime(2026, 7, 10, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            config = self._config(temporary)
+            self._write_heartbeat(config, now - timedelta(minutes=10), reports_success=False)
+            with patch("inky_bird_frame.notifications.safe_notify") as notify:
+                fresh = check_display_heartbeat(config, now=now)
+            self._write_heartbeat(config, now - timedelta(minutes=200), reports_success=False)
+            with patch(
+                "inky_bird_frame.notifications.safe_notify",
+                return_value={"queued": True},
+            ):
+                stale = check_display_heartbeat(config, now=now)
+
+        self.assertFalse(fresh["stale"])
+        notify.assert_not_called()
+        self.assertTrue(stale["stale"])
 
     def test_fetching_without_any_completed_update_alerts(self) -> None:
         now = datetime(2026, 7, 10, tzinfo=UTC)

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -10,9 +10,10 @@ from unittest.mock import patch
 
 from PIL import Image, PngImagePlugin
 
-from inky_bird_frame.catalog import rebuild_catalog_index, sha256_file, write_json_atomic
+from inky_bird_frame.catalog import rebuild_catalog_index, sha256_file
 from inky_bird_frame.config import PublicCatalogConfig, load_config
 from inky_bird_frame.errors import CatalogPublishError
+from inky_bird_frame.http import write_json_atomic
 from inky_bird_frame.publisher import (
     _remote_repository,
     _validate_checkout,

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -558,6 +558,7 @@ class PublisherTests(unittest.TestCase):
             remote, checkout = _initialize_remote(root)
             config = load_config(_write_config(root, checkout))
             _create_species(config.controller.catalog_dir, 1, "Example Bird")
+            (config.controller.catalog_dir / ".staging").mkdir()
 
             def fake_gh(
                 _publication: object,

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 import random
 import unittest
 
-from inky_bird_frame.birds import BirdSpecies
 from inky_bird_frame.catalog import CatalogEntry
 from inky_bird_frame.config import RotationMode
 from inky_bird_frame.selection import (
     select_catalog_entry,
-    select_rotating_species,
     select_shuffle_bag_entry,
 )
 
@@ -29,22 +27,6 @@ def catalog_entry(taxon_id: int, count: int) -> CatalogEntry:
 
 
 class SelectionTests(unittest.TestCase):
-    def test_select_rotating_species_wraps_by_step(self) -> None:
-        species = [
-            BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 26, "iNaturalist"),
-            BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 18, "iNaturalist"),
-        ]
-
-        self.assertEqual(select_rotating_species(species, 0).common_name, "Eastern Bluebird")
-        self.assertEqual(select_rotating_species(species, 1).common_name, "Carolina Wren")
-        self.assertEqual(select_rotating_species(species, 2).common_name, "Eastern Bluebird")
-
-    def test_select_rotating_species_rejects_bad_input(self) -> None:
-        with self.assertRaises(ValueError):
-            select_rotating_species([])
-        with self.assertRaises(ValueError):
-            select_rotating_species([BirdSpecies(1, "A", "B", 1, "test")], -1)
-
     def test_shuffle_visits_each_entry_before_repeating(self) -> None:
         entries = [catalog_entry(1, 10), catalog_entry(2, 5), catalog_entry(3, 1)]
         rng = random.Random(7)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import threading
 import unittest
+from collections.abc import Iterator
+from contextlib import contextmanager
 from http.client import HTTPConnection
 from http.server import ThreadingHTTPServer
 from pathlib import Path
@@ -10,38 +12,173 @@ from tempfile import TemporaryDirectory
 
 from inky_bird_frame.server import CatalogRequestHandler
 
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+
+@contextmanager
+def _serving(catalog_dir: Path, active_catalog_path: Path, state_dir: Path) -> Iterator[int]:
+    handler = type(
+        "TestCatalogRequestHandler",
+        (CatalogRequestHandler,),
+        {
+            "catalog_dir": catalog_dir,
+            "active_catalog_path": active_catalog_path,
+            "state_dir": state_dir,
+        },
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        yield server.server_port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def _get(port: int, path: str) -> tuple[int, dict[str, str], bytes]:
+    connection = HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        connection.request("GET", path)
+        response = connection.getresponse()
+        return response.status, dict(response.getheaders()), response.read()
+    finally:
+        connection.close()
+
 
 class ServerTests(unittest.TestCase):
-    def test_active_catalog_is_not_cached_as_an_immutable_asset(self) -> None:
+    @contextmanager
+    def _environment(self) -> Iterator[tuple[Path, Path, Path]]:
         with TemporaryDirectory() as temporary:
             root = Path(temporary)
-            catalog_dir = root / "catalog"
-            catalog_dir.mkdir()
-            active_catalog_path = root / "active-catalog.json"
-            active_catalog_path.write_text(json.dumps({"schema_version": 1, "species": []}))
-            handler = type(
-                "TestCatalogRequestHandler",
-                (CatalogRequestHandler,),
-                {
-                    "catalog_dir": catalog_dir,
-                    "active_catalog_path": active_catalog_path,
-                },
-            )
-            server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
-            thread = threading.Thread(target=server.serve_forever)
-            thread.start()
-            try:
-                connection = HTTPConnection("127.0.0.1", server.server_port, timeout=5)
-                connection.request("GET", "/v1/catalog")
-                response = connection.getresponse()
-                response.read()
-            finally:
-                server.shutdown()
-                server.server_close()
-                thread.join()
+            catalog_dir = root / "nested" / "catalog"
+            catalog_dir.mkdir(parents=True)
+            state_dir = root / "state"
+            state_dir.mkdir()
+            yield root, catalog_dir, state_dir
 
-        self.assertEqual(response.status, 200)
-        self.assertEqual(response.getheader("Cache-Control"), "no-store")
+    def test_active_catalog_is_not_cached_as_an_immutable_asset(self) -> None:
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps({"schema_version": 1, "species": []}))
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                status, headers, _ = _get(port, "/v1/catalog")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(headers.get("Cache-Control"), "no-store")
+
+    def test_asset_is_served_with_png_content_type(self) -> None:
+        with self._environment() as (_, catalog_dir, state_dir):
+            asset = catalog_dir / "species" / "1-robin" / "portrait.png"
+            asset.parent.mkdir(parents=True)
+            asset.write_bytes(PNG_BYTES)
+            with _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port:
+                status, headers, body = _get(port, "/v1/assets/species/1-robin/portrait.png")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(headers.get("Content-Type"), "image/png")
+        self.assertEqual(body, PNG_BYTES)
+
+    def test_asset_path_traversal_is_rejected(self) -> None:
+        secret = b"top secret"
+        with self._environment() as (root, catalog_dir, state_dir):
+            (root / "secret.txt").write_bytes(secret)
+            with _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port:
+                for path in (
+                    "/v1/assets/..%2f..%2fsecret.txt",
+                    "/v1/assets/%2e%2e/%2e%2e/secret.txt",
+                    "/v1/assets//etc/hostname",
+                ):
+                    status, _, body = _get(port, path)
+                    self.assertEqual(status, 404, path)
+                    self.assertNotIn(secret, body, path)
+                    self.assertEqual(json.loads(body), {"ok": False, "error": "not found"})
+
+    def test_unknown_route_returns_json_not_found(self) -> None:
+        with (
+            self._environment() as (_, catalog_dir, state_dir),
+            _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port,
+        ):
+            status, headers, body = _get(port, "/nope")
+
+        self.assertEqual(status, 404)
+        self.assertEqual(headers.get("Content-Type"), "application/json")
+        self.assertEqual(json.loads(body), {"ok": False, "error": "not found"})
+
+    def test_catalog_returns_503_when_active_catalog_is_missing(self) -> None:
+        with (
+            self._environment() as (_, catalog_dir, state_dir),
+            _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port,
+        ):
+            status, _, body = _get(port, "/v1/catalog")
+
+        self.assertEqual(status, 503)
+        self.assertEqual(
+            json.loads(body),
+            {"ok": False, "error": "active catalog unavailable", "schema_version": 1},
+        )
+
+    def test_catalog_returns_503_when_active_catalog_is_corrupt(self) -> None:
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text('{"schema_version": 1, "species"')
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                status, _, body = _get(port, "/v1/catalog")
+            heartbeat = state_dir / "display-last-fetch.json"
+            self.assertFalse(heartbeat.exists())
+
+        self.assertEqual(status, 503)
+        self.assertEqual(
+            json.loads(body),
+            {"ok": False, "error": "active catalog unavailable", "schema_version": 1},
+        )
+
+    def test_catalog_success_records_display_fetch_heartbeat(self) -> None:
+        active = {"schema_version": 1, "species": [{"taxon_id": 1}]}
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(active))
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                status, _, body = _get(port, "/v1/catalog")
+            heartbeat = json.loads((state_dir / "display-last-fetch.json").read_text())
+
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(body), active)
+        self.assertEqual(heartbeat["schema_version"], 1)
+        self.assertRegex(heartbeat["fetched_at"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
+
+    def test_health_reports_counts_without_touching_the_index(self) -> None:
+        with self._environment() as (_, catalog_dir, state_dir):
+            index_path = catalog_dir / "index.json"
+            index_path.write_text(json.dumps({"schema_version": 1, "species": [{}, {}]}))
+            index_stat = index_path.stat()
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps({"schema_version": 1, "species": [{}]}))
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                status, _, body = _get(port, "/health")
+            self.assertEqual(index_path.stat().st_mtime_ns, index_stat.st_mtime_ns)
+            self.assertEqual(index_path.stat().st_size, index_stat.st_size)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            json.loads(body),
+            {"ok": True, "approved_species": 2, "active_species": 1, "schema_version": 1},
+        )
+
+    def test_health_tolerates_missing_index_and_corrupt_active_catalog(self) -> None:
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text("not json")
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                status, _, body = _get(port, "/health")
+            self.assertFalse((catalog_dir / "index.json").exists())
+
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            json.loads(body),
+            {"ok": True, "approved_species": 0, "active_species": 0, "schema_version": 1},
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -68,6 +68,18 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertEqual(headers.get("Cache-Control"), "no-store")
 
+    def test_display_success_report_is_recorded(self) -> None:
+        with self._environment() as (_, catalog_dir, state_dir):
+            with _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port:
+                status, _, body = _get(port, "/v1/display-success")
+
+            recorded = json.loads((state_dir / "display-last-success.json").read_text())
+
+        self.assertEqual(status, 200)
+        self.assertTrue(json.loads(body)["ok"])
+        self.assertEqual(recorded["schema_version"], 1)
+        self.assertIn("succeeded_at", recorded)
+
     def test_asset_is_served_with_png_content_type(self) -> None:
         with self._environment() as (_, catalog_dir, state_dir):
             asset = catalog_dir / "species" / "1-robin" / "portrait.png"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -209,6 +209,8 @@ class ServerTests(unittest.TestCase):
             active_catalog_path.write_text(json.dumps(active))
             with _serving(catalog_dir, active_catalog_path, state_dir) as port:
                 plain_status, _, _ = _get(port, "/v1/catalog")
+                _get(port, "/v1/catalog?not_reports_success=1")
+                _get(port, "/v1/catalog?reports_success=10")
                 plain_written = (state_dir / "display-last-fetch.json").exists()
                 status, _, body = _get(port, "/v1/catalog?reports_success=1")
             heartbeat = json.loads((state_dir / "display-last-fetch.json").read_text())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -208,9 +208,13 @@ class ServerTests(unittest.TestCase):
             active_catalog_path = state_dir / "active-catalog.json"
             active_catalog_path.write_text(json.dumps(active))
             with _serving(catalog_dir, active_catalog_path, state_dir) as port:
-                status, _, body = _get(port, "/v1/catalog")
+                plain_status, _, _ = _get(port, "/v1/catalog")
+                plain_written = (state_dir / "display-last-fetch.json").exists()
+                status, _, body = _get(port, "/v1/catalog?reports_success=1")
             heartbeat = json.loads((state_dir / "display-last-fetch.json").read_text())
 
+        self.assertEqual(plain_status, 200)
+        self.assertFalse(plain_written)
         self.assertEqual(status, 200)
         self.assertEqual(json.loads(body), active)
         self.assertEqual(heartbeat["schema_version"], 1)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,7 @@ from http.server import ThreadingHTTPServer
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from inky_bird_frame.server import CatalogRequestHandler
+from inky_bird_frame.server import CatalogRequestHandler, rebuild_index_logging_failures
 
 PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
 
@@ -67,6 +67,44 @@ class ServerTests(unittest.TestCase):
 
         self.assertEqual(status, 200)
         self.assertEqual(headers.get("Cache-Control"), "no-store")
+
+    def test_non_utf8_state_files_degrade_gracefully(self) -> None:
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_bytes(b'{"schema_version": 1, "species": [\xff\xfe')
+            (catalog_dir / "index.json").write_bytes(b'{"species": [\xff\xfe')
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                catalog_status, _, _ = _get(port, "/v1/catalog")
+                health_status, _, health_body = _get(port, "/health")
+
+        self.assertEqual(catalog_status, 503)
+        self.assertEqual(health_status, 200)
+        payload = json.loads(health_body)
+        self.assertEqual(payload["approved_species"], 0)
+        self.assertEqual(payload["active_species"], 0)
+
+    def test_startup_index_rebuild_survives_missing_assets(self) -> None:
+        with self._environment() as (_, catalog_dir, _state_dir):
+            species = catalog_dir / "species" / "1-robin"
+            species.mkdir(parents=True)
+            (species / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "status": "approved",
+                        "taxon_id": 1,
+                        "common_name": "Robin",
+                        "scientific_name": "Turdus migratorius",
+                        "slug": "robin",
+                        "approved_at": "2026-07-10T00:00:00+00:00",
+                        "assets": {
+                            "portrait": {"filename": "portrait.png", "sha256": "a" * 64},
+                            "display": {"filename": "display.png", "sha256": "b" * 64},
+                        },
+                    }
+                )
+            )
+            rebuild_index_logging_failures(catalog_dir)
 
     def test_display_success_report_is_recorded(self) -> None:
         with self._environment() as (_, catalog_dir, state_dir):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -106,6 +106,24 @@ class ServerTests(unittest.TestCase):
             )
             rebuild_index_logging_failures(catalog_dir)
 
+    def test_staging_and_dot_paths_are_never_served(self) -> None:
+        with self._environment() as (_, catalog_dir, state_dir):
+            staged = catalog_dir / ".staging" / "1-robin"
+            staged.mkdir(parents=True)
+            (staged / "manifest.json").write_text("{}")
+            hidden = catalog_dir / "species" / ".hidden.png"
+            hidden.parent.mkdir(parents=True)
+            hidden.write_bytes(b"secret")
+            with _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port:
+                staging_status, _, staging_body = _get(
+                    port, "/v1/assets/.staging/1-robin/manifest.json"
+                )
+                hidden_status, _, _ = _get(port, "/v1/assets/species/.hidden.png")
+
+        self.assertEqual(staging_status, 404)
+        self.assertEqual(hidden_status, 404)
+        self.assertNotIn(b"{}", staging_body)
+
     def test_display_success_report_is_recorded(self) -> None:
         with self._environment() as (_, catalog_dir, state_dir):
             with _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port:


### PR DESCRIPTION
## Summary

A full-project review surfaced a set of robustness gaps concentrated in crash recovery, health-check cost, and failure visibility. This change closes all of them with small, scoped fixes and focused tests, and incorporates seven rounds of review findings.

**Approval pipeline crash safety.** `approve_candidate` previously flipped the pending manifest in place before copying into the live catalog; a crash between those steps permanently wedged every future generation cycle. It now stages the approved copy under `catalog/.staging` and renames it into `species/` atomically, never mutates the pending directory, and recovers idempotently from every interruption window — including orphans and partial copies left by the old flow, validated as complete catalog entries before any pending copy is dropped. Per-species cache faults (corrupt or non-UTF-8 profiles, reference manifests, or individual reference entries) are quarantined as terminal failures for that taxon instead of aborting the whole cycle, while genuine catalog-wide corruption still aborts. The `retry` command clears per-taxon profile and reference caches so a retried species starts clean.

**Cheap, tolerant health checks.** `/health` re-hashed every catalog image (437 MB at the current catalog) and rewrote `index.json` on every request — every 30 seconds under the Docker healthcheck. It now reports counts from the last built index, never writes, and tolerates torn or non-UTF-8 state files, as does `/v1/catalog`. Startup index-rebuild failures log and continue instead of crash-looping the service. The asset endpoint refuses dot-prefixed path segments so approval staging is never servable.

**Display failure visibility.** The display node pulls from the controller and e-paper retains its last image, so a dead display previously failed silent indefinitely. Display fetches now carry a marker that records a heartbeat (other catalog readers never refresh it), completed panel updates are reported through `GET /v1/display-success`, and new `display_stale` / `display_recovered` events alert through the existing incident machinery when updates stop — including a node that fetches but has never completed an update. Stale cached images are evicted per taxon after each successful update.

**Durability and hardening.** The atomic JSON/bytes writers fsync file and parent directory around the rename (torn-state window on power loss) and are consolidated in one place. Outbound fetches enforce response-size caps and HTTP(S)-only schemes, including across redirects. The macOS installer rolls launchd back to its full pre-install state on failure (including newly bootstrapped agents and the legacy single-agent layout), uninstall scripts exist for all three roles, long-running systemd services get basic sandboxing directives, and the controller port is validated against 65535.

**Tests and docs.** New coverage: server path-traversal, dot-path, and health behavior over real sockets; codex subprocess failure paths via stub executables; display checksum-mismatch and unicode asset paths; staleness alerts and heartbeat semantics; approval recovery from every interruption shape; redirect-scheme enforcement against a live server; installer rollback ordering; and uninstall scripts. The suite is hermetic against inherited git configuration and blocks accidental outbound network. Previously undocumented commands (`controller-cycle`, `prepare-image`, `catalog sync`) and retention, clock-skew, `bind_host`, and upgrade-order guidance are now documented.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy` (strict, src and tests)
- `uv run pytest` (`304 passed`, `4 subtests passed`)
- `uv run inky-bird-frame catalog validate --catalog catalog`
- `shellcheck deploy/*.sh`
- `git diff --check`