### PR TITLE
ci: trigger henrysowell.com rebuild on catalog updates

### DIFF
--- a/.github/workflows/site-deploy-hook.yml
+++ b/.github/workflows/site-deploy-hook.yml
@@ -1,0 +1,28 @@
+name: site-deploy-hook
+
+# When a reviewed species lands in the catalog, ping the Cloudflare Pages
+# deploy hook for henrysowell.com so the public gallery rebuilds. The hook
+# URL is a secret because anyone holding it can trigger builds.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "catalog/**"
+
+permissions: {}
+
+jobs:
+  trigger-site-rebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger henrysowell.com rebuild
+        env:
+          DEPLOY_HOOK_URL: ${{ secrets.HENRYSOWELL_COM_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$DEPLOY_HOOK_URL" ]; then
+            echo "HENRYSOWELL_COM_DEPLOY_HOOK secret is not set; skipping." >&2
+            exit 0
+          fi
+          curl -fsS -X POST "$DEPLOY_HOOK_URL" > /dev/null
+          echo "Deploy hook fired."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,11 @@ uv run inky-bird-frame catalog validate --catalog catalog
 - Public pull requests run only on GitHub-hosted runners.
 - Deployment is manual, owner-gated, and runs only from `main` on the trusted
   controller runner.
+- Exception: `site-deploy-hook.yml` may POST the owner's Cloudflare Pages
+  deploy hook when `catalog/**` changes on `main`. It deploys nothing from
+  this repo and touches no runner secrets beyond the hook URL; it only asks
+  henrysowell.com to rebuild its gallery from the already-reviewed committed
+  catalog. Merging to `main` is the owner gate.
 - Container publication runs only from trusted `main`, a repository release,
   or an owner-started workflow. Pull requests never publish packages.
 - Never expose or copy a ChatGPT/Codex login into GitHub Actions.


### PR DESCRIPTION
## What Problem This Solves

The public gallery at henrysowell.com renders this repo's reviewed species catalog at build time. Today nothing tells the site a new plate landed, so the gallery lags the catalog until an unrelated deploy.

## Why This Change Was Made

A minimal push-triggered workflow (paths-filtered to `catalog/**` on `main`) POSTs the site's Cloudflare Pages deploy hook, so a newly approved species appears on the site minutes after it merges. The hook URL lives in the `HENRYSOWELL_COM_DEPLOY_HOOK` repo secret; the workflow exits cleanly with a notice if the secret is absent, and declares `permissions: {}` since it needs no repo access. No external actions are used, so there is nothing to SHA-pin.

## User Impact

Contributors see their approved plates on the public gallery automatically. No behavior change for the frame, controller, or CI.