### PR TITLE
Release version 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.1.2"
+version = "0.2.0"
 description = "Generate and display reusable bird field-journal plates"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/inky_bird_frame/__init__.py
+++ b/src/inky_bird_frame/__init__.py
@@ -1,3 +1,3 @@
 """Local bird field-journal plates for Pimoroni Inky displays."""
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary

- bump the package, runtime, and lockfile version to 0.2.0
- release worldwide discovery coordinates and Geoapify postal lookup from #105
- release exact historical coordinate/date-range seeding from #107
- include the post-0.1.2 reference-boundary, deployment, catalog, and publication reliability work already merged to main

Tracks #99 and #106.

## Validation

- `uv sync --extra dev --locked`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src tests`
- `uv run pytest` (341 passed, 19 subtests passed)
- `uv run inky-bird-frame catalog validate --catalog catalog` (75 species)
- workflow action pinning check
- `actionlint`
- `shellcheck deploy/*.sh`
- package/runtime version consistency check
- `git diff --check`

## Release scope

This PR changes version metadata only. The functional changes were separately reviewed and merged; the worldwide location migration and historical seeding path were also deployed and live-verified before this version bump. Existing configurations remain compatible and no required migration is introduced.