### PR TITLE
Preserve plates during quality correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,15 @@ candidate:
    neutrality; and
 4. returns structured scores and concrete findings.
 
-A failed review becomes corrective input for the next attempt. Attempts are
-bounded by configuration, and exhausted work stops for inspection rather than
-publishing. A deliberate `retry` refreshes the cached research and carries the
-final review findings into the first new attempt. Once a taxon passes, it is
-never regenerated implicitly.
+A failed review returns separate actionable corrections for the next attempt,
+which uses them to edit the failed plate while preserving its successful
+composition and content. Attempts are bounded by configuration, and exhausted
+work stops for
+inspection rather than publishing. A deliberate `retry` refreshes cached
+research and carries the final corrections into the next cycle. Maintainers can
+select a strong retained plate with `retry TAXON_ID --source-attempt N`; the
+source is archived, checksum-tracked, and edited rather than regenerated from
+scratch. Once a taxon passes, it is never regenerated implicitly.
 
 Regular application code handles selection, licensing rules, checksums, image
 dimensions, rotation, publishing, downloads, and display state. Codex handles

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,11 +39,15 @@ then:
 4. generates a plate through the built-in `$imagegen` skill;
 5. prepares portrait and display assets;
 6. runs an independent, sourced Codex factual and visual review;
-7. regenerates failed reviews with corrective findings, within a configured
+7. edits failed plates with actionable corrective findings, within a configured
    attempt limit;
 8. atomically publishes passing output through the pending queue; and
 9. immediately rebuilds the private active catalog from the latest observation
    snapshot.
+
+Plate rulers are vertical schematic body-length keys: they show the sourced
+range and units, are labeled as not to scale, remain separate from the specimen,
+and never claim that display pixels reproduce physical size.
 
 Transient per-taxon failures are written to a durable retry schedule with capped
 exponential backoff. Deferred taxa are skipped without consuming the successful
@@ -147,9 +151,12 @@ unchanged. The next scheduled cycle retries from the current remote branch.
 | eligible | No terminal state exists | Yes |
 
 `retry TAXON_ID` archives rejected or failed state and makes that taxon
-eligible. For failed quality reviews, it also retains the final findings as
-durable input to the first new generation attempt while refreshing cached
-research. Approved art is never replaced implicitly.
+eligible. For failed quality reviews, it retains the final actionable
+corrections as durable input to the first new generation attempt while
+refreshing cached research. `retry TAXON_ID --source-attempt N` additionally
+selects a retained portrait as the edit base. The archive-relative source path
+stays in private retry state, and the passing manifest records its SHA-256 for
+provenance. Approved art is never replaced implicitly.
 
 ## Privacy and licensing
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -271,12 +271,15 @@ only; they never enter the approved catalog or rotation.
 - Unsuitable licensed references: inspect the reference manifest and source
   pages. The taxon is deferred automatically and later queue items continue.
 - Generated image or text defect: the controller feeds review findings into a
-  new attempt automatically. After all configured attempts fail, inspect the
-  retained artifacts and use `retry` for a deliberate new cycle. The command
-  refreshes cached references and profile data while preserving the final
-  review findings for the first regenerated plate. Transient source failures
-  retain that guidance until generation reaches a successful or terminal
-  quality result.
+  targeted edit of the previous attempt automatically. The reviewer keeps its
+  complete findings for audit but returns only concrete required changes as
+  correction input. After all configured attempts fail, inspect the retained
+  artifacts and use `retry TAXON_ID --source-attempt N` when a specific attempt
+  is a strong edit base. The command archives that portrait, refreshes cached
+  references and profile data, and preserves the selected attempt's corrections
+  for the first edit. Omit `--source-attempt` when no retained image should be
+  reused. Transient source failures retain the guidance and edit source until
+  generation reaches a successful or terminal quality result.
 - Controller unavailable: the current e-paper image remains visible. Display
   state is not advanced.
 - Checksum mismatch: the display refuses the asset and preserves current state.

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -232,6 +232,7 @@ def approved_taxon_ids(catalog_dir: Path) -> set[int]:
 def has_passing_sourced_review(review: object) -> bool:
     if not isinstance(review, dict):
         return False
