### PR TITLE
Preserve quality guidance across manual retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ candidate:
 
 A failed review becomes corrective input for the next attempt. Attempts are
 bounded by configuration, and exhausted work stops for inspection rather than
-publishing. Once a taxon passes, it is never regenerated implicitly.
+publishing. A deliberate `retry` refreshes the cached research and carries the
+final review findings into the first new attempt. Once a taxon passes, it is
+never regenerated implicitly.
 
 Regular application code handles selection, licensing rules, checksums, image
 dimensions, rotation, publishing, downloads, and display state. Codex handles

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -147,7 +147,9 @@ unchanged. The next scheduled cycle retries from the current remote branch.
 | eligible | No terminal state exists | Yes |
 
 `retry TAXON_ID` archives rejected or failed state and makes that taxon
-eligible. Approved art is never replaced implicitly.
+eligible. For failed quality reviews, it also retains the final findings as
+durable input to the first new generation attempt while refreshing cached
+research. Approved art is never replaced implicitly.
 
 ## Privacy and licensing
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -272,7 +272,11 @@ only; they never enter the approved catalog or rotation.
   pages. The taxon is deferred automatically and later queue items continue.
 - Generated image or text defect: the controller feeds review findings into a
   new attempt automatically. After all configured attempts fail, inspect the
-  retained artifacts and use `retry` for a deliberate new cycle.
+  retained artifacts and use `retry` for a deliberate new cycle. The command
+  refreshes cached references and profile data while preserving the final
+  review findings for the first regenerated plate. Transient source failures
+  retain that guidance until generation reaches a successful or terminal
+  quality result.
 - Controller unavailable: the current e-paper image remains visible. Display
   state is not advanced.
 - Checksum mismatch: the display refuses the asset and preserves current state.

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -31,6 +31,7 @@ from .config import (
     load_config,
 )
 from .controller import (
+    REVIEW_FAILURE_FALLBACK,
     discover_species,
     enqueue_seed_species,
     exclusive_cycle_lock,
@@ -368,10 +369,18 @@ def reject_command(args: argparse.Namespace) -> int:
 def _latest_quality_findings(failed_directories: list[Path]) -> tuple[str, ...]:
     if not failed_directories:
         return ()
-    attempts = sorted(failed_directories[-1].glob("attempt-*"))
+    attempts: list[tuple[int, Path]] = []
+    for attempt_path in failed_directories[-1].glob("attempt-*"):
+        try:
+            attempt_number = int(attempt_path.name.removeprefix("attempt-"))
+        except ValueError as exc:
+            raise SpeciesStateError(f"Invalid generation attempt: {attempt_path}") from exc
+        if attempt_number <= 0 or not attempt_path.is_dir():
+            raise SpeciesStateError(f"Invalid generation attempt: {attempt_path}")
+        attempts.append((attempt_number, attempt_path))
     if not attempts:
         return ()
-    review_path = attempts[-1] / "quality-review.json"
+    review_path = max(attempts, key=lambda item: item[0])[1] / "quality-review.json"
     if not review_path.is_file():
         return ()
     try:
@@ -385,7 +394,7 @@ def _latest_quality_findings(failed_directories: list[Path]) -> tuple[str, ...]:
         not isinstance(finding, str) or not finding.strip() for finding in findings
     ):
         raise SpeciesStateError(f"Invalid quality review findings: {review_path}")
-    return tuple(findings)
+    return tuple(findings) or (REVIEW_FAILURE_FALLBACK,)
 
 
 def retry_command(args: argparse.Namespace) -> int:

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -41,7 +41,7 @@ from .controller import (
 )
 from .display import show_on_inky
 from .display_node import run_display_cycle
