### PR TITLE
Run controller deploy in launchd keychain context

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,9 @@ jobs:
         env:
           # The launchd runner has a system-only PATH; uv is installed by Homebrew.
           UV_BIN: /opt/homebrew/bin/uv
-        run: ./deploy/install-controller.sh
+        # Run in the controller's GUI launchd domain so keychain-backed GitHub
+        # CLI credentials are available without exporting a token into Actions.
+        run: ./deploy/install-controller-via-launchd.sh
 
       - name: Deploy display node
         if: inputs.deploy_display_node

--- a/deploy/install-controller-via-launchd.sh
+++ b/deploy/install-controller-via-launchd.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "The launchd controller installer requires macOS." >&2
+  exit 1
+fi
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+installer="${root}/deploy/install-controller.sh"
+uv_bin=${UV_BIN:-}
+if [ -z "${uv_bin}" ]; then
+  uv_bin=$(command -v uv || true)
+fi
+if [ -z "${uv_bin}" ] || [ ! -x "${uv_bin}" ]; then
+  echo "uv is not executable. Install uv or set UV_BIN." >&2
+  exit 1
+fi
+
+timeout_seconds=${INKY_BIRD_LAUNCHD_INSTALL_TIMEOUT_SECONDS:-1800}
+case "${timeout_seconds}" in
+  '' | *[!0-9]* | 0)
+    echo "INKY_BIRD_LAUNCHD_INSTALL_TIMEOUT_SECONDS must be a positive integer." >&2
+    exit 1
+    ;;
+esac
+
+uid=$(id -u)
+temporary_root=${TMPDIR:-/tmp}
+temporary_root=${temporary_root%/}
+temporary_dir=$(mktemp -d "${temporary_root}/inky-bird-frame-install.XXXXXX")
+plist_path="${temporary_dir}/install.plist"
+stdout_path="${temporary_dir}/stdout.log"
+stderr_path="${temporary_dir}/stderr.log"
+status_path="${temporary_dir}/status"
+label="com.inky-bird-frame.install.${uid}.$$"
+
+# shellcheck disable=SC2329 # Invoked indirectly by the EXIT trap below.
+cleanup() {
+  status=$?
+  trap - EXIT
+  launchctl bootout "gui/${uid}/${label}" 2>/dev/null || true
+  rm -f "${plist_path}" "${stdout_path}" "${stderr_path}" "${status_path}"
+  rmdir "${temporary_dir}" 2>/dev/null || true
+  exit "${status}"
+}
+trap cleanup EXIT
+
+touch "${stdout_path}" "${stderr_path}"
+/usr/bin/python3 - \
+  "${plist_path}" "${label}" "${root}" "${HOME}" "${stdout_path}" "${stderr_path}" \
+  "${status_path}" "${uv_bin}" "${installer}" <<'PY'
+import plistlib
+import sys
+from pathlib import Path
+
+(
+    plist_path,
+    label,
+    working_directory,
+    home,
+    stdout_path,
+    stderr_path,
+    status_path,
+    uv_bin,
+    installer,
+) = sys.argv[1:]
+payload = {
+    "Label": label,
+    "ProgramArguments": [
+        "/bin/bash",
+        "-c",
+        'UV_BIN="$1" "$2"; child_status=$?; '
+        'printf "%s\\n" "$child_status" > "$3"; exit "$child_status"',
+        "_",
+        uv_bin,
+        installer,
+        status_path,
+    ],
+    "WorkingDirectory": working_directory,
+    "EnvironmentVariables": {
+        "HOME": home,
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin",
+    },
+    "ProcessType": "Background",
+    "RunAtLoad": True,
+    "StandardOutPath": stdout_path,
+    "StandardErrorPath": stderr_path,
+}
+with Path(plist_path).open("wb") as handle:
+    plistlib.dump(payload, handle, sort_keys=True)
+PY
+
+launchctl bootstrap "gui/${uid}" "${plist_path}"
+deadline=$((SECONDS + timeout_seconds))
+while [ ! -f "${status_path}" ]; do
+  if [ "${SECONDS}" -ge "${deadline}" ]; then
+    cat "${stdout_path}"
+    cat "${stderr_path}" >&2
+    echo "Controller installation timed out after ${timeout_seconds} seconds." >&2
+    exit 124
+  fi
+  if ! launchctl print "gui/${uid}/${label}" >/dev/null 2>&1; then
+    cat "${stdout_path}"
+    cat "${stderr_path}" >&2
+    echo "Controller installation stopped without reporting an exit status." >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+# The status file is written immediately before the child exits. Give launchd a
+# short bounded window to flush the configured stdout/stderr files.
+for _ in {1..20}; do
+  if ! launchctl print "gui/${uid}/${label}" 2>/dev/null | grep -q 'state = running'; then
+    break
+  fi
+  sleep 0.1
+done
+
+cat "${stdout_path}"
+cat "${stderr_path}" >&2
+child_status=$(tr -d '[:space:]' < "${status_path}")
+case "${child_status}" in
+  '' | *[!0-9]*)
+    echo "Controller installation returned an invalid exit status." >&2
+    exit 1
+    ;;
+esac
+exit "${child_status}"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -195,7 +195,13 @@ LaunchAgent only when `[public_catalog].enabled` is true.
 ## Maintainer deployment on macOS
 
 The optional owner-only deployment workflow uses the included macOS controller
-installer. Its trusted runner reads display connection details from
+installer. The self-hosted Actions runner dispatches that installer as a
+one-shot job in the controller user's GUI launchd domain. This is the same
+security context as the catalog publisher, so the existing keychain-backed
+GitHub CLI credential remains available without copying it into an Actions
+secret or environment variable.
+
+The trusted runner reads display connection details from
 `~/Library/Application Support/Inky Bird Frame/deployment.env`:
 
 ```bash

--- a/tests/test_deployment_scripts.py
+++ b/tests/test_deployment_scripts.py
@@ -109,6 +109,22 @@ def test_macos_controller_installer_restores_previously_loaded_agents_on_failure
     assert 'rm -rf "${plist_backup_dir}"' in script
 
 
+def test_actions_controller_installer_uses_gui_launchd_without_exporting_tokens() -> None:
+    root = Path(__file__).resolve().parents[1]
+    script = (root / "deploy" / "install-controller-via-launchd.sh").read_text()
+    workflow = (root / ".github" / "workflows" / "deploy.yml").read_text()
+
+    assert 'launchctl bootstrap "gui/${uid}" "${plist_path}"' in script
+    assert 'launchctl bootout "gui/${uid}/${label}"' in script
+    assert '"RunAtLoad": True' in script
+    assert '"KeepAlive"' not in script
+    assert '"${root}/deploy/install-controller.sh"' in script
+    assert "GH_TOKEN" not in script
+    assert "GITHUB_TOKEN" not in script
+    assert "./deploy/install-controller-via-launchd.sh" in workflow
+    assert "./deploy/install-controller.sh\n" not in workflow
+
+
 def test_local_display_installer_uses_configured_schedule_and_verifies_timer() -> None:
     script = (
         Path(__file__).resolve().parents[1] / "deploy" / "install-display-local.sh"


### PR DESCRIPTION
## Summary
- run controller deployment through a one-shot GUI launchd job so macOS Keychain credentials are available
- keep GitHub tokens out of Actions environment variables and files
- document and test the credential-context boundary

## Verification
- 314 tests passed, 6 subtests
- ruff format/check, mypy, actionlint, shellcheck, workflow pinning, and catalog validation passed
- live launchd-wrapper install completed successfully on the controller