### PR TITLE
Release version 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.1.1"
+version = "0.1.2"
 description = "Generate and display reusable bird field-journal plates"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/inky_bird_frame/__init__.py
+++ b/src/inky_bird_frame/__init__.py
@@ -1,3 +1,3 @@
 """Local bird field-journal plates for Pimoroni Inky displays."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary

- bump the package and runtime version to 0.1.2
- release the 7.3-inch PIM773 display support merged in #95
- retain configuration compatibility and the existing 13.3-inch PIM774 behavior

Tracks #92.

## Validation

- `uv sync --extra dev --locked`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src tests`
- `uv run pytest` (313 passed, 6 subtests passed)
- `uv run inky-bird-frame catalog validate --catalog catalog` (71 species)
- workflow action pinning check
- `actionlint`
- `shellcheck deploy/*.sh`
- package/runtime version consistency check
- `git diff --check`

## Release scope

This PR changes version metadata only. The functional change was separately reviewed, merged, deployed, and live-verified in #95. No configuration migration is required.
