### PR TITLE
Bound iNaturalist reference metadata

### DIFF
--- a/src/inky_bird_frame/references.py
+++ b/src/inky_bird_frame/references.py
@@ -14,6 +14,17 @@ from .models import ReferencePhoto
 
 ALLOWED_LICENSES: Final = ("cc0", "cc-by")
 MIN_REFERENCE_EDGE: Final = 800
+REFERENCE_FIELDS: Final = (
+    "id",
+    "uri",
+    "user.login",
+    "photos.id",
+    "photos.attribution",
+    "photos.license_code",
+    "photos.url",
+    "photos.original_dimensions.width",
+    "photos.original_dimensions.height",
+)
 
 
 @dataclass(frozen=True)
@@ -144,9 +155,10 @@ def fetch_reference_candidates(
             "order_by": "votes",
             "order": "desc",
             "per_page": str(max(30, count * 10)),
+            "fields": ",".join(REFERENCE_FIELDS),
         }
     )
-    payload = get_json(f"https://api.inaturalist.org/v1/observations?{params}", timeout_seconds)
+    payload = get_json(f"https://api.inaturalist.org/v2/observations?{params}", timeout_seconds)
     return parse_reference_candidates(payload, count)
 
 

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
 import unittest
+from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlsplit
 
 from inky_bird_frame.errors import InsufficientReferencesError
-from inky_bird_frame.references import parse_reference_candidates, photo_url_for_size
+from inky_bird_frame.references import (
+    REFERENCE_FIELDS,
+    fetch_reference_candidates,
+    parse_reference_candidates,
+    photo_url_for_size,
+)
 
 
 def observation(
@@ -49,6 +56,32 @@ class ReferenceTests(unittest.TestCase):
     def test_rejects_insufficient_licensed_references(self) -> None:
         with self.assertRaises(InsufficientReferencesError):
             parse_reference_candidates({"results": [observation(1, "alice", 11, "cc-by-nc")]}, 1)
+
+    @patch("inky_bird_frame.references.get_json")
+    def test_fetches_only_reference_selection_fields(self, get_json: MagicMock) -> None:
+        get_json.return_value = {
+            "results": [
+                observation(1, "alice", 11),
+                observation(2, "alice", 12),
+                observation(3, "bob", 13, "cc0"),
+            ]
+        }
+
+        references = fetch_reference_candidates(9602, 2, timeout_seconds=12.0)
+
+        self.assertEqual([item.photo_id for item in references], [11, 13])
+        get_json.assert_called_once()
+        url, timeout = get_json.call_args.args
+        parsed = urlsplit(url)
+        query = parse_qs(parsed.query)
+        self.assertEqual(parsed.scheme, "https")
+        self.assertEqual(parsed.netloc, "api.inaturalist.org")
+        self.assertEqual(parsed.path, "/v2/observations")
+        self.assertEqual(timeout, 12.0)
+        self.assertEqual(query["order_by"], ["votes"])
+        self.assertEqual(query["order"], ["desc"])
+        self.assertEqual(query["per_page"], ["30"])
+        self.assertEqual(query["fields"], [",".join(REFERENCE_FIELDS)])
 
     def test_photo_url_size_is_validated(self) -> None:
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## What changed

- move licensed reference discovery to the official iNaturalist v2 observations endpoint
- request only the observation, observer, licensing, URL, and dimension fields used by reference selection
- preserve vote ordering, distinct-observer selection, CC0/CC-BY filtering, minimum dimensions, and `large` image downloads
- add a regression test for the projected request contract and unchanged selection behavior

## Why

The v1 observations response includes large nested taxon, identification, vote, and location payloads that the generation path never uses. Dense records can exceed the controller's 8 MiB JSON safety cap before any reference image is downloaded.

Field projection removes that unused metadata instead of weakening the safety cap. Live 40-observation samples fell from 2.8-4.0 MB to about 28 KB, while the chosen reference photo IDs and `large` asset URLs remained unchanged.

## Impact

Reference metadata stays bounded without lowering generated-image quality or increasing iNaturalist request volume. Image bytes remain on the existing separate 64 MiB asset path.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest` (315 passed, 6 subtests passed)
- `uv run inky-bird-frame catalog validate --catalog catalog` (75 species, valid)
- live iNaturalist projected-response smoke test through `fetch_reference_candidates`
