### PR TITLE
Add historical location seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,13 @@ uv run inky-bird-frame generate --config config.toml
 uv run inky-bird-frame seed --config config.toml --source inaturalist \
   --window last-year --species-limit 500
 
+# Queue species from one historical place and inclusive date range without
+# changing the configured discovery location or active display window.
+uv run inky-bird-frame seed --config config.toml --source inaturalist \
+  --latitude 40.7128 --longitude -74.0060 --radius-km 11 \
+  --start-date 2026-04-01 --end-date 2026-04-03 \
+  --species-limit 500 --dry-run
+
 # Inspect approved, pending, and failed work.
 uv run inky-bird-frame status --config config.toml
 

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -183,6 +183,23 @@ inky-bird-frame seed --config /path/to/config.toml \
   --source inaturalist --window last-year --species-limit 500
 ```
 
+For an exact historical place-and-time window, provide both coordinates and
+both inclusive ISO dates. This command-scoped location does not alter the
+configured discovery location:
+
+```bash
+inky-bird-frame seed --config /path/to/config.toml \
+  --source inaturalist --latitude 40.7128 --longitude -74.0060 \
+  --radius-km 11 --start-date 2026-04-01 --end-date 2026-04-03 \
+  --species-limit 500 --dry-run
+```
+
+Exact date ranges require iNaturalist because the other configured providers
+cannot guarantee the same coordinate-radius historical query semantics. Run
+without `--dry-run` only after reviewing the structured result. The seed stores
+distinct taxa in the generation queue, not raw observation records or the
+command-scoped coordinates.
+
 Repeat `--source` for a multi-provider seed, for example `--source inaturalist
 --source ebird`. CLI overrides accept concrete providers rather than legacy
 group aliases.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -112,9 +112,21 @@ inky-bird-frame seed --config /path/to/config.toml \
   --source inaturalist --window last-year --species-limit 500
 ```
 
+To seed a historical trip or event, preview an inclusive iNaturalist date range
+around a command-scoped coordinate before applying the same command:
+
+```bash
+inky-bird-frame seed --config /path/to/config.toml \
+  --source inaturalist --latitude 40.7128 --longitude -74.0060 \
+  --radius-km 11 --start-date 2026-04-01 --end-date 2026-04-03 \
+  --species-limit 500 --dry-run
+```
+
 The configured source is used unless `--source` is provided. eBird cannot query
-beyond 30 days, so historical seeds must use iNaturalist. The configured radius
-is used unless `--radius-km` is provided. Repeating a seed
+beyond 30 days or guarantee arbitrary coordinate-radius historical windows, so
+exact date ranges require iNaturalist. `--latitude` and `--longitude` must be
+provided together and do not change the configured location. The configured
+radius is used unless `--radius-km` is provided. Repeating a seed
 is idempotent: approved, terminal, and already queued taxa are not added again.
 Current observations remain ahead of seed-only taxa during generation.
 

--- a/src/inky_bird_frame/birds.py
+++ b/src/inky_bird_frame/birds.py
@@ -89,6 +89,12 @@ class DateRange:
     start: date | None
     end: date | None
 
+    def __post_init__(self) -> None:
+        if (self.start is None) != (self.end is None):
+            raise ValueError("date range requires both start and end dates")
+        if self.start is not None and self.end is not None and self.start > self.end:
+            raise ValueError("start date must be on or before end date")
+
     def as_query_params(self) -> dict[str, str]:
         params: dict[str, str] = {}
         if self.start is not None:
@@ -170,6 +176,7 @@ def fetch_inaturalist_birds(
     radius_km: int,
     limit: int,
     window: ObservationWindow = ObservationWindow.ALL_TIME,
+    date_range: DateRange | None = None,
     today: date | None = None,
     timeout_seconds: float = 10.0,
 ) -> list[BirdSpecies]:
@@ -188,7 +195,8 @@ def fetch_inaturalist_birds(
         "photos": "true",
         "per_page": str(limit),
     }
