### PR TITLE
Stop post-merge review gate timeouts

### DIFF
--- a/.github/scripts/review_gate.py
+++ b/.github/scripts/review_gate.py
@@ -23,7 +23,9 @@ Gating model (hybrid; see PR #71 discussion):
 Engagement (polling): after the repository owner requests Codex review and
 names the exact head SHA, the script waits up to POLL_BUDGET_SECONDS for Codex
 to engage via review, clean comment, or reaction. Contributor activity and
-automatic review alone cannot satisfy the gate.
+automatic review alone cannot satisfy the gate. If the PR is already merged,
+the gate exits successfully because it can no longer protect the merge and a
+post-merge timeout would only report a false failure.
 
 Run locally for debugging:
     GH_TOKEN=$(gh auth token) \\
@@ -84,6 +86,7 @@ GRAPHQL_QUERY: Final = """
 query($owner: String!, $repo: String!, $pr: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $pr) {
+      state
       headRefOid
       commits(last: 1) {
         nodes {
@@ -784,6 +787,9 @@ def main() -> int:
         return 2
 
     state = fetch_pr_state(repo, pr)
+    if state.get("state") == "MERGED":
+        print(f"PR #{pr} is already merged; review gate is no longer applicable.", flush=True)
+        return 0
     owner_login = repo.split("/", 1)[0]
     head_sha = state.get("headRefOid")
     if not isinstance(head_sha, str):
@@ -842,6 +848,12 @@ def main() -> int:
             # engagement can't be confirmed, the timeout fails closed.
             print("PR state fetch failed; retrying next interval.", flush=True)
             continue
+        if state.get("state") == "MERGED":
+            print(
+                f"PR #{pr} merged while waiting; review gate is no longer applicable.",
+                flush=True,
+            )
+            return 0
         # A new push supersedes this run: the workflow fires a fresh run for
         # the new head (concurrency no longer cancels, so this early exit is
         # what bounds CI minutes). Exiting 0 is safe — required checks are

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -29,7 +29,8 @@ on:
 # One run per head SHA, never cancelled: a cancelled conclusion on the
 # current head blocks required-status evaluation (the auto-merge stall this
 # group previously caused). Runs for superseded heads exit early on their
-  # own. review_gate.py returns success as soon as it sees the PR head move,
+# own. review_gate.py returns success as soon as it sees the PR head move or
+# the PR merge, because a post-merge timeout cannot protect the completed merge,
 # so CI minutes stay bounded without cancel-in-progress.
 concurrency:
   group: review-gate-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}

--- a/tests/test_review_gate_script.py
+++ b/tests/test_review_gate_script.py
@@ -70,6 +70,7 @@ def _load_review_gate() -> ReviewGateModule:
 
 def _state_with_commit(*, pushed: str | None, committed: str) -> dict[str, object]:
     return {
+        "state": "OPEN",
         "commits": {
             "nodes": [
                 {
@@ -916,6 +917,45 @@ def test_engagement_poll_refreshes_head_time_from_updated_pr_state(
     monkeypatch.setattr(review_gate, "POLL_BUDGET_SECONDS", 1)
     times = iter([0.0, 0.0])
     monkeypatch.setattr("review_gate_under_test.time.monotonic", lambda: next(times))
+    monkeypatch.setattr("review_gate_under_test.time.sleep", lambda _seconds: None)
+
+    assert review_gate.main() == 0
+
+
+def test_gate_exits_when_pr_is_already_merged(monkeypatch: pytest.MonkeyPatch) -> None:
+    review_gate = _load_review_gate()
+    state = _state_with_commit(
+        pushed="2026-06-15T11:59:00Z",
+        committed="2026-06-01T12:00:00Z",
+    )
+    state["state"] = "MERGED"
+
+    monkeypatch.setattr(review_gate, "fetch_pr_state", lambda _repo, _pr: state)
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("PR_NUMBER", "123")
+
+    assert review_gate.main() == 0
+
+
+def test_gate_exits_when_pr_merges_during_polling(monkeypatch: pytest.MonkeyPatch) -> None:
+    review_gate = _load_review_gate()
+    initial = _state_with_commit(
+        pushed="2026-06-15T11:59:00Z",
+        committed="2026-06-01T12:00:00Z",
+    )
+    merged = _state_with_commit(
+        pushed="2026-06-15T11:59:00Z",
+        committed="2026-06-01T12:00:00Z",
+    )
+    merged["state"] = "MERGED"
+    states = iter((initial, merged))
+
+    monkeypatch.setattr(review_gate, "fetch_pr_state", lambda _repo, _pr: next(states))
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("PR_NUMBER", "123")
+    monkeypatch.setattr(review_gate, "POLL_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(review_gate, "POLL_BUDGET_SECONDS", 1)
+    monkeypatch.setattr("review_gate_under_test.time.monotonic", lambda: 0.0)
     monkeypatch.setattr("review_gate_under_test.time.sleep", lambda _seconds: None)
 
     assert review_gate.main() == 0


### PR DESCRIPTION
Closes #125.

Summary:
- include pull-request state in the review-gate snapshot
- exit successfully when the PR is already merged or merges during polling
- preserve exact-head fail-closed behavior for every open PR
- document the post-merge short-circuit and add regression coverage

Root cause:
The owner catalog publisher intentionally admin-merges catalog-only PRs immediately. Their review-gate jobs kept polling for an exact-head Codex request after the merge was complete, then reported a false failure after 30 minutes.

Validation:
- uv sync --extra dev --locked
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy
- uv run pytest (347 passed, 19 subtests passed)
- uv run inky-bird-frame catalog validate --catalog catalog (89 species)
- workflow action pinning
- actionlint
- shellcheck deploy/*.sh
- git diff --check