### PR TITLE
Keep generation work inside the Codex workspace

### DIFF
--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -727,7 +727,10 @@ def generate_candidate(config: AppConfig, species: BirdSpecies, workspace: Path)
     reference_root = state_dir / "references" / str(species.taxon_id)
     reference_paths = [reference_root / reference.filename for reference in references]
     runner = CodexRunner(config.controller.codex_path, workspace)
-    work_parent = state_dir / "work"
+    # Codex runs with workspace-write sandboxing, so every path it must create
+    # needs to live below the configured workspace. The trusted controller
+    # process copies a passing candidate into state after Codex exits.
+    work_parent = workspace.resolve() / ".inky-bird-frame-work"
     work_parent.mkdir(parents=True, exist_ok=True)
 
     with TemporaryDirectory(prefix=f"{species.taxon_id}-", dir=work_parent) as temporary:

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -727,11 +727,14 @@ def generate_candidate(config: AppConfig, species: BirdSpecies, workspace: Path)
     reference_root = state_dir / "references" / str(species.taxon_id)
     reference_paths = [reference_root / reference.filename for reference in references]
     runner = CodexRunner(config.controller.codex_path, workspace)
-    # Codex runs with workspace-write sandboxing, so every path it must create
-    # needs to live below the configured workspace. The trusted controller
-    # process copies a passing candidate into state after Codex exits.
-    work_parent = workspace.resolve() / ".inky-bird-frame-work"
+    work_parent = state_dir / "work"
     work_parent.mkdir(parents=True, exist_ok=True)
+    # The image tool copies its bitmap from inside Codex, so that one output
+    # must live below the workspace-write sandbox root. Keep profiles, review
+    # inputs, and candidate staging in controller state where Codex cannot
+    # mutate them, then let the trusted parent process prepare the bitmap.
+    generation_parent = workspace.resolve() / ".inky-bird-frame-generation"
+    generation_parent.mkdir(parents=True, exist_ok=True)
 
     with TemporaryDirectory(prefix=f"{species.taxon_id}-", dir=work_parent) as temporary:
         work = Path(temporary)
@@ -751,20 +754,23 @@ def generate_candidate(config: AppConfig, species: BirdSpecies, workspace: Path)
         for attempt in range(1, config.controller.max_generation_attempts + 1):
             attempt_dir = work / f"attempt-{attempt:02d}"
             attempt_dir.mkdir()
-            generated_path = attempt_dir / "generated.png"
-            runner.generate_plate(
-                species,
-                profile,
-                references,
-                reference_paths,
-                generated_path,
-                logs / f"02-generation-attempt-{attempt:02d}.log",
-                correction_findings,
-            )
             portrait_path = attempt_dir / "portrait.png"
             display_path = attempt_dir / "display.png"
