### PR TITLE
Expose detection timestamps in CLI output

### DIFF
--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -171,6 +171,8 @@ its configured rotation. This is display priority, not a confidence claim or a
 live event stream: the timestamp advances only when the controller refreshes
 the station summary, and recording-only detection limitations still apply.
 Configure `display_node.prioritize_latest_detection = false` to disable it.
+The `discover` command includes `latest_detection_at` on species entries when a
+configured provider supplies that timestamp and omits the field otherwise.
 
 ## Limits and data use
 

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -86,7 +86,7 @@ def print_error(exc: Exception) -> None:
 
 
 def species_to_dict(species: BirdSpecies) -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "taxon_id": species.taxon_id,
         "common_name": species.common_name,
         "scientific_name": species.scientific_name,
@@ -94,6 +94,9 @@ def species_to_dict(species: BirdSpecies) -> dict[str, object]:
         "source": species.source,
         "sources": list(species.sources),
     }
+    if species.latest_detection_at is not None:
+        payload["latest_detection_at"] = species.latest_detection_at
+    return payload
 
 
 def _config(args: argparse.Namespace, *, load_secrets: bool = True) -> AppConfig:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -223,6 +223,22 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(payload["source"], "iNaturalist")
         self.assertEqual(payload["sources"], ["iNaturalist"])
+        self.assertNotIn("latest_detection_at", payload)
+
+    def test_species_output_includes_latest_detection_timestamp(self) -> None:
+        timestamp = "2026-08-02T14:21:06-04:00"
+        species = BirdSpecies(
+            145310,
+            "American Goldfinch",
+            "Spinus tristis",
+            3,
+            "BirdWeather",
+            latest_detection_at=timestamp,
+        )
+
+        payload = species_to_dict(species)
+
+        self.assertEqual(payload["latest_detection_at"], timestamp)
 
     def test_seed_rejects_duplicate_source_overrides(self) -> None:
         with self.assertRaisesRegex(ValueError, "must not repeat"):


### PR DESCRIPTION
## Summary

Expose `latest_detection_at` in CLI species JSON when a provider supplies a detection timestamp. The field remains omitted for species without a timestamp, preserving the existing output shape for iNaturalist and eBird-only results.

Document the behavior and cover both timestamped and legacy output with focused tests.

## Change type

- [x] Code
- [x] Documentation
- [ ] Catalog plate
- [x] Tests or continuous integration
- [ ] Other maintenance

## Validation

```text
uv sync --extra dev --locked
uv run ruff format --check .
uv run ruff check .
uv run mypy
uv run pytest  # 366 passed, 19 subtests passed
uv run inky-bird-frame catalog validate --catalog catalog  # 101 valid
actionlint
shellcheck deploy/*.sh
```

A non-persisting live `discover` canary against all three configured providers returned 58 species and exposed 15 BirdWeather timestamps.

## Review notes

No security or configuration compatibility impact. This changes only structured CLI observability; persisted discovery and active-catalog payloads already included the same timestamp conditionally.