+    correction_findings = review.get("correction_findings", [])
     score_fields = (
         "species_accuracy",
         "anatomy_accuracy",
@@ -241,6 +242,8 @@ def has_passing_sourced_review(review: object) -> bool:
     if (
         review.get("passed") is not True
         or review.get("location_free") is not True
+        or not isinstance(correction_findings, list)
+        or bool(correction_findings)
         or any(
             not isinstance(review.get(field), int)
             or isinstance(review.get(field), bool)

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -113,11 +113,21 @@ def write_candidate_manifest(
     prompt_version: str,
     attempt: int = 1,
     max_attempts: int = 1,
+    correction_source_sha256: str | None = None,
 ) -> Path:
     portrait_path = destination / "portrait.png"
     display_path = destination / "display.png"
     if not portrait_path.is_file() or not display_path.is_file():
         raise CatalogError("Candidate must contain portrait.png and display.png")
+    generation: dict[str, object] = {
+        "generator": generator,
+        "prompt_version": prompt_version,
+        "generated_at": utc_now(),
+        "attempt": attempt,
+        "max_attempts": max_attempts,
+    }
+    if correction_source_sha256 is not None:
+        generation["correction_source_sha256"] = correction_source_sha256
     manifest = {
         "schema_version": SCHEMA_VERSION,
         "status": "pending",
@@ -127,13 +137,7 @@ def write_candidate_manifest(
         "slug": slugify(species.common_name),
         "profile": profile,
         "references": [reference.as_dict() for reference in references],
-        "generation": {
-            "generator": generator,
-            "prompt_version": prompt_version,
-            "generated_at": utc_now(),
-            "attempt": attempt,
-            "max_attempts": max_attempts,
-        },
+        "generation": generation,
         "quality_review": review.as_dict(),
         "assets": {
             "portrait": {"filename": "portrait.png", "sha256": sha256_file(portrait_path)},
@@ -265,12 +269,21 @@ def is_bounded_generation(generation: object) -> bool:
         return False
     attempt = generation.get("attempt")
     max_attempts = generation.get("max_attempts")
+    correction_source_sha256 = generation.get("correction_source_sha256")
     return (
         isinstance(attempt, int)
         and not isinstance(attempt, bool)
         and isinstance(max_attempts, int)
         and not isinstance(max_attempts, bool)
         and 1 <= attempt <= max_attempts
+        and (
+            correction_source_sha256 is None
+            or (
+                isinstance(correction_source_sha256, str)
+                and len(correction_source_sha256) == 64
+                and all(character in "0123456789abcdef" for character in correction_source_sha256)
+            )
+        )
     )
 
 

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -366,9 +366,14 @@ def reject_command(args: argparse.Namespace) -> int:
     return 0
 
 
-def _latest_quality_findings(failed_directories: list[Path]) -> tuple[str, ...]:
+def _retry_quality_guidance(
+    failed_directories: list[Path],
+    source_attempt: int | None,
+) -> tuple[tuple[str, ...], Path | None]:
     if not failed_directories:
-        return ()
+        if source_attempt is not None:
+            raise ValueError("--source-attempt requires retained failed generation attempts")
+        return (), None
     attempts: list[tuple[int, Path]] = []
     for attempt_path in failed_directories[-1].glob("attempt-*"):
         try:
@@ -379,22 +384,44 @@ def _latest_quality_findings(failed_directories: list[Path]) -> tuple[str, ...]:
             raise SpeciesStateError(f"Invalid generation attempt: {attempt_path}")
         attempts.append((attempt_number, attempt_path))
     if not attempts:
-        return ()
-    review_path = max(attempts, key=lambda item: item[0])[1] / "quality-review.json"
+        if source_attempt is not None:
+            raise ValueError("--source-attempt requires retained failed generation attempts")
+        return (), None
+    attempts_by_number = dict(attempts)
+    if source_attempt is None:
+        selected_attempt, attempt_path = max(attempts, key=lambda item: item[0])
+    else:
+        if source_attempt <= 0 or source_attempt not in attempts_by_number:
+            available = ", ".join(str(number) for number in sorted(attempts_by_number))
+            raise ValueError(
+                f"Generation attempt {source_attempt} is unavailable; choose one of: {available}"
+            )
+        selected_attempt = source_attempt
+        attempt_path = attempts_by_number[source_attempt]
+    review_path = attempt_path / "quality-review.json"
     if not review_path.is_file():
-        return ()
+        raise SpeciesStateError(
+            f"Generation attempt {selected_attempt} has no quality review: {attempt_path}"
+        )
     try:
         review = json.loads(review_path.read_text())
     except (json.JSONDecodeError, UnicodeDecodeError) as exc:
         raise SpeciesStateError(f"Invalid quality review: {review_path}") from exc
     if not isinstance(review, dict) or review.get("passed") is not False:
         raise SpeciesStateError(f"Invalid failed quality review: {review_path}")
-    findings = review.get("findings")
+    findings = review.get("correction_findings", review.get("findings"))
     if not isinstance(findings, list) or any(
         not isinstance(finding, str) or not finding.strip() for finding in findings
     ):
         raise SpeciesStateError(f"Invalid quality review findings: {review_path}")
-    return tuple(findings) or (REVIEW_FAILURE_FALLBACK,)
+    source_plate = None
+    if source_attempt is not None:
+        source_plate = attempt_path / "portrait.png"
+        if not source_plate.is_file():
+            raise SpeciesStateError(
+                f"Generation attempt {selected_attempt} has no portrait: {attempt_path}"
+            )
+    return tuple(findings) or (REVIEW_FAILURE_FALLBACK,), source_plate
 
 
 def retry_command(args: argparse.Namespace) -> int:
@@ -405,7 +432,11 @@ def retry_command(args: argparse.Namespace) -> int:
         failed_directories = sorted(
             (config.controller.state_dir / "failed").glob(f"{args.taxon_id}-*")
         )
-        quality_findings = _latest_quality_findings(failed_directories)
+        source_attempt = getattr(args, "source_attempt", None)
+        quality_findings, correction_source = _retry_quality_guidance(
+            failed_directories,
+            source_attempt,
+        )
         sources = list(failed_directories)
         rejected = find_taxon_directory(config.controller.state_dir / "rejected", args.taxon_id)
         if rejected is not None:
@@ -424,21 +455,42 @@ def retry_command(args: argparse.Namespace) -> int:
         cleared_cached_references = reference_cache.exists()
         if cleared_cached_references:
             sources.append(reference_cache)
+        correction_owner = (
+            next(
+                (source for source in sources if correction_source.is_relative_to(source)),
+                None,
+            )
+            if correction_source is not None
+            else None
+        )
+        if correction_source is not None and correction_owner is None:
+            raise SpeciesStateError("The selected correction source is outside retained state")
         archive = config.controller.state_dir / "archive"
         archive.mkdir(parents=True, exist_ok=True)
         moved: list[str] = []
+        archived_correction_source: Path | None = None
         for source in sources:
             destination = archive / source.name
             counter = 1
             while destination.exists():
                 destination = archive / f"{source.name}-{counter}"
                 counter += 1
+            if source == correction_owner and correction_source is not None:
+                archived_correction_source = destination / correction_source.relative_to(source)
             shutil.move(str(source), destination)
             moved.append(str(destination))
         retry_store.clear(args.taxon_id)
         guidance = retry_store.quality_guidance(args.taxon_id)
         if quality_findings:
-            guidance = retry_store.set_quality_guidance(args.taxon_id, quality_findings)
+            guidance = retry_store.set_quality_guidance(
+                args.taxon_id,
+                quality_findings,
+                source_plate=(
+                    archived_correction_source.relative_to(config.controller.state_dir).as_posix()
+                    if archived_correction_source is not None
+                    else None
+                ),
+            )
     print_result(
         {
             "taxon_id": args.taxon_id,
@@ -450,6 +502,8 @@ def retry_command(args: argparse.Namespace) -> int:
             "preserved_quality_findings_count": (
                 len(guidance.findings) if guidance is not None else 0
             ),
+            "source_attempt": source_attempt,
+            "preserved_correction_source": archived_correction_source is not None,
         }
     )
     return 0
@@ -882,6 +936,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_config_argument(retry_parser)
     retry_parser.add_argument("taxon_id", type=int)
+    retry_parser.add_argument(
+        "--source-attempt",
+        type=int,
+        help="Edit a selected retained attempt instead of generating the first retry from scratch",
+    )
     retry_parser.set_defaults(func=retry_command)
 
     status_parser = subparsers.add_parser("status", help="List approved and pending plates")

--- a/src/inky_bird_frame/codex_runner.py
+++ b/src/inky_bird_frame/codex_runner.py
@@ -365,21 +365,6 @@ def _parse_review(raw: object, allowed_domains: tuple[str, ...] | None = None) -
     correction_findings = tuple(
         _string_list(raw.get("correction_findings"), "correction_findings", 0)
     )
-    requires_correction = not (
-        reported_pass
-        and location_free
-        and min(
-            species_accuracy,
-            anatomy_accuracy,
-            text_accuracy,
-            composition_quality,
-        )
-        >= 4
-    )
-    if requires_correction and not correction_findings:
-        raise GenerationError("Failed Codex reviews must include correction_findings")
-    if not requires_correction and correction_findings:
-        raise GenerationError("Passing Codex reviews must not include correction_findings")
     sources = raw.get("verification_sources")
     if not isinstance(sources, list):
         raise GenerationError("Codex review verification_sources must be a list")
@@ -406,11 +391,15 @@ def _parse_review(raw: object, allowed_domains: tuple[str, ...] | None = None) -
                 url=url,
             )
         )
-    passed = (
+    if len(verification_sources) < 2:
+        raise GenerationError("Codex review must cite at least two verification sources")
+    if len(source_hosts) < 2:
+        raise GenerationError(
+            "Codex review must cite at least two independent verification source domains"
+        )
+    requires_correction = not (
         reported_pass
         and location_free
-        and len(verification_sources) >= 2
-        and len(source_hosts) >= 2
         and min(
             species_accuracy,
             anatomy_accuracy,
@@ -419,8 +408,12 @@ def _parse_review(raw: object, allowed_domains: tuple[str, ...] | None = None) -
         )
         >= 4
     )
+    if requires_correction and not correction_findings:
+        raise GenerationError("Failed Codex reviews must include correction_findings")
+    if not requires_correction and correction_findings:
+        raise GenerationError("Passing Codex reviews must not include correction_findings")
     return QualityReview(
-        passed=passed,
+        passed=not requires_correction,
         species_accuracy=species_accuracy,
         anatomy_accuracy=anatomy_accuracy,
         text_accuracy=text_accuracy,

--- a/src/inky_bird_frame/codex_runner.py
+++ b/src/inky_bird_frame/codex_runner.py
@@ -70,6 +70,7 @@ REVIEW_SCHEMA: Final[dict[str, object]] = {
         "composition_quality": {"type": "integer", "minimum": 1, "maximum": 5},
         "location_free": {"type": "boolean"},
         "findings": {"type": "array", "items": {"type": "string"}},
+        "correction_findings": {"type": "array", "items": {"type": "string"}},
         "verification_sources": {
             "type": "array",
             "items": {
@@ -88,6 +89,7 @@ REVIEW_SCHEMA: Final[dict[str, object]] = {
         "composition_quality",
         "location_free",
         "findings",
+        "correction_findings",
         "verification_sources",
     ],
     "additionalProperties": False,
@@ -206,15 +208,26 @@ class CodexRunner:
         output_path: Path,
         log_path: Path,
         correction_findings: tuple[str, ...] = (),
+        *,
+        correction_source_path: Path | None = None,
     ) -> Path:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         command = self._base_command(writable=True)
+        if correction_source_path is not None:
+            command.extend(["--image", str(correction_source_path.resolve())])
         for image in reference_paths:
             command.extend(["--image", str(image.resolve())])
         command.extend(["-"])
         self._run(
             command,
-            plate_prompt(species, profile, references, output_path, correction_findings),
+            plate_prompt(
+                species,
+                profile,
+                references,
+                output_path,
+                correction_findings,
+                has_correction_source=correction_source_path is not None,
+            ),
             log_path,
         )
         if not output_path.is_file() or output_path.stat().st_size == 0:
@@ -349,6 +362,24 @@ def _parse_review(raw: object, allowed_domains: tuple[str, ...] | None = None) -
     text_accuracy = _score(raw, "text_accuracy")
     composition_quality = _score(raw, "composition_quality")
     findings = tuple(_string_list(raw.get("findings"), "findings", 0))
+    correction_findings = tuple(
+        _string_list(raw.get("correction_findings"), "correction_findings", 0)
+    )
+    requires_correction = not (
+        reported_pass
+        and location_free
+        and min(
+            species_accuracy,
+            anatomy_accuracy,
+            text_accuracy,
+            composition_quality,
+        )
+        >= 4
+    )
+    if requires_correction and not correction_findings:
+        raise GenerationError("Failed Codex reviews must include correction_findings")
+    if not requires_correction and correction_findings:
+        raise GenerationError("Passing Codex reviews must not include correction_findings")
     sources = raw.get("verification_sources")
     if not isinstance(sources, list):
         raise GenerationError("Codex review verification_sources must be a list")
@@ -397,4 +428,5 @@ def _parse_review(raw: object, allowed_domains: tuple[str, ...] | None = None) -
         location_free=location_free,
         findings=findings,
         verification_sources=tuple(verification_sources),
+        correction_findings=correction_findings,
     )

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -37,6 +37,7 @@ from .catalog import (
     has_passing_sourced_review,
     is_bounded_generation,
     rebuild_catalog_index,
+    sha256_file,
     utc_now,
     write_candidate_manifest,
 )
@@ -760,6 +761,7 @@ def generate_candidate(
     workspace: Path,
     *,
     initial_correction_findings: tuple[str, ...] = (),
+    initial_correction_source: Path | None = None,
 ) -> Path:
     state_dir = config.controller.state_dir
     if species.taxon_id in approved_taxon_ids(config.controller.catalog_dir):
@@ -794,6 +796,7 @@ def generate_candidate(
             logs / "01-profile.log",
         )
         correction_findings = initial_correction_findings
+        correction_source = initial_correction_source
         history: list[dict[str, object]] = []
         for attempt in range(1, config.controller.max_generation_attempts + 1):
             attempt_dir = work / f"attempt-{attempt:02d}"
@@ -805,6 +808,9 @@ def generate_candidate(
                 dir=generation_parent,
             ) as generation_temporary:
                 generated_path = Path(generation_temporary) / "generated.png"
+                correction_source_sha256 = (
+                    sha256_file(correction_source) if correction_source is not None else None
+                )
                 runner.generate_plate(
                     species,
                     profile,
@@ -813,6 +819,7 @@ def generate_candidate(
                     generated_path,
                     logs / f"02-generation-attempt-{attempt:02d}.log",
                     correction_findings,
+                    correction_source_path=correction_source,
                 )
                 prepare_generated_plate(generated_path, portrait_path, display_path)
 
@@ -827,7 +834,13 @@ def generate_candidate(
                 allowed_domains=config.research.allowed_domains,
             )
             write_json_atomic(attempt_dir / "quality-review.json", review.as_dict())
-            history.append({"attempt": attempt, "quality_review": review.as_dict()})
+            history_entry: dict[str, object] = {
+                "attempt": attempt,
+                "quality_review": review.as_dict(),
+            }
+            if correction_source_sha256 is not None:
+                history_entry["correction_source_sha256"] = correction_source_sha256
+            history.append(history_entry)
             if review.passed:
                 shutil.copy2(profile_path, attempt_dir / "profile.json")
                 write_json_atomic(logs / "attempt-history.json", history)
@@ -841,6 +854,7 @@ def generate_candidate(
                     prompt_version=PROMPT_VERSION,
                     attempt=attempt,
                     max_attempts=config.controller.max_generation_attempts,
+                    correction_source_sha256=correction_source_sha256,
                 )
                 destination = candidate_directory(state_dir, species)
                 destination.parent.mkdir(parents=True, exist_ok=True)
@@ -848,7 +862,8 @@ def generate_candidate(
                     raise CatalogError(f"Pending destination already exists: {destination}")
                 shutil.copytree(attempt_dir, destination)
                 return destination
-            correction_findings = review.findings or (REVIEW_FAILURE_FALLBACK,)
+            correction_findings = review.correction_findings or (REVIEW_FAILURE_FALLBACK,)
+            correction_source = portrait_path
 
         failed = state_dir / "failed" / f"{species.taxon_id}-{_timestamp()}"
         failed.parent.mkdir(parents=True, exist_ok=True)
@@ -857,6 +872,16 @@ def generate_candidate(
             "Generated plate failed automated quality review after "
             f"{config.controller.max_generation_attempts} attempts; artifacts retained at {failed}"
         )
+
+
+def _retry_source_plate(state_dir: Path, relative_path: str | None) -> Path | None:
+    if relative_path is None:
+        return None
+    state_root = state_dir.resolve()
+    source = (state_dir / relative_path).resolve()
+    if not source.is_relative_to(state_root) or not source.is_file():
+        raise SpeciesStateError(f"Invalid retained correction source: {relative_path}")
+    return source
 
 
 def _has_terminal_state(state_dir: Path, taxon_id: int) -> bool:
@@ -957,6 +982,10 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                         species,
                         config.controller.workspace_dir,
                         initial_correction_findings=guidance.findings,
+                        initial_correction_source=_retry_source_plate(
+                            config.controller.state_dir,
+                            guidance.source_plate,
+                        ),
                     )
                 with catalog_state_lock(config.controller.state_dir):
                     entry = approve_candidate(

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -977,15 +977,20 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 if guidance is None:
                     generate_candidate(config, species, config.controller.workspace_dir)
                 else:
+                    try:
+                        correction_source = _retry_source_plate(
+                            config.controller.state_dir,
+                            guidance.source_plate,
+                        )
+                    except SpeciesStateError:
+                        retry_store.clear_quality_guidance(species.taxon_id)
+                        raise
                     generate_candidate(
                         config,
                         species,
                         config.controller.workspace_dir,
                         initial_correction_findings=guidance.findings,
-                        initial_correction_source=_retry_source_plate(
-                            config.controller.state_dir,
-                            guidance.source_plate,
-                        ),
+                        initial_correction_source=correction_source,
                     )
                 with catalog_state_lock(config.controller.state_dir):
                     entry = approve_candidate(

--- a/src/inky_bird_frame/models.py
+++ b/src/inky_bird_frame/models.py
@@ -70,6 +70,7 @@ class QualityReview:
     location_free: bool
     findings: tuple[str, ...]
     verification_sources: tuple[SourceLink, ...] = ()
+    correction_findings: tuple[str, ...] = ()
 
     def as_dict(self) -> dict[str, object]:
         return {
@@ -81,4 +82,5 @@ class QualityReview:
             "location_free": self.location_free,
             "findings": list(self.findings),
             "verification_sources": list(self.verification_sources),
+            "correction_findings": list(self.correction_findings),
         }

--- a/src/inky_bird_frame/prompts.py
+++ b/src/inky_bird_frame/prompts.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from .birds import BirdSpecies, TaxonContext
 from .models import ReferencePhoto, SpeciesProfileData
 
-PROMPT_VERSION = "field-journal-v2"
+PROMPT_VERSION = "field-journal-v3"
 
 
 class _TextExtractor(HTMLParser):
@@ -27,9 +27,9 @@ def strip_html(value: str) -> str:
     return "".join(parser.parts).strip()
 
 
-def reference_list(references: list[ReferencePhoto]) -> str:
+def reference_list(references: list[ReferencePhoto], *, start_index: int = 1) -> str:
     lines = []
-    for index, reference in enumerate(references, start=1):
+    for index, reference in enumerate(references, start=start_index):
         lines.append(
             f"Image {index}: {reference.attribution}; {reference.license_code}; "
             f"{reference.source_url}"
@@ -80,6 +80,8 @@ def plate_prompt(
     references: list[ReferencePhoto],
     output_path: Path,
     correction_findings: tuple[str, ...] = (),
+    *,
+    has_correction_source: bool = False,
 ) -> str:
     measurements = profile["measurements"]
     field_marks = "\n".join(f"  - {mark}" for mark in profile["field_marks"])
@@ -87,18 +89,45 @@ def plate_prompt(
     correction = ""
     if correction_findings:
         issues = "\n".join(f"- {finding}" for finding in correction_findings)
-        correction = f"""
-Correction required after an independent review of the previous attempt:
+        if has_correction_source:
+            correction = f"""
+Image 1 is the previous plate and the edit target. Images 2 onward are species-accuracy
+references. Correct only the concrete defects below while preserving the previous plate's
+successful content, visual identity, typography, and large specimen footprint. Keep every
+unflagged factual statement and design element unchanged. Do not shrink the bird or create new
+empty space to make room for corrections.
+
+Corrections required after an independent review:
 {issues}
 
-Create a new image that corrects every issue above. Do not copy or lightly edit the previous
-attempt.
+Use the supplied current profile as the authority for visible facts, including any text that the
+review requires changing. Preserve correct anatomy and composition from Image 1 while making the
+smallest complete edit that resolves every correction. Legacy review records may include
+statements confirming correct traits; preserve those traits as invariants rather than treating
+them as changes.
 """
+        else:
+            correction = f"""
+Corrections required after an independent review of an earlier generation cycle:
+{issues}
+
+Create a new image that resolves every correction while preserving the supplied correct facts and
+the required large-specimen composition. Legacy review records may include statements confirming
+correct traits; preserve those traits as invariants rather than treating them as changes.
+"""
+    reference_start = 2 if has_correction_source else 1
+    reference_roles = (
+        "Image 1 is the correction edit target. The remaining attached images are licensed "
+        "species-accuracy references."
+        if has_correction_source
+        else "Every attached image is a licensed species-accuracy reference."
+    )
     return f"""$imagegen
 
-Use case: scientific-educational
+Use case: {"precise-object-edit" if has_correction_source else "scientific-educational"}
 Asset type: reusable portrait plate for a 13.3-inch color e-paper frame
-Primary request: Create one polished scientific field-journal plate for the species below.
+Primary request: {"Correct" if has_correction_source else "Create"} one polished scientific
+field-journal plate for the species below.
 
 Species identity:
 - Common name, verbatim: "{species.common_name}"
@@ -116,23 +145,29 @@ Species-specific field notes:
 - Plumage palette: {palette}
 
 Reference images, in attachment order:
-{reference_list(references)}
+{reference_list(references, start_index=reference_start)}
 
-Treat every attached image as a species-accuracy reference. Synthesize the consistent anatomy,
-proportions, posture, plumage pattern, and colors across them. Do not reproduce any photograph's
-background, pose, crop, or composition.
+{reference_roles} Synthesize the consistent anatomy, proportions, posture, plumage pattern, and
+colors across the reference photographs. Do not reproduce any photograph's background, pose,
+crop, or composition.
 {correction}
 
 Style and composition:
 - Portrait 3:4 page on warm aged cream naturalist-notebook paper.
 - Fine graphite and confident ink linework with restrained transparent watercolor.
 - One full-body bird, large and centered-right, in a natural perched posture.
+- The bird remains the dominant page element and confidently uses the available space.
 - Left margin contains compact handwritten measurements and field marks.
 - Bottom margin contains a small wing-pattern study, a bill/head study, and color swatches.
-- Right edge contains a thin measurement ruler.
+- Right edge contains a thin, self-contained vertical schematic ruler keyed to the body-length
+  range "{measurements["length"]}". Use proportionally spaced ticks with explicit units, visibly
+  mark the published range, and label it "BODY LENGTH: {measurements["length"]}" and
+  "SCHEMATIC — NOT TO SCALE". Keep it separate from the bird; never imply that it measures the
+  printed illustration.
 - It should look like a carefully scanned scientific field-journal page, not Audubon, not a
   decorative poster, not a collage, and not photorealistic.
 - Quiet margins. No scenery, map, location, ZIP code, coordinates, date, logo, or watermark.
+- Preserve the exact 3:4 portrait aspect ratio and keep all text inside safe page margins.
 - Exactly one bird, one head, one beak, two wings, two legs, and one tail. Feet must be plausible.
 - Render only the exact species name and supplied factual notes. Do not invent extra prose.
 
@@ -163,12 +198,15 @@ these domains: {", ".join(allowed_domains)}. Do not rely on search snippets. Ins
 for correct plumage, proportions, bill, eye, wings, tail, legs, feet, and species field marks
 against the attached field-reference photos. Compare every visible factual claim to the
 independently verified facts. Confirm that no place name, ZIP code, coordinates, map, or
-local-observation detail appears. Record every concrete issue and return at least two direct HTTPS
-source URLs from distinct configured domains used for verification.
+local-observation detail appears. Use findings for the complete review record, including verified
+strengths and concrete issues. Put only required, actionable changes in correction_findings; do not
+repeat positive observations, source confirmations, or already-correct traits there. Return at
+least two direct HTTPS source URLs from distinct configured domains used for verification.
 
 Set passed=true only when all four scores are at least 4, location_free is true, the bird has
 exactly one head, one beak, two wings, two legs, and one tail, and there are no material species or
-text errors. Return only the requested JSON.
+text errors. When passed=false, correction_findings must contain at least one specific change.
+When passed=true, correction_findings must be empty. Return only the requested JSON.
 
 Reference provenance:
 {reference_list(references)}

--- a/src/inky_bird_frame/retry.py
+++ b/src/inky_bird_frame/retry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from .catalog import utc_now
 from .errors import CatalogError
@@ -39,9 +39,16 @@ class RetryRecord:
 class RetryGuidance:
     taxon_id: int
     findings: tuple[str, ...]
+    source_plate: str | None = None
 
     def as_dict(self) -> dict[str, object]:
-        return {"taxon_id": self.taxon_id, "findings": list(self.findings)}
+        value: dict[str, object] = {
+            "taxon_id": self.taxon_id,
+            "findings": list(self.findings),
+        }
+        if self.source_plate is not None:
+            value["source_plate"] = self.source_plate
+        return value
 
 
 class RetryStore:
@@ -122,9 +129,19 @@ class RetryStore:
     def quality_guidance(self, taxon_id: int) -> RetryGuidance | None:
         return self._quality_guidance.get(taxon_id)
 
-    def set_quality_guidance(self, taxon_id: int, findings: tuple[str, ...]) -> RetryGuidance:
+    def set_quality_guidance(
+        self,
+        taxon_id: int,
+        findings: tuple[str, ...],
+        *,
+        source_plate: str | None = None,
+    ) -> RetryGuidance:
         guidance = _parse_guidance(
-            {"taxon_id": taxon_id, "findings": list(findings)},
+            {
+                "taxon_id": taxon_id,
+                "findings": list(findings),
+                "source_plate": source_plate,
+            },
             self.path,
         )
         self._quality_guidance[taxon_id] = guidance
@@ -217,6 +234,7 @@ def _parse_guidance(raw: object, source: Path) -> RetryGuidance:
         raise CatalogError(f"Invalid retry quality guidance: {source}")
     taxon_id = raw.get("taxon_id")
     findings = raw.get("findings")
+    source_plate = raw.get("source_plate")
     if (
         not isinstance(taxon_id, int)
         or isinstance(taxon_id, bool)
@@ -226,4 +244,21 @@ def _parse_guidance(raw: object, source: Path) -> RetryGuidance:
         or any(not isinstance(finding, str) or not finding.strip() for finding in findings)
     ):
         raise CatalogError(f"Invalid retry quality guidance: {source}")
-    return RetryGuidance(taxon_id=taxon_id, findings=tuple(findings))
+    if source_plate is not None:
+        if not isinstance(source_plate, str) or not source_plate:
+            raise CatalogError(f"Invalid retry quality guidance: {source}")
+        source_path = PurePosixPath(source_plate)
+        if (
+            source_path.is_absolute()
+            or not source_path.parts
+            or source_path.parts[0] != "archive"
+            or ".." in source_path.parts
+            or source_path.suffix.casefold() != ".png"
+        ):
+            raise CatalogError(f"Invalid retry quality guidance: {source}")
+        source_plate = source_path.as_posix()
+    return RetryGuidance(
+        taxon_id=taxon_id,
+        findings=tuple(findings),
+        source_plate=source_plate,
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -243,6 +243,15 @@ class CliTests(unittest.TestCase):
         self.assertEqual(str(dispatch.config), "instance.toml")
         self.assertEqual(str(retry.config), "instance.toml")
 
+    def test_retry_parser_accepts_selected_source_attempt(self) -> None:
+        retry = build_parser().parse_args(
+            ["retry", "42", "--source-attempt", "3", "--config", "instance.toml"]
+        )
+
+        self.assertEqual(retry.taxon_id, 42)
+        self.assertEqual(retry.source_attempt, 3)
+        self.assertEqual(str(retry.config), "instance.toml")
+
     def test_notifications_dispatch_checks_display_heartbeat(self) -> None:
         output = io.StringIO()
         with (
@@ -445,6 +454,62 @@ rotation_mode = "shuffle_bag"
         self.assertIsNotNone(guidance)
         if guidance is not None:
             self.assertEqual(guidance.findings, (REVIEW_FAILURE_FALLBACK,))
+
+    def test_retry_preserves_selected_attempt_as_correction_source(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-example-bird"
+            for attempt, correction in ((1, "Fix the tail"), (2, "Fix the wing")):
+                attempt_dir = failed / f"attempt-{attempt:02d}"
+                attempt_dir.mkdir(parents=True)
+                (attempt_dir / "portrait.png").write_bytes(f"portrait-{attempt}".encode())
+                (attempt_dir / "quality-review.json").write_text(
+                    json.dumps(
+                        {
+                            "passed": False,
+                            "findings": ["Verified correct trait", correction],
+                            "correction_findings": [correction],
+                        }
+                    )
+                )
+            config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
+            output = io.StringIO()
+
+            with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
+                retry_command(Namespace(taxon_id=42, source_attempt=1))
+
+            result = json.loads(output.getvalue())["data"]
+            guidance = RetryStore(state_dir / "generation-retries.json").quality_guidance(42)
+            source_bytes = (
+                (state_dir / guidance.source_plate).read_bytes()
+                if guidance is not None and guidance.source_plate is not None
+                else None
+            )
+
+        self.assertTrue(result["preserved_correction_source"])
+        self.assertEqual(result["source_attempt"], 1)
+        self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(guidance.findings, ("Fix the tail",))
+            self.assertIsNotNone(guidance.source_plate)
+        self.assertEqual(source_bytes, b"portrait-1")
+
+    def test_retry_rejects_missing_source_attempt_before_archiving(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            review = state_dir / "failed/42-example-bird/attempt-01/quality-review.json"
+            review.parent.mkdir(parents=True)
+            review.write_text(json.dumps({"passed": False, "findings": ["Fix the tail"]}))
+            config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(ValueError, "choose one of: 1"),
+            ):
+                retry_command(Namespace(taxon_id=42, source_attempt=2))
+
+            self.assertTrue((state_dir / "failed/42-example-bird").is_dir())
+            self.assertFalse((state_dir / "archive").exists())
 
     def test_retry_rejects_malformed_quality_review_before_archiving(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -271,23 +271,22 @@ class CodexRunnerTests(unittest.TestCase):
         self.assertIn("birds.example, field.example", prompt)
 
     def test_review_requires_two_verification_sources(self) -> None:
-        review = _parse_review(
-            {
-                "passed": True,
-                "species_accuracy": 5,
-                "anatomy_accuracy": 5,
-                "text_accuracy": 5,
-                "composition_quality": 5,
-                "location_free": True,
-                "findings": [],
-                "correction_findings": [],
-                "verification_sources": [
-                    {"title": "Cornell", "url": "https://www.allaboutbirds.org/example"}
-                ],
-            }
-        )
-
-        self.assertFalse(review.passed)
+        with self.assertRaisesRegex(GenerationError, "at least two verification sources"):
+            _parse_review(
+                {
+                    "passed": True,
+                    "species_accuracy": 5,
+                    "anatomy_accuracy": 5,
+                    "text_accuracy": 5,
+                    "composition_quality": 5,
+                    "location_free": True,
+                    "findings": [],
+                    "correction_findings": [],
+                    "verification_sources": [
+                        {"title": "Cornell", "url": "https://www.allaboutbirds.org/example"}
+                    ],
+                }
+            )
 
     def test_review_passes_with_scores_and_two_verification_sources(self) -> None:
         review = _parse_review(
@@ -311,25 +310,29 @@ class CodexRunnerTests(unittest.TestCase):
         self.assertEqual(len(review.verification_sources), 2)
 
     def test_review_requires_two_distinct_verification_urls(self) -> None:
-        review = _parse_review(
-            {
-                "passed": True,
-                "species_accuracy": 5,
-                "anatomy_accuracy": 5,
-                "text_accuracy": 5,
-                "composition_quality": 5,
-                "location_free": True,
-                "findings": [],
-                "correction_findings": [],
-                "verification_sources": [
-                    {"title": "Cornell identification", "url": "https://example.test/bird"},
-                    {"title": "Cornell life history", "url": "https://example.test/bird"},
-                ],
-            }
-        )
-
-        self.assertFalse(review.passed)
-        self.assertEqual(len(review.verification_sources), 1)
+        with self.assertRaisesRegex(GenerationError, "at least two verification sources"):
+            _parse_review(
+                {
+                    "passed": True,
+                    "species_accuracy": 5,
+                    "anatomy_accuracy": 5,
+                    "text_accuracy": 5,
+                    "composition_quality": 5,
+                    "location_free": True,
+                    "findings": [],
+                    "correction_findings": [],
+                    "verification_sources": [
+                        {
+                            "title": "Cornell identification",
+                            "url": "https://example.test/bird",
+                        },
+                        {
+                            "title": "Cornell life history",
+                            "url": "https://example.test/bird",
+                        },
+                    ],
+                }
+            )
 
     def test_noninteractive_command_allows_deployment_workspace(self) -> None:
         with TemporaryDirectory() as temporary:
@@ -364,24 +367,23 @@ class CodexRunnerTests(unittest.TestCase):
             parse_species_profile(profile, ("birds.example",))
 
     def test_review_requires_independent_source_domains(self) -> None:
-        review = _parse_review(
-            {
-                "passed": True,
-                "species_accuracy": 5,
-                "anatomy_accuracy": 5,
-                "text_accuracy": 5,
-                "composition_quality": 5,
-                "location_free": True,
-                "findings": [],
-                "correction_findings": [],
-                "verification_sources": [
-                    {"title": "One", "url": "https://birds.example/one"},
-                    {"title": "Two", "url": "https://birds.example/two"},
-                ],
-            }
-        )
-
-        self.assertFalse(review.passed)
+        with self.assertRaisesRegex(GenerationError, "independent verification source domains"):
+            _parse_review(
+                {
+                    "passed": True,
+                    "species_accuracy": 5,
+                    "anatomy_accuracy": 5,
+                    "text_accuracy": 5,
+                    "composition_quality": 5,
+                    "location_free": True,
+                    "findings": [],
+                    "correction_findings": [],
+                    "verification_sources": [
+                        {"title": "One", "url": "https://birds.example/one"},
+                        {"title": "Two", "url": "https://birds.example/two"},
+                    ],
+                }
+            )
 
     def test_failed_review_requires_actionable_corrections(self) -> None:
         with self.assertRaisesRegex(GenerationError, "must include correction_findings"):

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -162,6 +162,40 @@ class CodexRunnerSubprocessTests(unittest.TestCase):
                     _species(), _profile(), [], [], plate_path, root / "plate.log"
                 )
 
+    def test_generate_plate_attaches_correction_source_before_references(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            executable = root / "codex"
+            executable.touch()
+            source = root / "source.png"
+            reference = root / "reference.png"
+            source.write_bytes(b"source")
+            reference.write_bytes(b"reference")
+            output = root / "plate.png"
+            runner = CodexRunner(executable, root)
+
+            def run(_command: list[str], _prompt: str, _log_path: Path) -> None:
+                output.write_bytes(b"generated")
+
+            with patch.object(runner, "_run", side_effect=run) as execute:
+                runner.generate_plate(
+                    _species(),
+                    _profile(),
+                    [],
+                    [reference],
+                    output,
+                    root / "plate.log",
+                    ("Shorten the tail",),
+                    correction_source_path=source,
+                )
+
+        command = execute.call_args.args[0]
+        images = [command[index + 1] for index, value in enumerate(command) if value == "--image"]
+        self.assertEqual(images, [str(source.resolve()), str(reference.resolve())])
+        self.assertIn(
+            "Image 1 is the previous plate and the edit target", execute.call_args.args[1]
+        )
+
     def test_create_profile_rejects_mismatched_taxon_identity(self) -> None:
         with TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -212,6 +246,7 @@ class CodexRunnerTests(unittest.TestCase):
             "composition_quality": 5,
             "location_free": True,
             "findings": [],
+            "correction_findings": [],
             "verification_sources": profile["sources"],
         }
         with TemporaryDirectory() as temporary:
@@ -245,6 +280,7 @@ class CodexRunnerTests(unittest.TestCase):
                 "composition_quality": 5,
                 "location_free": True,
                 "findings": [],
+                "correction_findings": [],
                 "verification_sources": [
                     {"title": "Cornell", "url": "https://www.allaboutbirds.org/example"}
                 ],
@@ -263,6 +299,7 @@ class CodexRunnerTests(unittest.TestCase):
                 "composition_quality": 4,
                 "location_free": True,
                 "findings": [],
+                "correction_findings": [],
                 "verification_sources": [
                     {"title": "Cornell", "url": "https://www.allaboutbirds.org/example"},
                     {"title": "Audubon", "url": "https://www.audubon.org/example"},
@@ -283,6 +320,7 @@ class CodexRunnerTests(unittest.TestCase):
                 "composition_quality": 5,
                 "location_free": True,
                 "findings": [],
+                "correction_findings": [],
                 "verification_sources": [
                     {"title": "Cornell identification", "url": "https://example.test/bird"},
                     {"title": "Cornell life history", "url": "https://example.test/bird"},
@@ -335,6 +373,7 @@ class CodexRunnerTests(unittest.TestCase):
                 "composition_quality": 5,
                 "location_free": True,
                 "findings": [],
+                "correction_findings": [],
                 "verification_sources": [
                     {"title": "One", "url": "https://birds.example/one"},
                     {"title": "Two", "url": "https://birds.example/two"},
@@ -343,6 +382,44 @@ class CodexRunnerTests(unittest.TestCase):
         )
 
         self.assertFalse(review.passed)
+
+    def test_failed_review_requires_actionable_corrections(self) -> None:
+        with self.assertRaisesRegex(GenerationError, "must include correction_findings"):
+            _parse_review(
+                {
+                    "passed": False,
+                    "species_accuracy": 3,
+                    "anatomy_accuracy": 4,
+                    "text_accuracy": 5,
+                    "composition_quality": 4,
+                    "location_free": True,
+                    "findings": ["The bill is too long"],
+                    "correction_findings": [],
+                    "verification_sources": [
+                        {"title": "Cornell", "url": "https://www.allaboutbirds.org/example"},
+                        {"title": "Audubon", "url": "https://www.audubon.org/example"},
+                    ],
+                }
+            )
+
+    def test_passing_review_rejects_actionable_corrections(self) -> None:
+        with self.assertRaisesRegex(GenerationError, "must not include correction_findings"):
+            _parse_review(
+                {
+                    "passed": True,
+                    "species_accuracy": 5,
+                    "anatomy_accuracy": 4,
+                    "text_accuracy": 5,
+                    "composition_quality": 4,
+                    "location_free": True,
+                    "findings": ["No material issue"],
+                    "correction_findings": ["Change the bill"],
+                    "verification_sources": [
+                        {"title": "Cornell", "url": "https://www.allaboutbirds.org/example"},
+                        {"title": "Audubon", "url": "https://www.audubon.org/example"},
+                    ],
+                }
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -437,10 +437,17 @@ class ControllerTests(unittest.TestCase):
                 initial_minutes=30,
                 maximum_minutes=60,
             )
-            retry_store.set_quality_guidance(first.taxon_id, ("Keep the wing angle accurate",))
+            source_plate = config.controller.state_dir / "archive/first/attempt-01/portrait.png"
+            source_plate.parent.mkdir(parents=True)
+            source_plate.write_bytes(b"source")
+            retry_store.set_quality_guidance(
+                first.taxon_id,
+                ("Keep the wing angle accurate",),
+                source_plate="archive/first/attempt-01/portrait.png",
+            )
             with (
                 patch("inky_bird_frame.controller.approved_taxon_ids", return_value=set()),
-                patch("inky_bird_frame.controller.generate_candidate"),
+                patch("inky_bird_frame.controller.generate_candidate") as generate,
                 patch("inky_bird_frame.controller.approve_candidate", return_value=entry),
                 patch("inky_bird_frame.controller._write_active_catalog", return_value=0),
             ):
@@ -453,6 +460,10 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(result["deferred_count"], 0)
         self.assertEqual(result["outstanding_retry_count"], 1)
         self.assertIsNone(first_guidance)
+        self.assertEqual(
+            generate.call_args.kwargs["initial_correction_source"],
+            source_plate.resolve(),
+        )
 
     def test_overlapping_refresh_is_rejected_before_discovery(self) -> None:
         with TemporaryDirectory() as temporary:
@@ -786,7 +797,16 @@ class ControllerTests(unittest.TestCase):
 
     def test_failed_review_is_corrected_and_passing_attempt_is_staged(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
-        failed_review = QualityReview(False, 3, 4, 5, 5, True, ("Crest is too short",))
+        failed_review = QualityReview(
+            False,
+            3,
+            4,
+            5,
+            5,
+            True,
+            ("The remaining anatomy is correct", "Crest is too short"),
+            correction_findings=("Crest is too short",),
+        )
         passed_review = QualityReview(
             True,
             5,
@@ -805,6 +825,7 @@ class ControllerTests(unittest.TestCase):
             corrections: list[tuple[str, ...]] = []
             generated_paths: list[Path] = []
             review_paths: list[Path] = []
+            correction_sources: list[Path | None] = []
             reviews = iter((failed_review, passed_review))
 
             def __init__(self, _executable: Path, workspace: Path) -> None:
@@ -817,7 +838,7 @@ class ControllerTests(unittest.TestCase):
                 output_path.write_text(json.dumps(PROFILE))
                 return PROFILE
 
-            def generate_plate(self, *_args: object) -> Path:
+            def generate_plate(self, *_args: object, **_kwargs: object) -> Path:
                 output_path = _args[-3]
                 correction = _args[-1]
                 assert isinstance(output_path, Path)
@@ -825,6 +846,9 @@ class ControllerTests(unittest.TestCase):
                 self.generated_paths.append(output_path)
                 assert output_path.resolve().is_relative_to(self.workspace)
                 self.corrections.append(correction)
+                source = _kwargs.get("correction_source_path")
+                assert source is None or isinstance(source, Path)
+                self.correction_sources.append(source)
                 output_path.write_bytes(b"generated")
                 return output_path
 
@@ -846,6 +870,9 @@ class ControllerTests(unittest.TestCase):
             )
             config = load_config(config_path)
             config.controller.workspace_dir.mkdir()
+            source_plate = config.controller.state_dir / "archive/source/portrait.png"
+            source_plate.parent.mkdir(parents=True)
+            source_plate.write_bytes(b"source")
             with (
                 patch("inky_bird_frame.controller.load_or_fetch_references", return_value=[]),
                 patch("inky_bird_frame.controller.fetch_taxon_context"),
@@ -857,6 +884,7 @@ class ControllerTests(unittest.TestCase):
                     species,
                     config.controller.workspace_dir,
                     initial_correction_findings=("Preserve the previous scale correction",),
+                    initial_correction_source=source_plate,
                 )
             manifest = json.loads((candidate / "manifest.json").read_text())
             private_histories = list(
@@ -869,6 +897,12 @@ class ControllerTests(unittest.TestCase):
         )
         self.assertEqual(len(FakeRunner.generated_paths), 2)
         self.assertEqual(len(FakeRunner.review_paths), 2)
+        self.assertEqual(FakeRunner.correction_sources[0], source_plate)
+        self.assertEqual(FakeRunner.correction_sources[1], FakeRunner.review_paths[0])
+        self.assertEqual(
+            manifest["generation"]["correction_source_sha256"],
+            "51c5a8296a032ce7b3014e66000c20d0d759d2e910873f28fa6107ab012bf887",
+        )
         self.assertEqual(manifest["generation"]["attempt"], 2)
         self.assertEqual(manifest["status"], "pending")
         self.assertFalse((candidate / "attempt-history.json").exists())
@@ -1032,7 +1066,7 @@ class ControllerTests(unittest.TestCase):
             def __init__(self, _executable: Path, _workspace: Path) -> None:
                 pass
 
-            def generate_plate(self, *_args: object) -> Path:
+            def generate_plate(self, *_args: object, **_kwargs: object) -> Path:
                 output_path = _args[-3]
                 assert isinstance(output_path, Path)
                 output_path.write_bytes(b"generated")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -465,6 +465,57 @@ class ControllerTests(unittest.TestCase):
             source_plate.resolve(),
         )
 
+    def test_missing_retry_source_clears_unusable_quality_guidance(self) -> None:
+        species = BirdSpecies(1, "First Bird", "Avis first", 4, "iNaturalist")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            (config.controller.state_dir / "discovery.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "refreshed_at": datetime.now(UTC).isoformat(),
+                        "place_name": "Exampleville",
+                        "state": "XY",
+                        "species": [
+                            {
+                                "taxon_id": species.taxon_id,
+                                "common_name": species.common_name,
+                                "scientific_name": species.scientific_name,
+                                "observation_count": species.observation_count,
+                                "source": species.source,
+                            }
+                        ],
+                    }
+                )
+            )
+            RetryStore(
+                config.controller.state_dir / "generation-retries.json"
+            ).set_quality_guidance(
+                species.taxon_id,
+                ("Keep the wing angle accurate",),
+                source_plate="archive/missing/attempt-01/portrait.png",
+            )
+            with (
+                patch("inky_bird_frame.controller.approved_taxon_ids", return_value=set()),
+                patch("inky_bird_frame.controller.generate_candidate") as generate,
+                patch("inky_bird_frame.controller._write_active_catalog", return_value=0),
+            ):
+                result = run_generation_cycle(config)
+            guidance = RetryStore(
+                config.controller.state_dir / "generation-retries.json"
+            ).quality_guidance(species.taxon_id)
+
+        self.assertIsNone(guidance)
+        generate.assert_not_called()
+        failures = result["failures"]
+        self.assertIsInstance(failures, list)
+        if isinstance(failures, list):
+            self.assertTrue(failures[0]["terminal"])
+            self.assertIn("Invalid retained correction source", failures[0]["error"])
+
     def test_overlapping_refresh_is_rejected_before_discovery(self) -> None:
         with TemporaryDirectory() as temporary:
             config_path = Path(temporary) / "config.toml"

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -77,6 +77,40 @@ class PromptTests(unittest.TestCase):
         self.assertIn("Correct the wing bars", prompt)
         self.assertIn("Create a new image", prompt)
 
+    def test_plate_prompt_edits_source_and_uses_schematic_ruler(self) -> None:
+        species = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 26, "iNaturalist")
+        profile = SpeciesProfileData(
+            taxon_id=12942,
+            common_name="Eastern Bluebird",
+            scientific_name="Sialia sialis",
+            family="Turdidae",
+            measurements={"length": "7 in", "wingspan": "12 in", "weight": "1 oz"},
+            field_marks=["blue head", "blue back", "rufous breast", "white belly"],
+            habitat="Open woodland",
+            behavior="Drops from perches to forage",
+            palette=["blue", "rufous", "white"],
+            sources=[
+                {"title": "A", "url": "https://example.test/a"},
+                {"title": "B", "url": "https://example.test/b"},
+            ],
+        )
+
+        prompt = plate_prompt(
+            species,
+            profile,
+            [],
+            Path("candidate.png"),
+            ("Shorten the tail",),
+            has_correction_source=True,
+        )
+
+        self.assertIn("Use case: precise-object-edit", prompt)
+        self.assertIn("Image 1 is the previous plate and the edit target", prompt)
+        self.assertIn("Do not shrink the bird", prompt)
+        self.assertIn("BODY LENGTH: 7 in", prompt)
+        self.assertIn("SCHEMATIC — NOT TO SCALE", prompt)
+        self.assertNotIn("Do not copy or lightly edit", prompt)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -592,6 +592,21 @@ class PublisherTests(unittest.TestCase):
             with self.assertRaisesRegex(CatalogPublishError, "lacks a publishable quality review"):
                 validate_public_catalog(catalog)
 
+    def test_rejects_passing_review_with_actionable_corrections(self) -> None:
+        with TemporaryDirectory() as temporary:
+            catalog = Path(temporary) / "catalog"
+            directory = _create_species(catalog, 1, "Example Bird")
+            manifest_path = directory / "manifest.json"
+            review_path = directory / "quality-review.json"
+            manifest = json.loads(manifest_path.read_text())
+            review = manifest["quality_review"]
+            review["correction_findings"] = ["Correct the ruler"]
+            write_json_atomic(review_path, review)
+            write_json_atomic(manifest_path, manifest)
+
+            with self.assertRaisesRegex(CatalogPublishError, "lacks a publishable quality review"):
+                validate_public_catalog(catalog)
+
     def test_rejects_invalid_correction_source_checksum(self) -> None:
         with TemporaryDirectory() as temporary:
             catalog = Path(temporary) / "catalog"

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -592,6 +592,18 @@ class PublisherTests(unittest.TestCase):
             with self.assertRaisesRegex(CatalogPublishError, "lacks a publishable quality review"):
                 validate_public_catalog(catalog)
 
+    def test_rejects_invalid_correction_source_checksum(self) -> None:
+        with TemporaryDirectory() as temporary:
+            catalog = Path(temporary) / "catalog"
+            directory = _create_species(catalog, 1, "Example Bird")
+            manifest_path = directory / "manifest.json"
+            manifest = json.loads(manifest_path.read_text())
+            manifest["generation"]["correction_source_sha256"] = "invalid"
+            write_json_atomic(manifest_path, manifest)
+
+            with self.assertRaisesRegex(CatalogPublishError, "lacks a publishable quality review"):
+                validate_public_catalog(catalog)
+
     def test_rejects_manifest_asset_path_traversal_before_reading_it(self) -> None:
         with TemporaryDirectory() as temporary:
             catalog = Path(temporary) / "catalog"

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -90,6 +90,31 @@ class RetryStoreTests(unittest.TestCase):
             with self.assertRaisesRegex(CatalogError, "Invalid retry quality guidance"):
                 RetryStore(path)
 
+    def test_correction_source_is_durable(self) -> None:
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "retries.json"
+            guidance = RetryStore(path).set_quality_guidance(
+                42,
+                ("Correct the scale",),
+                source_plate="archive/42-bird/attempt-03/portrait.png",
+            )
+
+            reloaded = RetryStore(path).quality_guidance(42)
+
+        self.assertEqual(guidance, reloaded)
+        self.assertEqual(guidance.source_plate, "archive/42-bird/attempt-03/portrait.png")
+
+    def test_correction_source_must_remain_in_archive(self) -> None:
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "retries.json"
+
+            with self.assertRaisesRegex(CatalogError, "Invalid retry quality guidance"):
+                RetryStore(path).set_quality_guidance(
+                    42,
+                    ("Correct the scale",),
+                    source_plate="../private/portrait.png",
+                )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- let operators select a retained failed attempt as the source for a retry
- edit the selected plate in place during corrective generations instead of restarting from scratch
- separate complete review notes from actionable correction findings
- standardize the field-guide ruler as a vertical, self-contained schematic using sourced body length
- record the correction source hash in attempt history and published manifests
- document the workflow and cover the new behavior with focused tests

## Why

Quality retries could discard a strong composition while fixing a localized defect because each attempt regenerated the plate from scratch. Review feedback also mixed positive observations with required corrections, and prior ruler treatments could imply a false physical scale. This keeps the strongest plate as the correction source, preserves verified qualities, and makes the ruler useful without claiming display-scale accuracy.

## Safety and compatibility

- source selection is opt-in through `retry --source-attempt`
- ordinary first-attempt generation remains unchanged
- retained source paths are archive-relative, validated, and traversal-safe
- historical review payloads without `correction_findings` remain supported
- no catalog artwork, observation data, credentials, or deployment configuration is included

## Validation

- `UV_CACHE_DIR=/tmp/inky-uv-cache uv sync --extra dev --locked`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q`
- `uv run inky-bird-frame catalog validate --catalog catalog` (101 species valid)
- `git diff --check`