-from .errors import InkyBirdFrameError
+from .errors import InkyBirdFrameError, SpeciesStateError
 from .images import prepare_uploaded_image
 from .installation import InstallationRole, doctor, setup
 from .notifications import (
@@ -365,12 +365,39 @@ def reject_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def _latest_quality_findings(failed_directories: list[Path]) -> tuple[str, ...]:
+    if not failed_directories:
+        return ()
+    attempts = sorted(failed_directories[-1].glob("attempt-*"))
+    if not attempts:
+        return ()
+    review_path = attempts[-1] / "quality-review.json"
+    if not review_path.is_file():
+        return ()
+    try:
+        review = json.loads(review_path.read_text())
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise SpeciesStateError(f"Invalid quality review: {review_path}") from exc
+    if not isinstance(review, dict) or review.get("passed") is not False:
+        raise SpeciesStateError(f"Invalid failed quality review: {review_path}")
+    findings = review.get("findings")
+    if not isinstance(findings, list) or any(
+        not isinstance(finding, str) or not finding.strip() for finding in findings
+    ):
+        raise SpeciesStateError(f"Invalid quality review findings: {review_path}")
+    return tuple(findings)
+
+
 def retry_command(args: argparse.Namespace) -> int:
     config = _config(args)
     with exclusive_cycle_lock(config.controller.state_dir):
         if find_taxon_directory(config.controller.state_dir / "pending", args.taxon_id):
             raise ValueError("Pending candidates must be approved or rejected before retrying")
-        sources = list((config.controller.state_dir / "failed").glob(f"{args.taxon_id}-*"))
+        failed_directories = sorted(
+            (config.controller.state_dir / "failed").glob(f"{args.taxon_id}-*")
+        )
+        quality_findings = _latest_quality_findings(failed_directories)
+        sources = list(failed_directories)
         rejected = find_taxon_directory(config.controller.state_dir / "rejected", args.taxon_id)
         if rejected is not None:
             sources.append(rejected)
@@ -400,6 +427,9 @@ def retry_command(args: argparse.Namespace) -> int:
             shutil.move(str(source), destination)
             moved.append(str(destination))
         retry_store.clear(args.taxon_id)
+        guidance = retry_store.quality_guidance(args.taxon_id)
+        if quality_findings:
+            guidance = retry_store.set_quality_guidance(args.taxon_id, quality_findings)
     print_result(
         {
             "taxon_id": args.taxon_id,
@@ -408,6 +438,9 @@ def retry_command(args: argparse.Namespace) -> int:
             "cleared_deferred_retry": deferred,
             "cleared_cached_profile": cleared_cached_profile,
             "cleared_cached_references": cleared_cached_references,
+            "preserved_quality_findings_count": (
+                len(guidance.findings) if guidance is not None else 0
+            ),
         }
     )
     return 0

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -752,7 +752,13 @@ def load_or_create_profile(
     return profile, output_path
 
 
-def generate_candidate(config: AppConfig, species: BirdSpecies, workspace: Path) -> Path:
+def generate_candidate(
+    config: AppConfig,
+    species: BirdSpecies,
+    workspace: Path,
+    *,
+    initial_correction_findings: tuple[str, ...] = (),
+) -> Path:
     state_dir = config.controller.state_dir
     if species.taxon_id in approved_taxon_ids(config.controller.catalog_dir):
         raise CatalogError(f"Taxon {species.taxon_id} is already approved")
@@ -785,7 +791,7 @@ def generate_candidate(config: AppConfig, species: BirdSpecies, workspace: Path)
             profile_output_path,
             logs / "01-profile.log",
         )
-        correction_findings: tuple[str, ...] = ()
+        correction_findings = initial_correction_findings
         history: list[dict[str, object]] = []
         for attempt in range(1, config.controller.max_generation_attempts + 1):
             attempt_dir = work / f"attempt-{attempt:02d}"
@@ -942,7 +948,16 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 continue
             attempted_count += 1
             try:
-                generate_candidate(config, species, config.controller.workspace_dir)
+                guidance = retry_store.quality_guidance(species.taxon_id)
+                if guidance is None:
+                    generate_candidate(config, species, config.controller.workspace_dir)
+                else:
+                    generate_candidate(
+                        config,
+                        species,
+                        config.controller.workspace_dir,
+                        initial_correction_findings=guidance.findings,
+                    )
                 with catalog_state_lock(config.controller.state_dir):
                     entry = approve_candidate(
                         config.controller.state_dir,
@@ -957,6 +972,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                     }
                 )
                 retry_store.clear(species.taxon_id)
+                retry_store.clear_quality_guidance(species.taxon_id)
             except InsufficientReferencesError as exc:
                 retry = retry_store.record_failure(
                     species.taxon_id,
@@ -994,6 +1010,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 )
             except QualityReviewError as exc:
                 retry_store.clear(species.taxon_id)