-            prepare_generated_plate(generated_path, portrait_path, display_path)
-            generated_path.unlink()
+            with TemporaryDirectory(
+                prefix=f"{species.taxon_id}-attempt-{attempt:02d}-",
+                dir=generation_parent,
+            ) as generation_temporary:
+                generated_path = Path(generation_temporary) / "generated.png"
+                runner.generate_plate(
+                    species,
+                    profile,
+                    references,
+                    reference_paths,
+                    generated_path,
+                    logs / f"02-generation-attempt-{attempt:02d}.log",
+                    correction_findings,
+                )
+                prepare_generated_plate(generated_path, portrait_path, display_path)
 
             review = runner.review_plate(
                 species,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -738,6 +738,7 @@ class ControllerTests(unittest.TestCase):
         class FakeRunner:
             corrections: list[tuple[str, ...]] = []
             generated_paths: list[Path] = []
+            review_paths: list[Path] = []
             reviews = iter((failed_review, passed_review))
 
             def __init__(self, _executable: Path, workspace: Path) -> None:
@@ -746,6 +747,7 @@ class ControllerTests(unittest.TestCase):
             def create_profile(self, *_args: object, **_kwargs: object) -> SpeciesProfileData:
                 output_path = _args[-2]
                 assert isinstance(output_path, Path)
+                assert not output_path.resolve().is_relative_to(self.workspace)
                 output_path.write_text(json.dumps(PROFILE))
                 return PROFILE
 
@@ -761,6 +763,10 @@ class ControllerTests(unittest.TestCase):
                 return output_path
 
             def review_plate(self, *_args: object, **_kwargs: object) -> QualityReview:
+                portrait_path = _args[3]
+                assert isinstance(portrait_path, Path)
+                self.review_paths.append(portrait_path)
+                assert not portrait_path.resolve().is_relative_to(self.workspace)
                 return next(self.reviews)
 
         def prepare(_source: Path, portrait: Path, display: Path) -> None:
@@ -769,8 +775,11 @@ class ControllerTests(unittest.TestCase):
 
         with TemporaryDirectory() as temporary:
             config_path = Path(temporary) / "config.toml"
-            config_path.write_text(CONFIG)
+            config_path.write_text(
+                CONFIG.replace('workspace_dir = "."', 'workspace_dir = "workspace"')
+            )
             config = load_config(config_path)
+            config.controller.workspace_dir.mkdir()
             with (
                 patch("inky_bird_frame.controller.load_or_fetch_references", return_value=[]),
                 patch("inky_bird_frame.controller.fetch_taxon_context"),
@@ -785,6 +794,7 @@ class ControllerTests(unittest.TestCase):
 
         self.assertEqual(FakeRunner.corrections, [(), ("Crest is too short",)])
         self.assertEqual(len(FakeRunner.generated_paths), 2)
+        self.assertEqual(len(FakeRunner.review_paths), 2)
         self.assertEqual(manifest["generation"]["attempt"], 2)
         self.assertEqual(manifest["status"], "pending")
         self.assertFalse((candidate / "attempt-history.json").exists())

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -737,10 +737,11 @@ class ControllerTests(unittest.TestCase):
 
         class FakeRunner:
             corrections: list[tuple[str, ...]] = []
+            generated_paths: list[Path] = []
             reviews = iter((failed_review, passed_review))
 
-            def __init__(self, _executable: Path, _workspace: Path) -> None:
-                pass
+            def __init__(self, _executable: Path, workspace: Path) -> None:
+                self.workspace = workspace.resolve()
 
             def create_profile(self, *_args: object, **_kwargs: object) -> SpeciesProfileData:
                 output_path = _args[-2]
@@ -753,6 +754,8 @@ class ControllerTests(unittest.TestCase):
                 correction = _args[-1]
                 assert isinstance(output_path, Path)
                 assert isinstance(correction, tuple)
+                self.generated_paths.append(output_path)
+                assert output_path.resolve().is_relative_to(self.workspace)
                 self.corrections.append(correction)
                 output_path.write_bytes(b"generated")
                 return output_path
@@ -781,6 +784,7 @@ class ControllerTests(unittest.TestCase):
             )
 
         self.assertEqual(FakeRunner.corrections, [(), ("Crest is too short",)])
+        self.assertEqual(len(FakeRunner.generated_paths), 2)
         self.assertEqual(manifest["generation"]["attempt"], 2)
         self.assertEqual(manifest["status"], "pending")
         self.assertFalse((candidate / "attempt-history.json").exists())


### PR DESCRIPTION
## What changed

- keep per-taxon generation work under the configured Codex workspace
- copy only passing candidates into the controller state directory
- assert generated image paths remain beneath the writable workspace

## Root cause

Codex runs with `workspace-write` sandboxing. The controller created `generated.png` targets under `~/Library/Application Support/Inky Bird Frame`, outside the configured workspace. Image generation succeeded, but Codex could not copy the bitmap to that target, so every cycle deferred the species as a generation failure.

## Impact

Generation can now complete on macOS while persistent controller state remains outside the Git checkout. Existing configuration is unchanged.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest` — 313 passed, 6 subtests passed
- `uv run inky-bird-frame catalog validate --catalog catalog` — 72 species valid
- `git diff --check`
