### PR TITLE
Release version 0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.2.2"
+version = "0.2.3"
 description = "Generate and display reusable bird field-journal plates"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/inky_bird_frame/__init__.py
+++ b/src/inky_bird_frame/__init__.py
@@ -1,3 +1,3 @@
 """Local bird field-journal plates for Pimoroni Inky displays."""
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary

Prepare the 0.2.3 patch release from current `main` by updating package, runtime, and lockfile version metadata together.

This release includes the `latest_detection_at` CLI observability fix from #143 and the already-reviewed Black-crowned Night Heron catalog addition from #144.

## Change type

- [ ] Code
- [ ] Documentation
- [ ] Catalog plate
- [ ] Tests or continuous integration
- [x] Other maintenance

## Validation

```text
uv sync --extra dev --locked
uv run ruff format --check .
uv run ruff check .
uv run mypy
uv run pytest  # 366 passed, 19 subtests passed
uv run inky-bird-frame catalog validate --catalog catalog  # 102 valid
uv run python .github/scripts/check_workflow_pinning.py
actionlint
shellcheck deploy/*.sh
```

Installed package metadata and `inky_bird_frame.__version__` both report `0.2.3`.

## Review notes

Version-only release change. No configuration or compatibility migration.