-    query_params.update(date_range_for_window(window, today).as_query_params())
+    selected_dates = date_range or date_range_for_window(window, today)
+    query_params.update(selected_dates.as_query_params())
     params = urlencode(query_params)
     payload = get_json(
         f"https://api.inaturalist.org/v1/observations/species_counts?{params}",

--- a/src/inky_bird_frame/birds.py
+++ b/src/inky_bird_frame/birds.py
@@ -201,6 +201,7 @@ def fetch_inaturalist_birds(
     payload = get_json(
         f"https://api.inaturalist.org/v1/observations/species_counts?{params}",
         timeout_seconds,
+        error_label="iNaturalist API",
     )
     return parse_inaturalist_species_counts(payload)
 

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -10,10 +10,11 @@ import signal
 import sys
 import threading
 from contextlib import nullcontext
+from datetime import date
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-from .birds import BirdSpecies, ObservationWindow, parse_observation_window
+from .birds import BirdSpecies, DateRange, ObservationWindow, parse_observation_window
 from .catalog import (
     approve_candidate,
     catalog_state_lock,
@@ -311,10 +312,28 @@ def seed_command(args: argparse.Namespace) -> int:
     source_values = args.source
     if source_values is not None and len(source_values) != len(set(source_values)):
         raise ValueError("--source must not repeat a provider")
+    if (args.latitude is None) != (args.longitude is None):
+        raise ValueError("--latitude and --longitude must be provided together")
+    if args.window is not None and args.end_date is not None:
+        raise ValueError("--end-date cannot be combined with --window")
+    date_range = None
+    if args.start_date is not None:
+        if args.end_date is None:
+            raise ValueError("--start-date and --end-date must be provided together")
+        try:
+            date_range = DateRange(
+                start=date.fromisoformat(args.start_date),
+                end=date.fromisoformat(args.end_date),
+            )
+        except ValueError as exc:
+            raise ValueError(f"invalid ISO date range: {exc}") from exc
     print_result(
         enqueue_seed_species(
             _config(args),
-            window=parse_observation_window(args.window),
+            window=parse_observation_window(args.window) if args.window is not None else None,
+            date_range=date_range,
+            latitude=args.latitude,
+            longitude=args.longitude,
             sources=(
                 tuple(DiscoveryProvider(value) for value in source_values)
                 if source_values is not None
@@ -784,11 +803,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="Queue distinct species from a broader observation window for generation",
     )
     add_config_argument(seed_parser)
-    seed_parser.add_argument(
+    seed_period = seed_parser.add_mutually_exclusive_group(required=True)
+    seed_period.add_argument(
         "--window",
-        required=True,
         choices=[window.value for window in ObservationWindow],
     )
+    seed_period.add_argument("--start-date", help="Inclusive observation date (YYYY-MM-DD)")
+    seed_parser.add_argument("--end-date", help="Inclusive observation date (YYYY-MM-DD)")
     seed_parser.add_argument(
         "--source",
         action="append",
@@ -796,6 +817,8 @@ def build_parser() -> argparse.ArgumentParser:
         help="Override discovery with one provider; repeat to select multiple providers",
     )
     seed_parser.add_argument("--radius-km", type=int)
+    seed_parser.add_argument("--latitude", type=float)
+    seed_parser.add_argument("--longitude", type=float)
     seed_parser.add_argument("--species-limit", type=int)
     seed_parser.add_argument("--dry-run", action="store_true")
     seed_parser.set_defaults(func=seed_command)

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -17,6 +17,7 @@ from typing import cast
 from .birds import (
     BirdSpecies,
     BirdWeatherSpecies,
+    DateRange,
     EbirdSpecies,
     ObservationWindow,
     fetch_birdweather_species,
@@ -132,6 +133,9 @@ def discover_species(
     *,
     sources: tuple[DiscoveryProvider, ...] | None = None,
     window: ObservationWindow | None = None,
+    date_range: DateRange | None = None,
+    latitude: float | None = None,
+    longitude: float | None = None,
     radius_km: int | None = None,
     species_limit: int | None = None,
     persist_taxonomy_cache: bool = True,
@@ -140,6 +144,10 @@ def discover_species(
     selected_window = window or config.discovery.observation_window
     selected_radius = radius_km if radius_km is not None else config.discovery.radius_km
     selected_limit = species_limit if species_limit is not None else config.discovery.species_limit
+    if (latitude is None) != (longitude is None):
+        raise ValueError("latitude and longitude must be provided together")
+    if date_range is not None and selected_sources != (DiscoveryProvider.INATURALIST,):
+        raise ValueError("explicit date ranges require --source inaturalist")
     if DiscoveryProvider.EBIRD in selected_sources:
         if selected_window in {ObservationWindow.LAST_YEAR, ObservationWindow.ALL_TIME}:
             raise ValueError("eBird discovery supports observation windows up to 30 days")
@@ -161,7 +169,14 @@ def discover_species(
         location_provider_names.append("ebird")
     if location_provider_names:
         try:
-            location = resolve_discovery_location(config.discovery)
+            if latitude is None and longitude is None:
+                location = resolve_discovery_location(config.discovery)
+            else:
+                location = resolve_discovery_location(
+                    config.discovery,
+                    latitude=latitude,
+                    longitude=longitude,
+                )
         except DataSourceError as exc:
             providers.extend(
                 ProviderStatus(name, "error", 0, error=f"Location lookup failed: {exc}")
@@ -176,6 +191,7 @@ def discover_species(
                 radius_km=selected_radius,
                 limit=selected_limit,
                 window=selected_window,
+                date_range=date_range,
             )
         except DataSourceError as exc:
             providers.append(ProviderStatus("inaturalist", "error", 0, error=str(exc)))
@@ -424,12 +440,19 @@ def _write_generation_queue(config: AppConfig, species: list[BirdSpecies]) -> No
 def enqueue_seed_species(
     config: AppConfig,
     *,
-    window: ObservationWindow,
+    window: ObservationWindow | None = None,
+    date_range: DateRange | None = None,
+    latitude: float | None = None,
+    longitude: float | None = None,
     sources: tuple[DiscoveryProvider, ...] | None = None,
     radius_km: int | None = None,
     species_limit: int | None = None,
     dry_run: bool = False,
 ) -> dict[str, object]:
+    if (window is None) == (date_range is None):
+        raise ValueError("provide either an observation window or an explicit date range")
+    if date_range is not None and (date_range.start is None or date_range.end is None):
+        raise ValueError("explicit date range requires both start and end dates")
     radius = radius_km if radius_km is not None else config.discovery.radius_km
     limit = species_limit if species_limit is not None else config.discovery.species_limit
     if radius <= 0:
@@ -443,6 +466,9 @@ def enqueue_seed_species(
             config,
             sources=sources,
             window=window,
+            date_range=date_range,
+            latitude=latitude,
+            longitude=longitude,
             radius_km=radius,
             species_limit=limit,
             persist_taxonomy_cache=not dry_run,
@@ -470,7 +496,17 @@ def enqueue_seed_species(
             _write_generation_queue(config, queued)
 
     return {
-        "window": window.value,
+        "window": window.value if window is not None else None,
+        "start_date": (
+            date_range.start.isoformat()
+            if date_range is not None and date_range.start is not None
+            else None
+        ),
+        "end_date": (
+            date_range.end.isoformat()
+            if date_range is not None and date_range.end is not None
+            else None
+        ),
         "source": discovery_source_label(sources or config.discovery.sources),
         "sources": [provider.value for provider in (sources or config.discovery.sources)],
         "radius_km": radius,

--- a/src/inky_bird_frame/geo.py
+++ b/src/inky_bird_frame/geo.py
@@ -196,7 +196,26 @@ def lookup_geoapify_postcode(
     return parse_geoapify_postcode_response(postal_code, country_code, payload)
 
 
-def resolve_discovery_location(config: DiscoveryConfig) -> DiscoveryLocation:
+def resolve_discovery_location(
+    config: DiscoveryConfig,
+    *,
+    latitude: float | None = None,
+    longitude: float | None = None,
+) -> DiscoveryLocation:
+    if (latitude is None) != (longitude is None):
+        raise ValueError("latitude and longitude must be provided together")
+    if latitude is not None and longitude is not None:
+        valid_latitude = _valid_coordinate(latitude, minimum=-90, maximum=90)
+        valid_longitude = _valid_coordinate(longitude, minimum=-180, maximum=180)
+        if valid_latitude is None or valid_longitude is None:
+            raise ValueError("latitude or longitude is outside the valid range")
+        return DiscoveryLocation(
+            postal_code=None,
+            place_name="",
+            state="",
+            latitude=valid_latitude,
+            longitude=valid_longitude,
+        )
     if config.latitude is not None and config.longitude is not None:
         return DiscoveryLocation(
             postal_code=None,

--- a/tests/test_birds.py
+++ b/tests/test_birds.py
@@ -10,6 +10,7 @@ from urllib.parse import parse_qs, urlsplit
 from inky_bird_frame.birds import (
     BirdSpecies,
     BirdWeatherSpecies,
+    DateRange,
     EbirdSpecies,
     ObservationWindow,
     date_range_for_window,
@@ -89,6 +90,27 @@ class InaturalistParsingTests(unittest.TestCase):
         params = parse_qs(urlsplit(url).query)
         self.assertEqual(params["rank"], ["species"])
         self.assertEqual(params["per_page"], ["50"])
+
+    @patch("inky_bird_frame.birds.get_json", return_value={"results": []})
+    def test_fetch_species_counts_uses_explicit_inclusive_dates(self, get_json: MagicMock) -> None:
+        fetch_inaturalist_birds(
+            latitude=33.6407,
+            longitude=-84.4277,
+            radius_km=11,
+            limit=500,
+            date_range=DateRange(date(2026, 7, 13), date(2026, 7, 16)),
+        )
+
+        params = parse_qs(urlsplit(get_json.call_args.args[0]).query)
+        self.assertEqual(params["d1"], ["2026-07-13"])
+        self.assertEqual(params["d2"], ["2026-07-16"])
+        self.assertEqual(params["radius"], ["11"])
+
+    def test_date_range_rejects_partial_or_reversed_dates(self) -> None:
+        with self.assertRaisesRegex(ValueError, "both start and end"):
+            DateRange(date(2026, 7, 13), None)
+        with self.assertRaisesRegex(ValueError, "on or before"):
+            DateRange(date(2026, 7, 16), date(2026, 7, 13))
 
     def test_date_range_for_window(self) -> None:
         today = date(2026, 7, 9)

--- a/tests/test_birds.py
+++ b/tests/test_birds.py
@@ -105,6 +105,7 @@ class InaturalistParsingTests(unittest.TestCase):
         self.assertEqual(params["d1"], ["2026-07-13"])
         self.assertEqual(params["d2"], ["2026-07-16"])
         self.assertEqual(params["radius"], ["11"])
+        self.assertEqual(get_json.call_args.kwargs["error_label"], "iNaturalist API")
 
     def test_date_range_rejects_partial_or_reversed_dates(self) -> None:
         with self.assertRaisesRegex(ValueError, "both start and end"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,12 +6,13 @@ import stat
 import unittest
 from argparse import Namespace
 from contextlib import redirect_stdout
+from datetime import date
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from inky_bird_frame.birds import BirdSpecies
+from inky_bird_frame.birds import BirdSpecies, DateRange
 from inky_bird_frame.cli import (
     build_parser,
     catalog_sync_command,
@@ -156,6 +157,58 @@ class CliTests(unittest.TestCase):
         self.assertEqual(args.radius_km, 16)
         self.assertEqual(args.species_limit, 500)
         self.assertTrue(args.dry_run)
+
+    def test_seed_supports_historical_dates_and_coordinates(self) -> None:
+        args = build_parser().parse_args(
+            [
+                "seed",
+                "--config",
+                "instance.toml",
+                "--start-date",
+                "2026-07-13",
+                "--end-date",
+                "2026-07-16",
+                "--source",
+                "inaturalist",
+                "--latitude",
+                "33.6407",
+                "--longitude",
+                "-84.4277",
+                "--radius-km",
+                "11",
+                "--dry-run",
+            ]
+        )
+        with (
+            patch("inky_bird_frame.cli._config", return_value=SimpleNamespace()),
+            patch("inky_bird_frame.cli.enqueue_seed_species", return_value={}) as enqueue,
+            redirect_stdout(io.StringIO()),
+        ):
+            seed_command(args)
+
+        self.assertEqual(
+            enqueue.call_args.kwargs["date_range"],
+            DateRange(start=date(2026, 7, 13), end=date(2026, 7, 16)),
+        )
+        self.assertEqual(enqueue.call_args.kwargs["latitude"], 33.6407)
+        self.assertEqual(enqueue.call_args.kwargs["longitude"], -84.4277)
+        self.assertIsNone(enqueue.call_args.kwargs["window"])
+
+    def test_seed_rejects_incomplete_date_or_coordinate_pairs(self) -> None:
+        common = {
+            "source": ["inaturalist"],
+            "window": None,
+            "start_date": "2026-07-13",
+            "end_date": None,
+            "latitude": 33.6407,
+            "longitude": -84.4277,
+        }
+        with self.assertRaisesRegex(ValueError, "start-date and --end-date"):
+            seed_command(Namespace(**common))
+
+        common.update(end_date="2026-07-16", longitude=None)
+        with self.assertRaisesRegex(ValueError, "latitude and --longitude"):
+            seed_command(Namespace(**common))
 
     def test_species_output_preserves_legacy_source(self) -> None:
         species = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 3, "iNaturalist")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import unittest
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import cast
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from inky_bird_frame.birds import (
     BirdSpecies,
     BirdWeatherSpecies,
+    DateRange,
     EbirdResolution,
     EbirdSpecies,
     ObservationWindow,
@@ -228,6 +229,51 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(result["added_count"], 1)
         self.assertFalse(state_exists)
         self.assertFalse(discover.call_args.kwargs["persist_taxonomy_cache"])
+
+    def test_historical_seed_uses_coordinate_override_without_mutating_config(self) -> None:
+        species = BirdSpecies(2, "Trip Bird", "Avis itineris", 3, "iNaturalist")
+        date_range = DateRange(date(2026, 7, 13), date(2026, 7, 16))
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            with (
+                patch(
+                    "inky_bird_frame.controller.fetch_inaturalist_birds",
+                    return_value=[species],
+                ) as fetch,
+                patch("inky_bird_frame.controller.approved_taxon_ids", return_value=set()),
+            ):
+                result = enqueue_seed_species(
+                    config,
+                    date_range=date_range,
+                    latitude=33.6407,
+                    longitude=-84.4277,
+                    sources=(DiscoveryProvider.INATURALIST,),
+                    radius_km=11,
+                    dry_run=True,
+                )
+
+        self.assertEqual(result["start_date"], "2026-07-13")
+        self.assertEqual(result["end_date"], "2026-07-16")
+        self.assertIsNone(result["window"])
+        self.assertEqual(fetch.call_args.kwargs["latitude"], 33.6407)
+        self.assertEqual(fetch.call_args.kwargs["longitude"], -84.4277)
+        self.assertEqual(fetch.call_args.kwargs["date_range"], date_range)
+        self.assertEqual(config.discovery.zip_code, "12345")
+
+    def test_historical_seed_rejects_provider_without_exact_date_semantics(self) -> None:
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            with self.assertRaisesRegex(ValueError, "require --source inaturalist"):
+                enqueue_seed_species(
+                    config,
+                    date_range=DateRange(date(2026, 7, 13), date(2026, 7, 16)),
+                    sources=(DiscoveryProvider.EBIRD,),
+                    dry_run=True,
+                )
 
     def test_generation_prioritizes_current_species_before_seed_queue(self) -> None:
         current = BirdSpecies(1, "Current Bird", "Avis current", 4, "iNaturalist")


### PR DESCRIPTION
## Summary

- add inclusive ISO date-range seeding through iNaturalist
- add command-scoped coordinate overrides without mutating active discovery configuration
- preserve dry-run and idempotent distinct-species queue behavior
- reject incomplete inputs and providers that cannot honor exact coordinate-radius history
- document and test the workflow

Closes #106

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest` (341 passed, 19 subtests)
- `uv run inky-bird-frame catalog validate --catalog catalog` (75 species)