### PR TITLE
Fix display fetch heartbeat race

### DIFF
--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -73,7 +73,6 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
                     {"ok": False, "error": "active catalog unavailable", "schema_version": 1},
                 )
                 return
-            self._send_json(HTTPStatus.OK, payload)
             # Only display nodes send the marker; a curl or monitor fetch must
             # not refresh the liveness signal.
             if parse_qs(split.query).get("reports_success") == ["1"]:
@@ -82,6 +81,7 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
                         self.state_dir / "display-last-fetch.json",
                         {"schema_version": 1, "fetched_at": utc_now()},
                     )
+            self._send_json(HTTPStatus.OK, payload)
             return
         if request_path == "/v1/display-success":
             with suppress(OSError):


### PR DESCRIPTION
## Summary

Persist the display catalog-fetch heartbeat before sending the successful response. This removes the response/write race exposed by exact-main CI while preserving the separate display-success signal for completed panel updates.

## Change type

- [x] Code
- [ ] Documentation
- [ ] Catalog plate
- [ ] Tests or continuous integration
- [ ] Other maintenance

## Validation

- uv run pytest tests/test_server.py::ServerTests::test_catalog_success_records_display_fetch_heartbeat -q: passed
- Focused regression stress run: 50 of 50 passed
- uv run ruff format --check .: passed
- uv run ruff check .: passed
- uv run mypy: passed
- uv run pytest: 366 passed, 19 subtests passed
- uv run inky-bird-frame catalog validate --catalog catalog: 102 species, valid
- Workflow pinning, actionlint, and ShellCheck: passed

## Review notes

The fetch heartbeat remains a controller-contact signal. Actual panel completion remains exclusively reported through /v1/display-success.