### PR TITLE
Release version 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.2.0"
+version = "0.2.1"
 description = "Generate and display reusable bird field-journal plates"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/inky_bird_frame/__init__.py
+++ b/src/inky_bird_frame/__init__.py
@@ -1,3 +1,3 @@
 """Local bird field-journal plates for Pimoroni Inky displays."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary

- bump the package, runtime, and lockfile version to 0.2.1
- release manual-retry quality guidance preservation from #115
- release the post-merge review-gate timeout fix from #126
- include the 14 catalog species published since v0.2.0, growing the reusable catalog from 75 to 89 species

## Validation

- `uv sync --extra dev --locked`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src tests`
- `uv run pytest` (347 passed, 19 subtests passed)
- `uv run inky-bird-frame catalog validate --catalog catalog` (89 species)
- workflow action pinning check
- `actionlint`
- `shellcheck deploy/*.sh`
- package/runtime version consistency check
- `git diff --check`

## Release scope

This PR changes version metadata only. The functional changes were separately reviewed and merged. Existing configurations remain compatible and no required migration is introduced.