### PR TITLE
Release version 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.2.1"
+version = "0.2.2"
 description = "Generate and display reusable bird field-journal plates"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/inky_bird_frame/__init__.py
+++ b/src/inky_bird_frame/__init__.py
@@ -1,3 +1,3 @@
 """Local bird field-journal plates for Pimoroni Inky displays."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary

- bump the package, runtime, and lockfile version to 0.2.2
- release the provenance-safe plate correction workflow from #141
- release review-gate lifecycle hardening from #137
- include the 12 catalog species published since v0.2.1, growing the reusable catalog from 89 to 101 species

## Validation

- `uv sync --extra dev --locked`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest` (365 passed, 19 subtests passed)
- `uv run inky-bird-frame catalog validate --catalog catalog` (101 species)
- workflow action pinning check
- `actionlint`
- `shellcheck deploy/*.sh`
- package/runtime version consistency check
- `git diff --check`

## Release scope

This PR changes version metadata only. The functional changes and catalog additions were separately reviewed and merged. Existing configurations remain compatible and no required migration is introduced.