+                retry_store.clear_quality_guidance(species.taxon_id)
                 failure_path = record_failure(config.controller.state_dir, species, exc)
                 failures.append(
                     {

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -62,6 +62,8 @@ from .research import ResearchBudget
 from .retry import RetryStore
 from .timeutil import parse_utc_timestamp
 
+REVIEW_FAILURE_FALLBACK = "The previous attempt did not meet every automated review threshold."
+
 
 @dataclass(frozen=True)
 class DiscoverySnapshot:
@@ -846,9 +848,7 @@ def generate_candidate(
                     raise CatalogError(f"Pending destination already exists: {destination}")
                 shutil.copytree(attempt_dir, destination)
                 return destination
-            correction_findings = review.findings or (
-                "The previous attempt did not meet every automated review threshold.",
-            )
+            correction_findings = review.findings or (REVIEW_FAILURE_FALLBACK,)
 
         failed = state_dir / "failed" / f"{species.taxon_id}-{_timestamp()}"
         failed.parent.mkdir(parents=True, exist_ok=True)

--- a/src/inky_bird_frame/retry.py
+++ b/src/inky_bird_frame/retry.py
@@ -35,14 +35,23 @@ class RetryRecord:
         }
 
 
+@dataclass(frozen=True)
+class RetryGuidance:
+    taxon_id: int
+    findings: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {"taxon_id": self.taxon_id, "findings": list(self.findings)}
+
+
 class RetryStore:
     def __init__(self, path: Path) -> None:
         self.path = path
-        self._records = self._read()
+        self._records, self._quality_guidance = self._read()
 
-    def _read(self) -> dict[int, RetryRecord]:
+    def _read(self) -> tuple[dict[int, RetryRecord], dict[int, RetryGuidance]]:
         if not self.path.exists():
-            return {}
+            return {}, {}
         try:
             raw = json.loads(self.path.read_text())
         except json.JSONDecodeError as exc:
@@ -58,7 +67,16 @@ class RetryStore:
             if record.taxon_id in parsed:
                 raise CatalogError(f"Duplicate taxon in retry state: {self.path}")
             parsed[record.taxon_id] = record
-        return parsed
+        raw_guidance = raw.get("quality_guidance", [])
+        if not isinstance(raw_guidance, list):
+            raise CatalogError(f"Invalid retry state: {self.path}")
+        guidance: dict[int, RetryGuidance] = {}
+        for item in raw_guidance:
+            entry = _parse_guidance(item, self.path)
+            if entry.taxon_id in guidance:
+                raise CatalogError(f"Duplicate quality guidance in retry state: {self.path}")
+            guidance[entry.taxon_id] = entry
+        return parsed, guidance
 
     def get(self, taxon_id: int) -> RetryRecord | None:
         return self._records.get(taxon_id)
@@ -101,6 +119,22 @@ class RetryStore:
         if self._records.pop(taxon_id, None) is not None:
             self._write()
 
+    def quality_guidance(self, taxon_id: int) -> RetryGuidance | None:
+        return self._quality_guidance.get(taxon_id)
+
+    def set_quality_guidance(self, taxon_id: int, findings: tuple[str, ...]) -> RetryGuidance:
+        guidance = _parse_guidance(
+            {"taxon_id": taxon_id, "findings": list(findings)},
+            self.path,
+        )
+        self._quality_guidance[taxon_id] = guidance
+        self._write()
+        return guidance
+
+    def clear_quality_guidance(self, taxon_id: int) -> None:
+        if self._quality_guidance.pop(taxon_id, None) is not None:
+            self._write()
+
     def deferred(self, taxon_ids: set[int], now: datetime) -> list[RetryRecord]:
         return sorted(
             (
@@ -129,6 +163,12 @@ class RetryStore:
                 "records": [
                     record.as_dict()
                     for record in sorted(self._records.values(), key=lambda item: item.taxon_id)
+                ],
+                "quality_guidance": [
+                    guidance.as_dict()
+                    for guidance in sorted(
+                        self._quality_guidance.values(), key=lambda item: item.taxon_id
+                    )
                 ],
             },
         )
@@ -170,3 +210,20 @@ def _parse_record(raw: object, source: Path) -> RetryRecord:
         last_failed_at=_parse_datetime(raw.get("last_failed_at"), source),
         next_attempt_at=_parse_datetime(raw.get("next_attempt_at"), source),
     )
+
+
+def _parse_guidance(raw: object, source: Path) -> RetryGuidance:
+    if not isinstance(raw, dict):
+        raise CatalogError(f"Invalid retry quality guidance: {source}")
+    taxon_id = raw.get("taxon_id")
+    findings = raw.get("findings")
+    if (
+        not isinstance(taxon_id, int)
+        or isinstance(taxon_id, bool)
+        or taxon_id <= 0
+        or not isinstance(findings, list)
+        or not findings
+        or any(not isinstance(finding, str) or not finding.strip() for finding in findings)
+    ):
+        raise CatalogError(f"Invalid retry quality guidance: {source}")
+    return RetryGuidance(taxon_id=taxon_id, findings=tuple(findings))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,7 @@ from inky_bird_frame.cli import (
     species_to_dict,
 )
 from inky_bird_frame.config import DiscoveryProvider
-from inky_bird_frame.controller import exclusive_cycle_lock
+from inky_bird_frame.controller import REVIEW_FAILURE_FALLBACK, exclusive_cycle_lock
 from inky_bird_frame.errors import (
     ConfigurationError,
     DataSourceError,
@@ -392,7 +392,10 @@ rotation_mode = "shuffle_bag"
             state_dir = Path(temporary)
             failed = state_dir / "failed/42-example-bird"
             failed.mkdir(parents=True)
-            review = failed / "attempt-03/quality-review.json"
+            old_review = failed / "attempt-99/quality-review.json"
+            old_review.parent.mkdir()
+            old_review.write_text(json.dumps({"passed": False, "findings": ["Outdated finding"]}))
+            review = failed / "attempt-100/quality-review.json"
             review.parent.mkdir()
             review.write_text(
                 json.dumps({"passed": False, "findings": ["Correct the ruler scale"]})
@@ -422,6 +425,26 @@ rotation_mode = "shuffle_bag"
         self.assertIsNotNone(guidance)
         if guidance is not None:
             self.assertEqual(guidance.findings, ("Correct the ruler scale",))
+
+    def test_retry_preserves_fallback_for_empty_quality_findings(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            review = state_dir / "failed/42-example-bird/attempt-01/quality-review.json"
+            review.parent.mkdir(parents=True)
+            review.write_text(json.dumps({"passed": False, "findings": []}))
+            config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
+            output = io.StringIO()
+
+            with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
+                retry_command(Namespace(taxon_id=42))
+
+            result = json.loads(output.getvalue())["data"]
+            guidance = RetryStore(state_dir / "generation-retries.json").quality_guidance(42)
+
+        self.assertEqual(result["preserved_quality_findings_count"], 1)
+        self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(guidance.findings, (REVIEW_FAILURE_FALLBACK,))
 
     def test_retry_rejects_malformed_quality_review_before_archiving(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,13 @@ from inky_bird_frame.cli import (
 )
 from inky_bird_frame.config import DiscoveryProvider
 from inky_bird_frame.controller import exclusive_cycle_lock
-from inky_bird_frame.errors import ConfigurationError, DataSourceError, GenerationError
+from inky_bird_frame.errors import (
+    ConfigurationError,
+    DataSourceError,
+    GenerationError,
+    SpeciesStateError,
+)
+from inky_bird_frame.retry import RetryStore
 
 
 class CliTests(unittest.TestCase):
@@ -386,6 +392,11 @@ rotation_mode = "shuffle_bag"
             state_dir = Path(temporary)
             failed = state_dir / "failed/42-example-bird"
             failed.mkdir(parents=True)
+            review = failed / "attempt-03/quality-review.json"
+            review.parent.mkdir()
+            review.write_text(
+                json.dumps({"passed": False, "findings": ["Correct the ruler scale"]})
+            )
             profile = state_dir / "profiles/42/profile.json"
             profile.parent.mkdir(parents=True)
             profile.write_text("{}")
@@ -399,6 +410,7 @@ rotation_mode = "shuffle_bag"
                 retry_command(Namespace(taxon_id=42))
 
             result = json.loads(output.getvalue())["data"]
+            guidance = RetryStore(state_dir / "generation-retries.json").quality_guidance(42)
             profile_exists = profile.exists() or references.exists()
             archived_profile_exists = (state_dir / "archive/42/profile.json").exists()
 
@@ -406,6 +418,28 @@ rotation_mode = "shuffle_bag"
         self.assertTrue(result["cleared_cached_references"])
         self.assertFalse(profile_exists)
         self.assertTrue(archived_profile_exists)
+        self.assertEqual(result["preserved_quality_findings_count"], 1)
+        self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(guidance.findings, ("Correct the ruler scale",))
+
+    def test_retry_rejects_malformed_quality_review_before_archiving(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-example-bird"
+            review = failed / "attempt-03/quality-review.json"
+            review.parent.mkdir(parents=True)
+            review.write_text("not json")
+            config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(SpeciesStateError, "Invalid quality review"),
+            ):
+                retry_command(Namespace(taxon_id=42))
+
+            self.assertTrue(failed.is_dir())
+            self.assertFalse((state_dir / "archive").exists())
 
     def test_retry_is_excluded_by_running_generation_cycle(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -429,13 +429,15 @@ class ControllerTests(unittest.TestCase):
                     }
                 )
             )
-            RetryStore(config.controller.state_dir / "generation-retries.json").record_failure(
+            retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
+            retry_store.record_failure(
                 retrying.taxon_id,
                 DataSourceError("temporary"),
                 now=datetime.now(UTC) - timedelta(minutes=31),
                 initial_minutes=30,
                 maximum_minutes=60,
             )
+            retry_store.set_quality_guidance(first.taxon_id, ("Keep the wing angle accurate",))
             with (
                 patch("inky_bird_frame.controller.approved_taxon_ids", return_value=set()),
                 patch("inky_bird_frame.controller.generate_candidate"),
@@ -443,10 +445,14 @@ class ControllerTests(unittest.TestCase):
                 patch("inky_bird_frame.controller._write_active_catalog", return_value=0),
             ):
                 result = run_generation_cycle(config)
+            first_guidance = RetryStore(
+                config.controller.state_dir / "generation-retries.json"
+            ).quality_guidance(first.taxon_id)
 
         self.assertEqual(result["attempted_count"], 1)
         self.assertEqual(result["deferred_count"], 0)
         self.assertEqual(result["outstanding_retry_count"], 1)
+        self.assertIsNone(first_guidance)
 
     def test_overlapping_refresh_is_rejected_before_discovery(self) -> None:
         with TemporaryDirectory() as temporary:
@@ -747,6 +753,10 @@ class ControllerTests(unittest.TestCase):
             config_path = Path(temporary) / "config.toml"
             config_path.write_text(CONFIG)
             config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            RetryStore(
+                config.controller.state_dir / "generation-retries.json"
+            ).set_quality_guidance(species.taxon_id, ("Keep the bill proportion accurate",))
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",
@@ -757,6 +767,9 @@ class ControllerTests(unittest.TestCase):
                 generate.side_effect = InsufficientReferencesError("only 1 of 4 references")
                 result = run_controller_cycle(config)
             terminal_failures = list((config.controller.state_dir / "failed").glob("9083-*"))
+            guidance = RetryStore(
+                config.controller.state_dir / "generation-retries.json"
+            ).quality_guidance(species.taxon_id)
 
         self.assertEqual(terminal_failures, [])
         failures = result["failures"]
@@ -765,6 +778,11 @@ class ControllerTests(unittest.TestCase):
             self.assertFalse(failures[0]["terminal"])
             self.assertIn("retry_at", failures[0])
         self.assertEqual(result["deferred_count"], 1)
+        self.assertIsNotNone(guidance)
+        self.assertEqual(
+            generate.call_args.kwargs["initial_correction_findings"],
+            ("Keep the bill proportion accurate",),
+        )
 
     def test_failed_review_is_corrected_and_passing_attempt_is_staged(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
@@ -834,13 +852,21 @@ class ControllerTests(unittest.TestCase):
                 patch("inky_bird_frame.controller.CodexRunner", FakeRunner),
                 patch("inky_bird_frame.controller.prepare_generated_plate", side_effect=prepare),
             ):
-                candidate = generate_candidate(config, species, config.controller.workspace_dir)
+                candidate = generate_candidate(
+                    config,
+                    species,
+                    config.controller.workspace_dir,
+                    initial_correction_findings=("Preserve the previous scale correction",),
+                )
             manifest = json.loads((candidate / "manifest.json").read_text())
             private_histories = list(
                 (config.controller.state_dir / "runs").glob("*/attempt-history.json")
             )
 
-        self.assertEqual(FakeRunner.corrections, [(), ("Crest is too short",)])
+        self.assertEqual(
+            FakeRunner.corrections,
+            [("Preserve the previous scale correction",), ("Crest is too short",)],
+        )
         self.assertEqual(len(FakeRunner.generated_paths), 2)
         self.assertEqual(len(FakeRunner.review_paths), 2)
         self.assertEqual(manifest["generation"]["attempt"], 2)
@@ -855,6 +881,10 @@ class ControllerTests(unittest.TestCase):
             config_path = Path(temporary) / "config.toml"
             config_path.write_text(CONFIG)
             config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            RetryStore(
+                config.controller.state_dir / "generation-retries.json"
+            ).set_quality_guidance(species.taxon_id, ("Correct the ruler scale",))
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",
@@ -866,6 +896,9 @@ class ControllerTests(unittest.TestCase):
                 result = run_controller_cycle(config)
 
             failures = list((config.controller.state_dir / "failed").glob("9083-*"))
+            guidance = RetryStore(
+                config.controller.state_dir / "generation-retries.json"
+            ).quality_guidance(species.taxon_id)
 
         self.assertEqual(failures, [])
         self.assertEqual(result["eligible_count"], 1)
@@ -876,6 +909,11 @@ class ControllerTests(unittest.TestCase):
         if isinstance(first_failure, dict):
             self.assertEqual(first_failure["error"], "profile failed")
             self.assertFalse(first_failure["terminal"])
+        self.assertIsNotNone(guidance)
+        self.assertEqual(
+            generate.call_args.kwargs["initial_correction_findings"],
+            ("Correct the ruler scale",),
+        )
 
     def test_catalog_wide_error_still_aborts_the_cycle(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
@@ -1102,6 +1140,10 @@ class ControllerTests(unittest.TestCase):
             config_path = Path(temporary) / "config.toml"
             config_path.write_text(CONFIG)
             config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            RetryStore(
+                config.controller.state_dir / "generation-retries.json"
+            ).set_quality_guidance(species.taxon_id, ("Correct the ruler scale",))
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",
@@ -1113,12 +1155,20 @@ class ControllerTests(unittest.TestCase):
                 result = run_controller_cycle(config)
 
             failures = list((config.controller.state_dir / "failed").glob("9083-*"))
+            guidance = RetryStore(
+                config.controller.state_dir / "generation-retries.json"
+            ).quality_guidance(species.taxon_id)
 
         self.assertEqual(len(failures), 1)
         failure_results = result["failures"]
         self.assertIsInstance(failure_results, list)
         if isinstance(failure_results, list):
             self.assertTrue(failure_results[0]["terminal"])
+        self.assertIsNone(guidance)
+        self.assertEqual(
+            generate.call_args.kwargs["initial_correction_findings"],
+            ("Correct the ruler scale",),
+        )
 
 
 class DiscoveryProviderTests(unittest.TestCase):

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -5,7 +5,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from inky_bird_frame.retry import RetryStore
+from inky_bird_frame.errors import CatalogError
+from inky_bird_frame.retry import RetryGuidance, RetryStore
 
 
 class RetryStoreTests(unittest.TestCase):
@@ -50,6 +51,44 @@ class RetryStoreTests(unittest.TestCase):
 
         self.assertEqual(record.next_attempt_at, now + timedelta(days=7))
         self.assertIsNone(store.get(42))
+
+    def test_quality_guidance_is_durable_and_independent_from_backoff(self) -> None:
+        now = datetime(2026, 7, 10, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "retries.json"
+            store = RetryStore(path)
+            store.record_failure(
+                42,
+                RuntimeError("temporary"),
+                now=now,
+                initial_minutes=30,
+                maximum_minutes=60,
+            )
+            guidance = store.set_quality_guidance(42, ("Correct the scale",))
+            store.clear(42)
+            reloaded = RetryStore(path)
+
+            self.assertEqual(
+                guidance,
+                RetryGuidance(taxon_id=42, findings=("Correct the scale",)),
+            )
+            self.assertIsNone(reloaded.get(42))
+            self.assertEqual(reloaded.quality_guidance(42), guidance)
+
+            reloaded.clear_quality_guidance(42)
+
+            self.assertIsNone(RetryStore(path).quality_guidance(42))
+
+    def test_invalid_quality_guidance_is_rejected(self) -> None:
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "retries.json"
+            path.write_text(
+                '{"schema_version":1,"records":[],"quality_guidance":'
+                '[{"taxon_id":42,"findings":[]}]}'
+            )
+
+            with self.assertRaisesRegex(CatalogError, "Invalid retry quality guidance"):
+                RetryStore(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #113.

Summary:
- persist final failed quality-review findings in the existing retry store
- feed preserved findings into the first attempt of a deliberate retry
- retain guidance through transient source failures and consume it after success or terminal review
- fail closed on malformed retained review artifacts and report the preserved finding count
- document the retry behavior

Validation:
- uv sync --extra dev --locked
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy
- uv run pytest (344 passed, 19 subtests passed)
- uv run inky-bird-frame catalog validate --catalog catalog (80 species)