### PR TITLE
Add private local bird collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,18 +220,27 @@ uv run inky-bird-frame refresh --config config.toml
 # Generate and review missing plates from the latest refresh.
 uv run inky-bird-frame generate --config config.toml
 
-# Queue a broader one-time set without changing the active display window.
+# Add a broader one-time set to the private collection and queue missing plates.
 uv run inky-bird-frame seed --config config.toml --source inaturalist \
   --window last-year --species-limit 500
 
-# Queue species from one historical place and inclusive date range without
-# changing the configured discovery location or active display window.
+# Add species from one historical place and inclusive date range without
+# changing the configured discovery location or current observation snapshot.
 uv run inky-bird-frame seed --config config.toml --source inaturalist \
   --latitude 40.7128 --longitude -74.0060 --radius-km 11 \
   --start-date 2026-04-01 --end-date 2026-04-03 \
   --species-limit 500 --dry-run
 
-# Inspect approved, pending, and failed work.
+# Preview and explicitly trust every plate already in this local catalog.
+uv run inky-bird-frame collection import-approved --config config.toml --dry-run
+uv run inky-bird-frame collection import-approved --config config.toml
+
+# Inspect or adjust persistent local membership one taxon at a time.
+uv run inky-bird-frame collection list --config config.toml
+uv run inky-bird-frame collection add 12942 --config config.toml
+uv run inky-bird-frame collection remove 12942 --config config.toml --dry-run
+
+# Inspect approved, actionable, deferred, terminal-blocked, and failed work.
 uv run inky-bird-frame status --config config.toml
 
 # Serve the catalog and rotate the next approved plate.
@@ -252,6 +261,14 @@ Choose `last-day`, `last-week`, `last-30-days`, `last-year`, or `all-time` for
 the observation window. Provider limits still apply. The
 [discovery guide](docs/discovery.md) explains credentials, merging, privacy,
 and those limits.
+
+The active display catalog contains approved taxa that are either currently
+observed or members of the private collection. Observation metadata wins when a
+taxon appears in both. Collection-only plates carry no invented observation
+count or detection timestamp. Catalog synchronization never adds collection
+membership by itself; use an observation, `seed`, `collection add`, or the
+explicit one-time `collection import-approved` command to make a new catalog
+taxon locally eligible.
 
 Rotation modes are `sequential`, `shuffle`, `shuffle_bag`, and `weighted`.
 `shuffle_bag` is the default: it shows every active bird once before starting a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,8 +26,15 @@ An observation refresh:
 2. queries each explicitly configured observation provider independently;
 3. exact-matches external taxonomy to canonical iNaturalist species IDs;
 4. atomically stores the private observation snapshot; and
-5. publishes a private active catalog containing only observed taxa that
-   already have approved plates.
+5. publishes a private active catalog containing approved taxa that are either
+   observed now or retained in the private local collection.
+
+The collection is a private, schema-versioned membership set. It stores only a
+taxon ID, the initial membership origin, and a timestamp. A historical `seed`
+adds every discovered taxon to this set while separately queueing missing
+plates. `collection import-approved` is the explicit migration and trust step
+for an existing catalog; later catalog synchronization does not mutate the
+collection.
 
 A locked generation cycle reads the latest non-stale snapshot and the durable
 seed queue. Current observations take priority over queued seed taxa. The cycle
@@ -43,7 +50,13 @@ then:
    attempt limit;
 8. atomically publishes passing output through the pending queue; and
 9. immediately rebuilds the private active catalog from the latest observation
-   snapshot.
+   snapshot plus collection membership.
+
+For active taxa present in the observation snapshot, provider count and latest
+detection metadata override the location-neutral catalog entry. Collection-only
+taxa omit observation metadata. This preserves active-catalog schema version 1
+and gives weighted rotation its existing neutral fallback weight without
+inventing evidence.
 
 Plate rulers are vertical schematic body-length keys: they show the sourced
 range and units, are labeled as not to scale, remain separate from the specimen,
@@ -148,6 +161,7 @@ unchanged. The next scheduled cycle retries from the current remote branch.
 | rejected | Operator override rejected a candidate | No |
 | failed | Generation exhausted its bounded attempts | No |
 | queued | Broader seed discovery awaits generation | Yes |
+| terminal-blocked | A queued taxon also has rejected or failed state | No |
 | eligible | No terminal state exists | Yes |
 
 `retry TAXON_ID` archives rejected or failed state and makes that taxon
@@ -160,10 +174,11 @@ provenance. Approved art is never replaced implicitly.
 
 ## Privacy and licensing
 
-The private discovery location and observation window influence the generation queue and
-active rotation. They are not passed to image generation and are not stored in
-catalog manifests. Observation snapshots and counts stay in ignored
-controller state.
+The private discovery location and observation window influence the generation
+queue and active rotation. They are not passed to image generation and are not
+stored in catalog manifests. Observation snapshots and counts stay in ignored
+controller state. Collection state records taxon membership only; it never
+stores locations, raw observations, or provider counts.
 
 Reference acquisition accepts only iNaturalist research-grade photos marked
 CC0 or CC BY, uses distinct observers, records attribution and source URLs, and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,12 +34,14 @@ taxon ID, the initial membership origin, and a timestamp. A historical `seed`
 adds every discovered taxon to this set while separately queueing missing
 plates. `collection import-approved` is the explicit migration and trust step
 for an existing catalog; later catalog synchronization does not mutate the
-collection. Before generation can consume work, it idempotently backfills any
-pre-collection seed-queue taxa into membership.
+collection. The first seed, collection mutation, or generation cycle imports
+any pre-collection seed-queue taxa and records a one-time migration timestamp.
+This happens before pending approvals and prevents a later cycle from undoing
+an explicit collection removal.
 
-A locked generation cycle reads the latest non-stale snapshot and the durable
-seed queue. Current observations take priority over queued seed taxa. The cycle
-then:
+A locked generation cycle completes that migration, recovers passing pending
+work, and then reads the latest non-stale snapshot and durable seed queue.
+Current observations take priority over queued seed taxa. The cycle then:
 
 1. selects taxa without a terminal local state;
 2. acquires and verifies licensed references;
@@ -159,14 +161,15 @@ unchanged. The next scheduled cycle retries from the current remote branch.
 | --- | --- | --- |
 | approved | Independent Codex review passed; published immutably | No |
 | pending | Passing candidate awaiting atomic publication or crash recovery | No |
+| incomplete pending | Interrupted candidate directory without a manifest | No |
 | rejected | Operator override rejected a candidate | No |
 | failed | Generation exhausted its bounded attempts | No |
 | queued | Broader seed discovery awaits generation | Yes |
-| terminal-blocked | A queued taxon also has rejected or failed state | No |
+| terminal-blocked | A queued taxon also has incomplete pending, rejected, or failed state | No |
 | eligible | No terminal state exists | Yes |
 
-`retry TAXON_ID` archives rejected or failed state and makes that taxon
-eligible. For failed quality reviews, it retains the final actionable
+`retry TAXON_ID` archives incomplete pending, rejected, or failed state and
+makes that taxon eligible. For failed quality reviews, it retains the final actionable
 corrections as durable input to the first new generation attempt while
 refreshing cached research. `retry TAXON_ID --source-attempt N` additionally
 selects a retained portrait as the edit base. The archive-relative source path

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,8 @@ taxon ID, the initial membership origin, and a timestamp. A historical `seed`
 adds every discovered taxon to this set while separately queueing missing
 plates. `collection import-approved` is the explicit migration and trust step
 for an existing catalog; later catalog synchronization does not mutate the
-collection.
+collection. Before generation can consume work, it idempotently backfills any
+pre-collection seed-queue taxa into membership.
 
 A locked generation cycle reads the latest non-stale snapshot and the durable
 seed queue. Current observations take priority over queued seed taxa. The cycle

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -199,8 +199,16 @@ inky-bird-frame seed --config /path/to/config.toml \
 Exact date ranges require iNaturalist because the other configured providers
 cannot guarantee the same coordinate-radius historical query semantics. Run
 without `--dry-run` only after reviewing the structured result. The seed stores
-distinct taxa in the generation queue, not raw observation records or the
-command-scoped coordinates.
+every distinct taxon as private collection membership and queues only missing,
+non-terminal plates. It stores no raw observation records or command-scoped
+coordinates. Approved seeded taxa become active immediately; unapproved taxa
+become active after a plate passes review and approval.
+
+Collection membership is independent from catalog synchronization. A plate
+added to the public catalog later is not added to the private collection merely
+because it was downloaded. Use `collection import-approved` for an explicit
+point-in-time migration or `collection add TAXON_ID` for one taxon. Current
+observations remain an independent source of active eligibility.
 
 Repeat `--source` for a multi-provider seed, for example `--source inaturalist
 --source ebird`. CLI overrides accept concrete providers rather than legacy

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -244,10 +244,14 @@ curl --fail --silent "http://127.0.0.1:8793/health"
 
 The health response must have `"ok": true`. `approved_species` is the reusable
 catalog size. `active_species` is the approved subset currently observed in the
-configured window and radius. It may initially be zero in a region whose birds
-have not been generated yet. Both counts are read from the last built catalog
-index rather than a fresh catalog scan, so the endpoint stays fast as the
-catalog grows.
+configured window and radius or retained in the private collection. It may
+initially be zero in a region whose birds have not been generated yet. Both
+counts are read from the last built catalog index rather than a fresh catalog
+scan, so the endpoint stays fast as the catalog grows.
+
+An existing controller can explicitly retain every currently approved plate
+after upgrading by previewing and applying `collection import-approved`; see
+the [operations guide](operations.md#seed-and-manage-a-private-collection).
 
 ## 2. Prepare the display Pi
 
@@ -483,7 +487,8 @@ just pulled rather than the previous managed copy.
 When the controller and display are updated separately, update display nodes
 first. The active catalog wire format is `schema_version: 1`, and a display
 node refuses a catalog with a newer schema version: the cycle fails closed
-and the panel keeps its last image until the display is updated.
+and the panel keeps its last image until the display is updated. Private
+collection membership does not change this wire schema.
 
 Docker controller updates pull a published image and recreate the services. See
 the [Docker update instructions](docker.md#update) for version pinning and

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -144,8 +144,9 @@ inky-bird-frame collection list --config /path/to/config.toml
 ```
 
 The import is a point-in-time trust decision. Later catalog synchronization does
-not silently add new members. Manage individual taxa with the same previewable
-commands:
+not silently add new members. On upgrade, the first generation cycle also
+backfills taxa already present in a pre-0.2.4 seed queue before it can consume
+that queue. Manage individual taxa with the same previewable commands:
 
 ```bash
 inky-bird-frame collection add 12942 --config /path/to/config.toml --dry-run

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -99,11 +99,12 @@ and display state paths remain TOML configuration. Installer bootstrap paths,
 including the TOML path itself, remain environment variables because the
 installer must find the configuration before it can load it.
 
-## Seed a broader catalog
+## Seed and manage a private collection
 
-The active display window and the generation backlog are separate. Use `seed`
-to enqueue distinct taxa from a broader period without changing which birds are
-currently active on the display:
+The current observation snapshot, private collection, and generation backlog
+are separate state. Use `seed` to add every distinct discovered taxon to the
+private collection and enqueue any missing plate without changing the
+configured discovery location or current observation snapshot:
 
 ```bash
 inky-bird-frame seed --config /path/to/config.toml \
@@ -127,8 +128,57 @@ beyond 30 days or guarantee arbitrary coordinate-radius historical windows, so
 exact date ranges require iNaturalist. `--latitude` and `--longitude` must be
 provided together and do not change the configured location. The configured
 radius is used unless `--radius-km` is provided. Repeating a seed
-is idempotent: approved, terminal, and already queued taxa are not added again.
-Current observations remain ahead of seed-only taxa during generation.
+is idempotent: collection members and queued taxa are not duplicated. Approved
+seeded taxa become active immediately; unapproved taxa remain members while
+their missing plates move through generation. Terminal taxa stay blocked until
+an explicit `retry`. Current observations remain ahead of seed-only taxa during
+generation.
+
+To migrate an existing local catalog, preview and then explicitly import its
+currently approved taxa:
+
+```bash
+inky-bird-frame collection import-approved --config /path/to/config.toml --dry-run
+inky-bird-frame collection import-approved --config /path/to/config.toml
+inky-bird-frame collection list --config /path/to/config.toml
+```
+
+The import is a point-in-time trust decision. Later catalog synchronization does
+not silently add new members. Manage individual taxa with the same previewable
+commands:
+
+```bash
+inky-bird-frame collection add 12942 --config /path/to/config.toml --dry-run
+inky-bird-frame collection add 12942 --config /path/to/config.toml
+inky-bird-frame collection remove 12942 --config /path/to/config.toml --dry-run
+inky-bird-frame collection remove 12942 --config /path/to/config.toml
+```
+
+Removal clears persistent membership but does not suppress a taxon that is also
+in the current observation snapshot. The private `collection.json` stores only
+taxon ID, initial membership origin, and timestamp. It stores no coordinates,
+raw observations, names, or provider counts.
+
+The active catalog contains approved taxa in either current observations or the
+private collection. When both contain a taxon, current observation count and
+latest BirdWeather detection metadata take precedence. Collection-only entries
+omit both fields; weighted rotation uses the display node's existing neutral
+weight of one instead of fabricated evidence.
+
+## Interpret generation status
+
+`status` separates persistent generation work into these views:
+
+- `queued`: unapproved seed-queue taxa still eligible for automatic work;
+- `deferred`: the subset governed by a durable retry schedule after a transient
+  failure; and
+- `terminal_blocked`: queued taxa with rejected or exhausted failed state that
+  require explicit `retry`.
+
+`deferred` can overlap `queued`; it explains when an otherwise actionable taxon
+will be attempted again. `terminal_blocked` never counts toward `queued_count`
+in generation-cycle output. Passing pending candidates remain visible in the
+separate `pending` view and are recovered at the start of a generation cycle.
 
 ## Run a combined cycle
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -144,9 +144,12 @@ inky-bird-frame collection list --config /path/to/config.toml
 ```
 
 The import is a point-in-time trust decision. Later catalog synchronization does
-not silently add new members. On upgrade, the first generation cycle also
-backfills taxa already present in a pre-0.2.4 seed queue before it can consume
-that queue. Manage individual taxa with the same previewable commands:
+not silently add new members. On upgrade, the first seed, collection mutation,
+or generation cycle also imports taxa already present in a pre-0.2.4 seed queue
+and records a one-time migration timestamp. Generation performs this step
+before pending approval recovery. The marker prevents later cycles from
+re-adding a taxon after an explicit removal. Manage individual taxa with the
+same previewable commands:
 
 ```bash
 inky-bird-frame collection add 12942 --config /path/to/config.toml --dry-run
@@ -157,8 +160,9 @@ inky-bird-frame collection remove 12942 --config /path/to/config.toml
 
 Removal clears persistent membership but does not suppress a taxon that is also
 in the current observation snapshot. The private `collection.json` stores only
-taxon ID, initial membership origin, and timestamp. It stores no coordinates,
-raw observations, names, or provider counts.
+taxon ID, initial membership origin, membership timestamp, and the one-time
+queue-migration timestamp. It stores no coordinates, raw observations, names,
+or provider counts.
 
 The active catalog contains approved taxa in either current observations or the
 private collection. When both contain a taxon, current observation count and
@@ -173,13 +177,16 @@ weight of one instead of fabricated evidence.
 - `queued`: unapproved seed-queue taxa still eligible for automatic work;
 - `deferred`: the subset governed by a durable retry schedule after a transient
   failure; and
-- `terminal_blocked`: queued taxa with rejected or exhausted failed state that
-  require explicit `retry`.
+- `terminal_blocked`: queued taxa with an incomplete pending directory,
+  rejected state, or exhausted failed state that require explicit `retry`.
 
 `deferred` can overlap `queued`; it explains when an otherwise actionable taxon
 will be attempted again. `terminal_blocked` never counts toward `queued_count`
 in generation-cycle output. Passing pending candidates remain visible in the
 separate `pending` view and are recovered at the start of a generation cycle.
+An interrupted pending directory without a manifest appears as
+`incomplete_pending` under `terminal_blocked`; `retry TAXON_ID` archives the
+partial directory before making the taxon eligible again.
 
 ## Run a combined cycle
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.2.3"
+version = "0.2.4"
 description = "Generate and display reusable bird field-journal plates"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -45,6 +45,12 @@ class CollectionEntry:
         }
 
 
+@dataclass(frozen=True)
+class CollectionState:
+    entries: list[CollectionEntry]
+    legacy_seed_queue_migrated_at: str | None
+
+
 @contextmanager
 def catalog_state_lock(state_dir: Path) -> Iterator[None]:
     state_dir.mkdir(parents=True, exist_ok=True)
@@ -93,16 +99,26 @@ def utc_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat()
 
 
-def read_collection(state_dir: Path) -> list[CollectionEntry]:
+def read_collection_state(state_dir: Path) -> CollectionState:
     path = state_dir / "collection.json"
     if not path.exists():
-        return []
+        return CollectionState([], None)
     raw = read_json(path)
     if (
         not isinstance(raw, dict)
-        or set(raw) != {"schema_version", "updated_at", "taxa"}
+        or set(raw)
+        != {
+            "schema_version",
+            "updated_at",
+            "legacy_seed_queue_migrated_at",
+            "taxa",
+        }
         or raw.get("schema_version") != COLLECTION_SCHEMA_VERSION
         or parse_utc_timestamp(raw.get("updated_at")) is None
+        or (
+            raw.get("legacy_seed_queue_migrated_at") is not None
+            and parse_utc_timestamp(raw.get("legacy_seed_queue_migrated_at")) is None
+        )
         or not isinstance(raw.get("taxa"), list)
     ):
         raise CatalogError(f"Invalid collection state: {path}")
@@ -131,10 +147,27 @@ def read_collection(state_dir: Path) -> list[CollectionEntry]:
             raise CatalogError(f"Invalid collection entry: {path}") from exc
         seen.add(taxon_id)
         entries.append(CollectionEntry(taxon_id, added_at, parsed_origin))
-    return sorted(entries, key=lambda entry: entry.taxon_id)
+    return CollectionState(
+        sorted(entries, key=lambda entry: entry.taxon_id),
+        cast(str | None, raw["legacy_seed_queue_migrated_at"]),
+    )
 
 
-def write_collection(state_dir: Path, entries: list[CollectionEntry]) -> None:
+def read_collection(state_dir: Path) -> list[CollectionEntry]:
+    return read_collection_state(state_dir).entries
+
+
+def write_collection(
+    state_dir: Path,
+    entries: list[CollectionEntry],
+    *,
+    legacy_seed_queue_migrated_at: str | None,
+) -> None:
+    if (
+        legacy_seed_queue_migrated_at is not None
+        and parse_utc_timestamp(legacy_seed_queue_migrated_at) is None
+    ):
+        raise CatalogError("Cannot write invalid collection state")
     seen: set[int] = set()
     for entry in entries:
         if (
@@ -151,6 +184,7 @@ def write_collection(state_dir: Path, entries: list[CollectionEntry]) -> None:
         {
             "schema_version": COLLECTION_SCHEMA_VERSION,
             "updated_at": utc_now(),
+            "legacy_seed_queue_migrated_at": legacy_seed_queue_migrated_at,
             "taxa": [entry.as_dict() for entry in sorted(entries, key=lambda item: item.taxon_id)],
         },
     )

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -10,6 +10,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path
 from typing import cast
 
@@ -18,8 +19,30 @@ from .errors import CatalogError
 from .http import write_json_atomic
 from .images import slugify
 from .models import QualityReview, ReferencePhoto, SpeciesProfileData
+from .timeutil import parse_utc_timestamp
 
 SCHEMA_VERSION = 1
+COLLECTION_SCHEMA_VERSION = 1
+
+
+class CollectionOrigin(StrEnum):
+    MANUAL = "manual"
+    CATALOG_IMPORT = "catalog_import"
+    HISTORICAL_SEED = "historical_seed"
+
+
+@dataclass(frozen=True)
+class CollectionEntry:
+    taxon_id: int
+    added_at: str
+    origin: CollectionOrigin
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "taxon_id": self.taxon_id,
+            "added_at": self.added_at,
+            "origin": self.origin.value,
+        }
 
 
 @contextmanager
@@ -68,6 +91,95 @@ class CatalogEntry:
 
 def utc_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat()
+
+
+def read_collection(state_dir: Path) -> list[CollectionEntry]:
+    path = state_dir / "collection.json"
+    if not path.exists():
+        return []
+    raw = read_json(path)
+    if (
+        not isinstance(raw, dict)
+        or set(raw) != {"schema_version", "updated_at", "taxa"}
+        or raw.get("schema_version") != COLLECTION_SCHEMA_VERSION
+        or parse_utc_timestamp(raw.get("updated_at")) is None
+        or not isinstance(raw.get("taxa"), list)
+    ):
+        raise CatalogError(f"Invalid collection state: {path}")
+
+    entries: list[CollectionEntry] = []
+    seen: set[int] = set()
+    for item in cast(list[object], raw["taxa"]):
+        if not isinstance(item, dict) or set(item) != {"taxon_id", "added_at", "origin"}:
+            raise CatalogError(f"Invalid collection entry: {path}")
+        taxon_id = item.get("taxon_id")
+        added_at = item.get("added_at")
+        origin = item.get("origin")
+        if (
+            not isinstance(taxon_id, int)
+            or isinstance(taxon_id, bool)
+            or taxon_id <= 0
+            or taxon_id in seen
+            or not isinstance(added_at, str)
+            or parse_utc_timestamp(added_at) is None
+            or not isinstance(origin, str)
+        ):
+            raise CatalogError(f"Invalid collection entry: {path}")
+        try:
+            parsed_origin = CollectionOrigin(origin)
+        except ValueError as exc:
+            raise CatalogError(f"Invalid collection entry: {path}") from exc
+        seen.add(taxon_id)
+        entries.append(CollectionEntry(taxon_id, added_at, parsed_origin))
+    return sorted(entries, key=lambda entry: entry.taxon_id)
+
+
+def write_collection(state_dir: Path, entries: list[CollectionEntry]) -> None:
+    seen: set[int] = set()
+    for entry in entries:
+        if (
+            not isinstance(entry.taxon_id, int)
+            or isinstance(entry.taxon_id, bool)
+            or entry.taxon_id <= 0
+            or entry.taxon_id in seen
+            or parse_utc_timestamp(entry.added_at) is None
+        ):
+            raise CatalogError("Cannot write invalid collection state")
+        seen.add(entry.taxon_id)
+    write_json_atomic(
+        state_dir / "collection.json",
+        {
+            "schema_version": COLLECTION_SCHEMA_VERSION,
+            "updated_at": utc_now(),
+            "taxa": [entry.as_dict() for entry in sorted(entries, key=lambda item: item.taxon_id)],
+        },
+    )
+
+
+def add_collection_taxa(
+    entries: list[CollectionEntry],
+    taxon_ids: set[int],
+    origin: CollectionOrigin,
+) -> tuple[list[CollectionEntry], list[CollectionEntry]]:
+    if any(
+        not isinstance(taxon_id, int) or isinstance(taxon_id, bool) or taxon_id <= 0
+        for taxon_id in taxon_ids
+    ):
+        raise ValueError("collection taxon IDs must be positive integers")
+    existing_ids = {entry.taxon_id for entry in entries}
+    added_at = utc_now()
+    added = [
+        CollectionEntry(taxon_id, added_at, origin) for taxon_id in sorted(taxon_ids - existing_ids)
+    ]
+    return sorted([*entries, *added], key=lambda entry: entry.taxon_id), added
+
+
+def remove_collection_taxa(
+    entries: list[CollectionEntry], taxon_ids: set[int]
+) -> tuple[list[CollectionEntry], list[CollectionEntry]]:
+    removed = [entry for entry in entries if entry.taxon_id in taxon_ids]
+    remaining = [entry for entry in entries if entry.taxon_id not in taxon_ids]
+    return remaining, removed
 
 
 def sha256_file(path: Path) -> str:

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -454,7 +454,8 @@ def _retry_quality_guidance(
 def retry_command(args: argparse.Namespace) -> int:
     config = _config(args)
     with exclusive_cycle_lock(config.controller.state_dir):
-        if find_taxon_directory(config.controller.state_dir / "pending", args.taxon_id):
+        pending = find_taxon_directory(config.controller.state_dir / "pending", args.taxon_id)
+        if pending is not None and (pending / "manifest.json").is_file():
             raise ValueError("Pending candidates must be approved or rejected before retrying")
         failed_directories = sorted(
             (config.controller.state_dir / "failed").glob(f"{args.taxon_id}-*")
@@ -464,7 +465,8 @@ def retry_command(args: argparse.Namespace) -> int:
             failed_directories,
             source_attempt,
         )
-        sources = list(failed_directories)
+        sources = [pending] if pending is not None else []
+        sources.extend(failed_directories)
         rejected = find_taxon_directory(config.controller.state_dir / "rejected", args.taxon_id)
         if rejected is not None:
             sources.append(rejected)

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -32,10 +32,14 @@ from .config import (
 )
 from .controller import (
     REVIEW_FAILURE_FALLBACK,
+    add_collection_member,
+    collection_status,
     discover_species,
     enqueue_seed_species,
     exclusive_cycle_lock,
-    read_generation_queue,
+    import_approved_collection,
+    read_generation_queue_partition,
+    remove_collection_member,
     run_controller_cycle,
     run_generation_cycle,
     run_refresh_cycle,
@@ -351,6 +355,26 @@ def seed_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def collection_list_command(args: argparse.Namespace) -> int:
+    print_result(collection_status(_config(args)))
+    return 0
+
+
+def collection_import_command(args: argparse.Namespace) -> int:
+    print_result(import_approved_collection(_config(args), dry_run=args.dry_run))
+    return 0
+
+
+def collection_add_command(args: argparse.Namespace) -> int:
+    print_result(add_collection_member(_config(args), args.taxon_id, dry_run=args.dry_run))
+    return 0
+
+
+def collection_remove_command(args: argparse.Namespace) -> int:
+    print_result(remove_collection_member(_config(args), args.taxon_id, dry_run=args.dry_run))
+    return 0
+
+
 def approve_command(args: argparse.Namespace) -> int:
     config = _config(args)
     entry = approve_candidate(
@@ -515,7 +539,8 @@ def retry_command(args: argparse.Namespace) -> int:
 def status_command(args: argparse.Namespace) -> int:
     config = _config(args)
     entries = rebuild_catalog_index(config.controller.catalog_dir)
-    queued = read_generation_queue(config)
+    queue = read_generation_queue_partition(config, approved={entry.taxon_id for entry in entries})
+    collection = collection_status(config, approved=entries)
     retries = RetryStore(config.controller.state_dir / "generation-retries.json")
     pending = []
     for path in sorted((config.controller.state_dir / "pending").glob("*/manifest.json")):
@@ -532,8 +557,10 @@ def status_command(args: argparse.Namespace) -> int:
     print_result(
         {
             "approved": [entry.as_dict() for entry in entries],
+            "collection": {key: value for key, value in collection.items() if key != "members"},
             "pending": pending,
-            "queued": [species_to_dict(item) for item in queued],
+            "queued": [species_to_dict(item) for item in queue.actionable],
+            "terminal_blocked": [entry.as_dict() for entry in queue.terminal_blocked],
             "deferred": [record.as_dict() for record in retries.records()],
             "failed": [
                 str(path) for path in sorted((config.controller.state_dir / "failed").glob("*"))
@@ -899,7 +926,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     seed_parser = subparsers.add_parser(
         "seed",
-        help="Queue distinct species from a broader observation window for generation",
+        help="Add broader observations to the private collection and generation queue",
     )
     add_config_argument(seed_parser)
     seed_period = seed_parser.add_mutually_exclusive_group(required=True)
@@ -921,6 +948,38 @@ def build_parser() -> argparse.ArgumentParser:
     seed_parser.add_argument("--species-limit", type=int)
     seed_parser.add_argument("--dry-run", action="store_true")
     seed_parser.set_defaults(func=seed_command)
+
+    collection_parser = subparsers.add_parser(
+        "collection", help="Manage private local display membership"
+    )
+    collection_subparsers = collection_parser.add_subparsers(
+        dest="collection_command", required=True
+    )
+    collection_list_parser = collection_subparsers.add_parser(
+        "list", help="List private collection membership and activation state"
+    )
+    add_config_argument(collection_list_parser)
+    collection_list_parser.set_defaults(func=collection_list_command)
+    collection_import_parser = collection_subparsers.add_parser(
+        "import-approved", help="Explicitly add every currently approved local plate"
+    )
+    add_config_argument(collection_import_parser)
+    collection_import_parser.add_argument("--dry-run", action="store_true")
+    collection_import_parser.set_defaults(func=collection_import_command)
+    collection_add_parser = collection_subparsers.add_parser(
+        "add", help="Add one taxon to the private collection"
+    )
+    add_config_argument(collection_add_parser)
+    collection_add_parser.add_argument("taxon_id", type=int)
+    collection_add_parser.add_argument("--dry-run", action="store_true")
+    collection_add_parser.set_defaults(func=collection_add_command)
+    collection_remove_parser = collection_subparsers.add_parser(
+        "remove", help="Remove one taxon from the private collection"
+    )
+    add_config_argument(collection_remove_parser)
+    collection_remove_parser.add_argument("taxon_id", type=int)
+    collection_remove_parser.add_argument("--dry-run", action="store_true")
+    collection_remove_parser.set_defaults(func=collection_remove_command)
 
     approve_parser = subparsers.add_parser("approve", help="Publish a pending candidate")
     add_config_argument(approve_parser)

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -1169,6 +1169,14 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
             )
         species_list = snapshot.species
         queued_species = read_generation_queue(config)
+        with catalog_state_lock(config.controller.state_dir):
+            collection, migrated_collection = add_collection_taxa(
+                read_collection(config.controller.state_dir),
+                {species.taxon_id for species in queued_species},
+                CollectionOrigin.HISTORICAL_SEED,
+            )
+            if migrated_collection:
+                write_collection(config.controller.state_dir, collection)
         generation_species = list(species_list)
         observed_taxa = {species.taxon_id for species in species_list}
         generation_species.extend(
@@ -1343,6 +1351,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
             "deferred_count": len(deferred),
             "deferred": [record.as_dict() for record in deferred],
             "outstanding_retry_count": len(outstanding_retries),
+            "migrated_collection_count": len(migrated_collection),
             "queued_count": len(queue_partition.actionable),
             "terminal_blocked_count": len(queue_partition.terminal_blocked),
             "terminal_blocked": [entry.as_dict() for entry in queue_partition.terminal_blocked],

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -28,6 +28,10 @@ from .birds import (
     resolve_ebird_species,
 )
 from .catalog import (
+    CatalogEntry,
+    CollectionEntry,
+    CollectionOrigin,
+    add_collection_taxa,
     approve_candidate,
     approved_taxon_ids,
     candidate_directory,
@@ -36,10 +40,14 @@ from .catalog import (
     find_taxon_directory,
     has_passing_sourced_review,
     is_bounded_generation,
+    read_catalog_entries,
+    read_collection,
     rebuild_catalog_index,
+    remove_collection_taxa,
     sha256_file,
     utc_now,
     write_candidate_manifest,
+    write_collection,
 )
 from .codex_runner import CodexRunner, parse_species_profile
 from .config import AppConfig, DiscoveryProvider, discovery_source_label
@@ -100,6 +108,26 @@ class DiscoveryResult:
     species: list[BirdSpecies]
     providers: list[ProviderStatus]
     unresolved: list[EbirdSpecies | BirdWeatherSpecies]
+
+
+@dataclass(frozen=True)
+class TerminalQueueEntry:
+    species: BirdSpecies
+    state: str
+    paths: tuple[Path, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            **_species_payload(self.species),
+            "terminal_state": self.state,
+            "paths": [str(path) for path in self.paths],
+        }
+
+
+@dataclass(frozen=True)
+class GenerationQueuePartition:
+    actionable: list[BirdSpecies]
+    terminal_blocked: list[TerminalQueueEntry]
 
 
 @contextmanager
@@ -477,26 +505,38 @@ def enqueue_seed_species(
             persist_taxonomy_cache=not dry_run,
         )
         discovered = discovery.species
-        approved = approved_taxon_ids(config.controller.catalog_dir)
-        existing = [
-            species for species in read_generation_queue(config) if species.taxon_id not in approved
-        ]
-        eligible = [
-            species
-            for species in discovered
-            if species.taxon_id not in approved
-            and not _has_terminal_state(config.controller.state_dir, species.taxon_id)
-        ]
-        queued_by_taxon = {species.taxon_id: species for species in existing}
-        added: list[BirdSpecies] = []
-        for species in eligible:
-            if species.taxon_id in queued_by_taxon:
-                continue
-            queued_by_taxon[species.taxon_id] = species
-            added.append(species)
-        queued = list(queued_by_taxon.values())
-        if not dry_run:
-            _write_generation_queue(config, queued)
+        state_lock = nullcontext() if dry_run else catalog_state_lock(config.controller.state_dir)
+        with state_lock:
+            approved = approved_taxon_ids(config.controller.catalog_dir)
+            existing = [
+                species
+                for species in read_generation_queue(config)
+                if species.taxon_id not in approved
+            ]
+            eligible = [
+                species
+                for species in discovered
+                if species.taxon_id not in approved
+                and not _has_terminal_state(config.controller.state_dir, species.taxon_id)
+            ]
+            queued_by_taxon = {species.taxon_id: species for species in existing}
+            added: list[BirdSpecies] = []
+            for species in eligible:
+                if species.taxon_id in queued_by_taxon:
+                    continue
+                queued_by_taxon[species.taxon_id] = species
+                added.append(species)
+            queued = list(queued_by_taxon.values())
+            collection, collection_added = add_collection_taxa(
+                read_collection(config.controller.state_dir),
+                {species.taxon_id for species in discovered},
+                CollectionOrigin.HISTORICAL_SEED,
+            )
+            if not dry_run:
+                _write_generation_queue(config, queued)
+                if collection_added:
+                    write_collection(config.controller.state_dir, collection)
+                _write_active_catalog(config, _current_discovery_species(config))
 
     return {
         "window": window.value if window is not None else None,
@@ -519,25 +559,37 @@ def enqueue_seed_species(
         "eligible_count": len(eligible),
         "added_count": len(added),
         "queued_count": len(queued),
+        "collection_added_count": len(collection_added),
+        "collection_count": len(collection),
         "dry_run": dry_run,
         "added": [_species_payload(species) for species in added],
+        "collection_added_taxon_ids": [entry.taxon_id for entry in collection_added],
         "providers": [provider.as_dict() for provider in discovery.providers],
         "unresolved_count": len(discovery.unresolved),
     }
 
 
-def _write_active_catalog(config: AppConfig, species_list: list[BirdSpecies]) -> int:
-    approved = rebuild_catalog_index(config.controller.catalog_dir)
+def _write_active_catalog(
+    config: AppConfig,
+    species_list: list[BirdSpecies],
+    *,
+    approved: list[CatalogEntry] | None = None,
+) -> int:
+    approved_entries = (
+        approved if approved is not None else rebuild_catalog_index(config.controller.catalog_dir)
+    )
     observed = {species.taxon_id: species for species in species_list}
+    collection_taxa = {entry.taxon_id for entry in read_collection(config.controller.state_dir)}
     active: list[dict[str, object]] = []
-    for entry in approved:
+    for entry in approved_entries:
         species = observed.get(entry.taxon_id)
-        if species is None:
+        if species is None and entry.taxon_id not in collection_taxa:
             continue
         value = entry.as_dict()
-        value["observation_count"] = species.observation_count
-        if species.latest_detection_at is not None:
-            value["latest_detection_at"] = species.latest_detection_at
+        if species is not None:
+            value["observation_count"] = species.observation_count
+            if species.latest_detection_at is not None:
+                value["latest_detection_at"] = species.latest_detection_at
         active.append(value)
     write_json_atomic(
         _active_catalog_path(config),
@@ -624,6 +676,136 @@ def _read_discovery_snapshot(config: AppConfig) -> DiscoverySnapshot:
 
     species = _parse_species_list(species_raw, path)
     return DiscoverySnapshot(refreshed, place_name, state, species)
+
+
+def _current_discovery_species(config: AppConfig) -> list[BirdSpecies]:
+    if not _snapshot_path(config).exists():
+        return []
+    return _read_discovery_snapshot(config).species
+
+
+def _collection_summary(
+    entries: list[CollectionEntry],
+    approved: list[CatalogEntry],
+    observed: list[BirdSpecies],
+) -> dict[str, object]:
+    approved_by_taxon = {entry.taxon_id: entry for entry in approved}
+    observed_taxa = {species.taxon_id for species in observed}
+    collection_taxa = {entry.taxon_id for entry in entries}
+    active_taxa = set(approved_by_taxon) & (observed_taxa | collection_taxa)
+    members: list[dict[str, object]] = []
+    for entry in entries:
+        approved_entry = approved_by_taxon.get(entry.taxon_id)
+        member = {
+            **entry.as_dict(),
+            "approved": approved_entry is not None,
+            "observed": entry.taxon_id in observed_taxa,
+            "active": entry.taxon_id in active_taxa,
+        }
+        if approved_entry is not None:
+            member["common_name"] = approved_entry.common_name
+            member["scientific_name"] = approved_entry.scientific_name
+        members.append(member)
+    return {
+        "collection_count": len(entries),
+        "approved_member_count": sum(entry.taxon_id in approved_by_taxon for entry in entries),
+        "active_approved_count": len(active_taxa),
+        "members": members,
+    }
+
+
+def collection_status(
+    config: AppConfig, *, approved: list[CatalogEntry] | None = None
+) -> dict[str, object]:
+    return _collection_summary(
+        read_collection(config.controller.state_dir),
+        approved if approved is not None else read_catalog_entries(config.controller.catalog_dir),
+        _current_discovery_species(config),
+    )
+
+
+def _change_collection(
+    config: AppConfig,
+    *,
+    taxon_ids: set[int] | None,
+    origin: CollectionOrigin | None,
+    remove: bool,
+    dry_run: bool,
+) -> dict[str, object]:
+    if taxon_ids is not None and any(
+        not isinstance(taxon_id, int) or isinstance(taxon_id, bool) or taxon_id <= 0
+        for taxon_id in taxon_ids
+    ):
+        raise ValueError("collection taxon IDs must be positive integers")
+    cycle_lock = nullcontext() if dry_run else exclusive_cycle_lock(config.controller.state_dir)
+    with cycle_lock:
+        state_lock = nullcontext() if dry_run else catalog_state_lock(config.controller.state_dir)
+        with state_lock:
+            approved = read_catalog_entries(config.controller.catalog_dir)
+            requested_taxa = (
+                {entry.taxon_id for entry in approved} if taxon_ids is None else taxon_ids
+            )
+            current = read_collection(config.controller.state_dir)
+            if remove:
+                updated, removed = remove_collection_taxa(current, requested_taxa)
+                added: list[CollectionEntry] = []
+            else:
+                if origin is None:
+                    raise ValueError("collection additions require an origin")
+                updated, added = add_collection_taxa(current, requested_taxa, origin)
+                removed = []
+            observed = _current_discovery_species(config)
+            summary = _collection_summary(updated, approved, observed)
+            if not dry_run:
+                if added or removed:
+                    write_collection(config.controller.state_dir, updated)
+                summary["active_approved_count"] = _write_active_catalog(
+                    config,
+                    observed,
+                    approved=approved,
+                )
+    return {
+        **{key: value for key, value in summary.items() if key != "members"},
+        "added_count": len(added),
+        "removed_count": len(removed),
+        "added_taxon_ids": [entry.taxon_id for entry in added],
+        "removed_taxon_ids": [entry.taxon_id for entry in removed],
+        "dry_run": dry_run,
+    }
+
+
+def import_approved_collection(config: AppConfig, *, dry_run: bool = False) -> dict[str, object]:
+    return _change_collection(
+        config,
+        taxon_ids=None,
+        origin=CollectionOrigin.CATALOG_IMPORT,
+        remove=False,
+        dry_run=dry_run,
+    )
+
+
+def add_collection_member(
+    config: AppConfig, taxon_id: int, *, dry_run: bool = False
+) -> dict[str, object]:
+    return _change_collection(
+        config,
+        taxon_ids={taxon_id},
+        origin=CollectionOrigin.MANUAL,
+        remove=False,
+        dry_run=dry_run,
+    )
+
+
+def remove_collection_member(
+    config: AppConfig, taxon_id: int, *, dry_run: bool = False
+) -> dict[str, object]:
+    return _change_collection(
+        config,
+        taxon_ids={taxon_id},
+        origin=None,
+        remove=True,
+        dry_run=dry_run,
+    )
 
 
 def _reference_from_dict(raw: object) -> ReferencePhoto:
@@ -884,11 +1066,50 @@ def _retry_source_plate(state_dir: Path, relative_path: str | None) -> Path | No
     return source
 
 
+def _terminal_state(state_dir: Path, taxon_id: int) -> tuple[str, tuple[Path, ...]] | None:
+    for category in ("pending", "rejected"):
+        path = find_taxon_directory(state_dir / category, taxon_id)
+        if path is not None:
+            return category, (path,)
+    failed = tuple(sorted((state_dir / "failed").glob(f"{taxon_id}-*")))
+    if failed:
+        return "failed", failed
+    return None
+
+
 def _has_terminal_state(state_dir: Path, taxon_id: int) -> bool:
-    return any(
-        find_taxon_directory(state_dir / category, taxon_id) is not None
-        for category in ("pending", "rejected")
-    ) or bool(list((state_dir / "failed").glob(f"{taxon_id}-*")))
+    return _terminal_state(state_dir, taxon_id) is not None
+
+
+def _partition_generation_queue(
+    state_dir: Path,
+    species_list: list[BirdSpecies],
+    approved: set[int],
+) -> GenerationQueuePartition:
+    actionable: list[BirdSpecies] = []
+    terminal_blocked: list[TerminalQueueEntry] = []
+    for species in species_list:
+        if species.taxon_id in approved:
+            continue
+        terminal = _terminal_state(state_dir, species.taxon_id)
+        if terminal is None:
+            actionable.append(species)
+            continue
+        state, paths = terminal
+        if state == "pending":
+            continue
+        terminal_blocked.append(TerminalQueueEntry(species, state, paths))
+    return GenerationQueuePartition(actionable, terminal_blocked)
+
+
+def read_generation_queue_partition(
+    config: AppConfig, *, approved: set[int] | None = None
+) -> GenerationQueuePartition:
+    return _partition_generation_queue(
+        config.controller.state_dir,
+        read_generation_queue(config),
+        approved if approved is not None else approved_taxon_ids(config.controller.catalog_dir),
+    )
 
 
 def record_failure(state_dir: Path, species: BirdSpecies, error: InkyBirdFrameError) -> Path:
@@ -1097,6 +1318,11 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 species for species in queued_species if species.taxon_id not in approved_after
             ]
             _write_generation_queue(config, remaining_queue)
+            queue_partition = _partition_generation_queue(
+                config.controller.state_dir,
+                remaining_queue,
+                approved_after,
+            )
         eligible_taxa = {species.taxon_id for species in eligible}
         deferred = retry_store.deferred(eligible_taxa, datetime.now(UTC))
         outstanding_retries = retry_store.outstanding(eligible_taxa)
@@ -1117,7 +1343,9 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
             "deferred_count": len(deferred),
             "deferred": [record.as_dict() for record in deferred],
             "outstanding_retry_count": len(outstanding_retries),
-            "queued_count": len(remaining_queue),
+            "queued_count": len(queue_partition.actionable),
+            "terminal_blocked_count": len(queue_partition.terminal_blocked),
+            "terminal_blocked": [entry.as_dict() for entry in queue_partition.terminal_blocked],
             "generated": generated,
             "failures": failures,
         }

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -31,6 +31,7 @@ from .catalog import (
     CatalogEntry,
     CollectionEntry,
     CollectionOrigin,
+    CollectionState,
     add_collection_taxa,
     approve_candidate,
     approved_taxon_ids,
@@ -42,6 +43,7 @@ from .catalog import (
     is_bounded_generation,
     read_catalog_entries,
     read_collection,
+    read_collection_state,
     rebuild_catalog_index,
     remove_collection_taxa,
     sha256_file,
@@ -468,6 +470,20 @@ def _write_generation_queue(config: AppConfig, species: list[BirdSpecies]) -> No
     )
 
 
+def _migrate_legacy_seed_queue(
+    state: CollectionState,
+    queued_species: list[BirdSpecies],
+) -> tuple[list[CollectionEntry], list[CollectionEntry], str, bool]:
+    if state.legacy_seed_queue_migrated_at is not None:
+        return state.entries, [], state.legacy_seed_queue_migrated_at, False
+    updated, added = add_collection_taxa(
+        state.entries,
+        {species.taxon_id for species in queued_species},
+        CollectionOrigin.HISTORICAL_SEED,
+    )
+    return updated, added, utc_now(), True
+
+
 def enqueue_seed_species(
     config: AppConfig,
     *,
@@ -508,11 +524,8 @@ def enqueue_seed_species(
         state_lock = nullcontext() if dry_run else catalog_state_lock(config.controller.state_dir)
         with state_lock:
             approved = approved_taxon_ids(config.controller.catalog_dir)
-            existing = [
-                species
-                for species in read_generation_queue(config)
-                if species.taxon_id not in approved
-            ]
+            legacy_queue = read_generation_queue(config)
+            existing = [species for species in legacy_queue if species.taxon_id not in approved]
             eligible = [
                 species
                 for species in discovered
@@ -527,15 +540,25 @@ def enqueue_seed_species(
                 queued_by_taxon[species.taxon_id] = species
                 added.append(species)
             queued = list(queued_by_taxon.values())
+            collection, migrated_legacy_queue, migrated_at, migration_applied = (
+                _migrate_legacy_seed_queue(
+                    read_collection_state(config.controller.state_dir),
+                    legacy_queue,
+                )
+            )
             collection, collection_added = add_collection_taxa(
-                read_collection(config.controller.state_dir),
+                collection,
                 {species.taxon_id for species in discovered},
                 CollectionOrigin.HISTORICAL_SEED,
             )
             if not dry_run:
                 _write_generation_queue(config, queued)
-                if collection_added:
-                    write_collection(config.controller.state_dir, collection)
+                if migration_applied or collection_added:
+                    write_collection(
+                        config.controller.state_dir,
+                        collection,
+                        legacy_seed_queue_migrated_at=migrated_at,
+                    )
                 _write_active_catalog(config, _current_discovery_species(config))
 
     return {
@@ -559,6 +582,8 @@ def enqueue_seed_species(
         "eligible_count": len(eligible),
         "added_count": len(added),
         "queued_count": len(queued),
+        "migrated_legacy_queue_count": len(migrated_legacy_queue),
+        "migrated_legacy_queue_taxon_ids": [entry.taxon_id for entry in migrated_legacy_queue],
         "collection_added_count": len(collection_added),
         "collection_count": len(collection),
         "dry_run": dry_run,
@@ -688,6 +713,8 @@ def _collection_summary(
     entries: list[CollectionEntry],
     approved: list[CatalogEntry],
     observed: list[BirdSpecies],
+    *,
+    legacy_seed_queue_migrated_at: str | None,
 ) -> dict[str, object]:
     approved_by_taxon = {entry.taxon_id: entry for entry in approved}
     observed_taxa = {species.taxon_id for species in observed}
@@ -710,6 +737,8 @@ def _collection_summary(
         "collection_count": len(entries),
         "approved_member_count": sum(entry.taxon_id in approved_by_taxon for entry in entries),
         "active_approved_count": len(active_taxa),
+        "legacy_seed_queue_migrated": legacy_seed_queue_migrated_at is not None,
+        "legacy_seed_queue_migrated_at": legacy_seed_queue_migrated_at,
         "members": members,
     }
 
@@ -717,10 +746,12 @@ def _collection_summary(
 def collection_status(
     config: AppConfig, *, approved: list[CatalogEntry] | None = None
 ) -> dict[str, object]:
+    state = read_collection_state(config.controller.state_dir)
     return _collection_summary(
-        read_collection(config.controller.state_dir),
+        state.entries,
         approved if approved is not None else read_catalog_entries(config.controller.catalog_dir),
         _current_discovery_species(config),
+        legacy_seed_queue_migrated_at=state.legacy_seed_queue_migrated_at,
     )
 
 
@@ -745,7 +776,12 @@ def _change_collection(
             requested_taxa = (
                 {entry.taxon_id for entry in approved} if taxon_ids is None else taxon_ids
             )
-            current = read_collection(config.controller.state_dir)
+            current, migrated_legacy_queue, migrated_at, migration_applied = (
+                _migrate_legacy_seed_queue(
+                    read_collection_state(config.controller.state_dir),
+                    read_generation_queue(config),
+                )
+            )
             if remove:
                 updated, removed = remove_collection_taxa(current, requested_taxa)
                 added: list[CollectionEntry] = []
@@ -755,10 +791,19 @@ def _change_collection(
                 updated, added = add_collection_taxa(current, requested_taxa, origin)
                 removed = []
             observed = _current_discovery_species(config)
-            summary = _collection_summary(updated, approved, observed)
+            summary = _collection_summary(
+                updated,
+                approved,
+                observed,
+                legacy_seed_queue_migrated_at=migrated_at,
+            )
             if not dry_run:
-                if added or removed:
-                    write_collection(config.controller.state_dir, updated)
+                if migration_applied or added or removed:
+                    write_collection(
+                        config.controller.state_dir,
+                        updated,
+                        legacy_seed_queue_migrated_at=migrated_at,
+                    )
                 summary["active_approved_count"] = _write_active_catalog(
                     config,
                     observed,
@@ -770,6 +815,8 @@ def _change_collection(
         "removed_count": len(removed),
         "added_taxon_ids": [entry.taxon_id for entry in added],
         "removed_taxon_ids": [entry.taxon_id for entry in removed],
+        "migrated_legacy_queue_count": len(migrated_legacy_queue),
+        "migrated_legacy_queue_taxon_ids": [entry.taxon_id for entry in migrated_legacy_queue],
         "dry_run": dry_run,
     }
 
@@ -1067,10 +1114,13 @@ def _retry_source_plate(state_dir: Path, relative_path: str | None) -> Path | No
 
 
 def _terminal_state(state_dir: Path, taxon_id: int) -> tuple[str, tuple[Path, ...]] | None:
-    for category in ("pending", "rejected"):
-        path = find_taxon_directory(state_dir / category, taxon_id)
-        if path is not None:
-            return category, (path,)
+    pending = find_taxon_directory(state_dir / "pending", taxon_id)
+    if pending is not None:
+        state = "pending" if (pending / "manifest.json").is_file() else "incomplete_pending"
+        return state, (pending,)
+    rejected = find_taxon_directory(state_dir / "rejected", taxon_id)
+    if rejected is not None:
+        return "rejected", (rejected,)
     failed = tuple(sorted((state_dir / "failed").glob(f"{taxon_id}-*")))
     if failed:
         return "failed", failed
@@ -1159,7 +1209,20 @@ def approve_passing_candidates(config: AppConfig) -> list[dict[str, object]]:
 
 def run_generation_cycle(config: AppConfig) -> dict[str, object]:
     with exclusive_cycle_lock(config.controller.state_dir):
+        queued_species = read_generation_queue(config)
         with catalog_state_lock(config.controller.state_dir):
+            collection, migrated_legacy_queue, migrated_at, migration_applied = (
+                _migrate_legacy_seed_queue(
+                    read_collection_state(config.controller.state_dir),
+                    queued_species,
+                )
+            )
+            if migration_applied:
+                write_collection(
+                    config.controller.state_dir,
+                    collection,
+                    legacy_seed_queue_migrated_at=migrated_at,
+                )
             published = approve_passing_candidates(config)
         snapshot = _read_discovery_snapshot(config)
         maximum_age = timedelta(minutes=config.schedule.refresh_minutes * 2)
@@ -1168,15 +1231,6 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 "Discovery state is stale; a successful refresh is required before generation"
             )
         species_list = snapshot.species
-        queued_species = read_generation_queue(config)
-        with catalog_state_lock(config.controller.state_dir):
-            collection, migrated_collection = add_collection_taxa(
-                read_collection(config.controller.state_dir),
-                {species.taxon_id for species in queued_species},
-                CollectionOrigin.HISTORICAL_SEED,
-            )
-            if migrated_collection:
-                write_collection(config.controller.state_dir, collection)
         generation_species = list(species_list)
         observed_taxa = {species.taxon_id for species in species_list}
         generation_species.extend(
@@ -1351,7 +1405,8 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
             "deferred_count": len(deferred),
             "deferred": [record.as_dict() for record in deferred],
             "outstanding_retry_count": len(outstanding_retries),
-            "migrated_collection_count": len(migrated_collection),
+            "migrated_legacy_queue_count": len(migrated_legacy_queue),
+            "migrated_legacy_queue_taxon_ids": [entry.taxon_id for entry in migrated_legacy_queue],
             "queued_count": len(queue_partition.actionable),
             "terminal_blocked_count": len(queue_partition.terminal_blocked),
             "terminal_blocked": [entry.as_dict() for entry in queue_partition.terminal_blocked],

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -16,6 +16,7 @@ from inky_bird_frame.catalog import (
     candidate_directory,
     read_catalog_entries,
     read_collection,
+    read_collection_state,
     read_json,
     rebuild_catalog_index,
     remove_collection_taxa,
@@ -83,13 +84,28 @@ class CatalogTests(unittest.TestCase):
                 )
             ]
 
-            write_collection(state, expected)
+            migrated_at = "2026-08-02T12:05:00+00:00"
+            write_collection(
+                state,
+                expected,
+                legacy_seed_queue_migrated_at=migrated_at,
+            )
 
             payload = json.loads((state / "collection.json").read_text())
             actual = read_collection(state)
+            collection_state = read_collection_state(state)
 
         self.assertEqual(actual, expected)
-        self.assertEqual(set(payload), {"schema_version", "updated_at", "taxa"})
+        self.assertEqual(collection_state.legacy_seed_queue_migrated_at, migrated_at)
+        self.assertEqual(
+            set(payload),
+            {
+                "schema_version",
+                "updated_at",
+                "legacy_seed_queue_migrated_at",
+                "taxa",
+            },
+        )
         self.assertEqual(
             set(payload["taxa"][0]),
             {"taxon_id", "added_at", "origin"},
@@ -130,6 +146,7 @@ class CatalogTests(unittest.TestCase):
                     {
                         "schema_version": 1,
                         "updated_at": "2026-08-02T12:00:00+00:00",
+                        "legacy_seed_queue_migrated_at": None,
                         "taxa": [
                             {
                                 "taxon_id": 12942,

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -9,12 +9,18 @@ from tempfile import TemporaryDirectory
 
 from inky_bird_frame.birds import BirdSpecies
 from inky_bird_frame.catalog import (
+    CollectionEntry,
+    CollectionOrigin,
+    add_collection_taxa,
     approve_candidate,
     candidate_directory,
     read_catalog_entries,
+    read_collection,
     read_json,
     rebuild_catalog_index,
+    remove_collection_taxa,
     write_candidate_manifest,
+    write_collection,
 )
 from inky_bird_frame.errors import CatalogError
 from inky_bird_frame.http import write_json_atomic
@@ -65,6 +71,79 @@ class CatalogTests(unittest.TestCase):
             payload = json.loads(path.read_text())
 
         self.assertIn(payload["value"], range(32))
+
+    def test_collection_round_trip_contains_only_private_membership_metadata(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state = Path(temporary)
+            expected = [
+                CollectionEntry(
+                    12942,
+                    "2026-08-02T12:00:00+00:00",
+                    CollectionOrigin.CATALOG_IMPORT,
+                )
+            ]
+
+            write_collection(state, expected)
+
+            payload = json.loads((state / "collection.json").read_text())
+            actual = read_collection(state)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(set(payload), {"schema_version", "updated_at", "taxa"})
+        self.assertEqual(
+            set(payload["taxa"][0]),
+            {"taxon_id", "added_at", "origin"},
+        )
+
+    def test_collection_addition_is_idempotent_and_removal_is_explicit(self) -> None:
+        entries, added = add_collection_taxa(
+            [],
+            {2, 1},
+            CollectionOrigin.HISTORICAL_SEED,
+        )
+
+        repeated, repeated_added = add_collection_taxa(
+            entries,
+            {1},
+            CollectionOrigin.MANUAL,
+        )
+        remaining, removed = remove_collection_taxa(repeated, {2})
+
+        self.assertEqual([entry.taxon_id for entry in added], [1, 2])
+        self.assertEqual(repeated, entries)
+        self.assertEqual(repeated_added, [])
+        self.assertEqual(
+            [entry.origin for entry in repeated],
+            [
+                CollectionOrigin.HISTORICAL_SEED,
+                CollectionOrigin.HISTORICAL_SEED,
+            ],
+        )
+        self.assertEqual([entry.taxon_id for entry in remaining], [1])
+        self.assertEqual([entry.taxon_id for entry in removed], [2])
+
+    def test_collection_rejects_unrecognized_state_fields(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state = Path(temporary)
+            (state / "collection.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "updated_at": "2026-08-02T12:00:00+00:00",
+                        "taxa": [
+                            {
+                                "taxon_id": 12942,
+                                "added_at": "2026-08-02T12:00:00+00:00",
+                                "origin": "manual",
+                                "latitude": 35.0,
+                            }
+                        ],
+                    }
+                )
+            )
+
+            with self.assertRaisesRegex(CatalogError, "Invalid collection entry"):
+                read_collection(state)
 
     def test_approved_seed_has_valid_checksums(self) -> None:
         catalog = Path(__file__).parents[1] / "catalog"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -530,6 +530,45 @@ rotation_mode = "shuffle_bag"
         if guidance is not None:
             self.assertEqual(guidance.findings, (REVIEW_FAILURE_FALLBACK,))
 
+    def test_retry_archives_incomplete_pending_candidate(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            pending = state_dir / "pending/42-example-bird"
+            pending.mkdir(parents=True)
+            (pending / "portrait.png").write_bytes(b"partial")
+            config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
+            output = io.StringIO()
+
+            with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
+                retry_command(Namespace(taxon_id=42))
+
+            result = json.loads(output.getvalue())["data"]
+            archived = state_dir / "archive/42-example-bird"
+            pending_exists = pending.exists()
+            archived_portrait_exists = (archived / "portrait.png").is_file()
+
+        self.assertEqual(result["status"], "eligible")
+        self.assertEqual(result["archived"], [str(archived)])
+        self.assertFalse(pending_exists)
+        self.assertTrue(archived_portrait_exists)
+
+    def test_retry_rejects_complete_pending_candidate(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            pending = state_dir / "pending/42-example-bird"
+            pending.mkdir(parents=True)
+            (pending / "manifest.json").write_text("{}")
+            config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(ValueError, "must be approved or rejected"),
+            ):
+                retry_command(Namespace(taxon_id=42))
+            pending_exists = pending.is_dir()
+
+        self.assertTrue(pending_exists)
+
     def test_retry_preserves_selected_attempt_as_correction_source(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,7 @@ from inky_bird_frame.cli import (
     seed_command,
     serve_command,
     species_to_dict,
+    status_command,
 )
 from inky_bird_frame.config import DiscoveryProvider
 from inky_bird_frame.controller import REVIEW_FAILURE_FALLBACK, exclusive_cycle_lock
@@ -163,6 +164,64 @@ class CliTests(unittest.TestCase):
         self.assertEqual(args.radius_km, 16)
         self.assertEqual(args.species_limit, 500)
         self.assertTrue(args.dry_run)
+
+    def test_collection_commands_support_explicit_preview_and_mutation(self) -> None:
+        listed = build_parser().parse_args(["collection", "list", "--config", "instance.toml"])
+        imported = build_parser().parse_args(
+            [
+                "collection",
+                "import-approved",
+                "--config",
+                "instance.toml",
+                "--dry-run",
+            ]
+        )
+        added = build_parser().parse_args(["collection", "add", "42", "--config", "instance.toml"])
+        removed = build_parser().parse_args(
+            ["collection", "remove", "42", "--config", "instance.toml", "--dry-run"]
+        )
+
+        self.assertEqual(str(listed.config), "instance.toml")
+        self.assertTrue(imported.dry_run)
+        self.assertEqual(added.taxon_id, 42)
+        self.assertFalse(added.dry_run)
+        self.assertEqual(removed.taxon_id, 42)
+        self.assertTrue(removed.dry_run)
+
+    def test_status_separates_terminal_blocked_queue_entries(self) -> None:
+        actionable = BirdSpecies(1, "Ready Bird", "Avis parata", 2, "iNaturalist")
+        blocked = {
+            "taxon_id": 2,
+            "common_name": "Blocked Bird",
+            "terminal_state": "failed",
+            "paths": ["state/failed/2-blocked-bird"],
+        }
+        queue = SimpleNamespace(
+            actionable=[actionable],
+            terminal_blocked=[SimpleNamespace(as_dict=lambda: blocked)],
+        )
+        with TemporaryDirectory() as temporary:
+            state = Path(temporary)
+            config = SimpleNamespace(
+                controller=SimpleNamespace(catalog_dir=state / "catalog", state_dir=state)
+            )
+            output = io.StringIO()
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                patch("inky_bird_frame.cli.rebuild_catalog_index", return_value=[]),
+                patch("inky_bird_frame.cli.read_generation_queue_partition", return_value=queue),
+                patch(
+                    "inky_bird_frame.cli.collection_status",
+                    return_value={"collection_count": 0, "members": []},
+                ),
+                redirect_stdout(output),
+            ):
+                status_command(Namespace())
+
+        payload = json.loads(output.getvalue())["data"]
+        self.assertEqual([entry["taxon_id"] for entry in payload["queued"]], [1])
+        self.assertEqual(payload["terminal_blocked"], [blocked])
+        self.assertEqual(payload["collection"], {"collection_count": 0})
 
     def test_seed_supports_historical_dates_and_coordinates(self) -> None:
         args = build_parser().parse_args(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -521,11 +521,15 @@ class ControllerTests(unittest.TestCase):
                 patch("inky_bird_frame.controller.rebuild_catalog_index", return_value=[]),
             ):
                 result = run_generation_cycle(config)
+            collection = read_collection(config.controller.state_dir)
 
         self.assertEqual(attempted, [current.taxon_id, queued.taxon_id])
         self.assertEqual(result["eligible_count"], 2)
         self.assertEqual(result["attempted_count"], 2)
+        self.assertEqual(result["migrated_collection_count"], 1)
         self.assertEqual(result["queued_count"], 1)
+        self.assertEqual([entry.taxon_id for entry in collection], [queued.taxon_id])
+        self.assertEqual(collection[0].origin, CollectionOrigin.HISTORICAL_SEED)
 
     def test_generation_skips_deferred_species_and_attempts_later_work(self) -> None:
         deferred = BirdSpecies(1, "Deferred Bird", "Avis deferred", 4, "iNaturalist")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -22,6 +22,7 @@ from inky_bird_frame.catalog import (
     CollectionOrigin,
     candidate_directory,
     read_collection,
+    read_collection_state,
     write_candidate_manifest,
     write_collection,
 )
@@ -398,6 +399,7 @@ class ControllerTests(unittest.TestCase):
                         CollectionOrigin.MANUAL,
                     )
                 ],
+                legacy_seed_queue_migrated_at="2026-08-02T12:00:00+00:00",
             )
             with (
                 patch(
@@ -417,6 +419,53 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(result["collection_count"], 0)
         self.assertEqual(result["active_approved_count"], 1)
 
+    def test_collection_remove_is_preserved_after_legacy_queue_migration(self) -> None:
+        queued = BirdSpecies(1, "Queued Bird", "Avis queued", 1, "iNaturalist")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            (config.controller.state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "updated_at": datetime.now(UTC).isoformat(),
+                        "species": [
+                            {
+                                "taxon_id": queued.taxon_id,
+                                "common_name": queued.common_name,
+                                "scientific_name": queued.scientific_name,
+                                "observation_count": queued.observation_count,
+                                "source": queued.source,
+                            }
+                        ],
+                    }
+                )
+            )
+            with (
+                patch("inky_bird_frame.controller.read_catalog_entries", return_value=[]),
+                patch("inky_bird_frame.controller._write_active_catalog", return_value=0),
+            ):
+                removed = remove_collection_member(config, queued.taxon_id)
+            state_after_remove = read_collection_state(config.controller.state_dir)
+            with (
+                patch("inky_bird_frame.controller.approve_passing_candidates", return_value=[]),
+                patch(
+                    "inky_bird_frame.controller._read_discovery_snapshot",
+                    side_effect=DataSourceError("missing"),
+                ),
+                self.assertRaisesRegex(DataSourceError, "missing"),
+            ):
+                run_generation_cycle(config)
+            state_after_generation = read_collection_state(config.controller.state_dir)
+
+        self.assertEqual(removed["migrated_legacy_queue_count"], 1)
+        self.assertEqual(removed["removed_count"], 1)
+        self.assertEqual(state_after_remove.entries, [])
+        self.assertIsNotNone(state_after_remove.legacy_seed_queue_migrated_at)
+        self.assertEqual(state_after_generation, state_after_remove)
+
     def test_collection_mutation_respects_the_controller_cycle_lock(self) -> None:
         with TemporaryDirectory() as temporary:
             config_path = Path(temporary) / "config.toml"
@@ -432,6 +481,8 @@ class ControllerTests(unittest.TestCase):
     def test_terminal_queue_entries_are_separate_from_actionable_work(self) -> None:
         actionable = BirdSpecies(1, "Ready Bird", "Avis parata", 2, "iNaturalist")
         blocked = BirdSpecies(2, "Blocked Bird", "Avis impedita", 1, "iNaturalist")
+        incomplete = BirdSpecies(3, "Incomplete Bird", "Avis incompleta", 1, "iNaturalist")
+        pending = BirdSpecies(4, "Pending Bird", "Avis pendens", 1, "iNaturalist")
         with TemporaryDirectory() as temporary:
             config_path = Path(temporary) / "config.toml"
             config_path.write_text(CONFIG)
@@ -450,20 +501,26 @@ class ControllerTests(unittest.TestCase):
                                 "observation_count": species.observation_count,
                                 "source": species.source,
                             }
-                            for species in (actionable, blocked)
+                            for species in (actionable, blocked, incomplete, pending)
                         ],
                     }
                 )
             )
             failed = config.controller.state_dir / "failed/2-blocked-bird"
             failed.mkdir(parents=True)
+            (config.controller.state_dir / "pending/3-incomplete-bird").mkdir(parents=True)
+            pending_dir = config.controller.state_dir / "pending/4-pending-bird"
+            pending_dir.mkdir(parents=True)
+            (pending_dir / "manifest.json").write_text("{}")
             with patch("inky_bird_frame.controller.approved_taxon_ids", return_value=set()):
                 partition = read_generation_queue_partition(config)
 
         self.assertEqual([species.taxon_id for species in partition.actionable], [1])
-        self.assertEqual(len(partition.terminal_blocked), 1)
+        self.assertEqual(len(partition.terminal_blocked), 2)
         self.assertEqual(partition.terminal_blocked[0].species.taxon_id, 2)
         self.assertEqual(partition.terminal_blocked[0].state, "failed")
+        self.assertEqual(partition.terminal_blocked[1].species.taxon_id, 3)
+        self.assertEqual(partition.terminal_blocked[1].state, "incomplete_pending")
 
     def test_generation_prioritizes_current_species_before_seed_queue(self) -> None:
         current = BirdSpecies(1, "Current Bird", "Avis current", 4, "iNaturalist")
@@ -526,7 +583,8 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(attempted, [current.taxon_id, queued.taxon_id])
         self.assertEqual(result["eligible_count"], 2)
         self.assertEqual(result["attempted_count"], 2)
-        self.assertEqual(result["migrated_collection_count"], 1)
+        self.assertEqual(result["migrated_legacy_queue_count"], 1)
+        self.assertEqual(result["migrated_legacy_queue_taxon_ids"], [queued.taxon_id])
         self.assertEqual(result["queued_count"], 1)
         self.assertEqual([entry.taxon_id for entry in collection], [queued.taxon_id])
         self.assertEqual(collection[0].origin, CollectionOrigin.HISTORICAL_SEED)
@@ -724,14 +782,36 @@ class ControllerTests(unittest.TestCase):
 
         discover.assert_not_called()
 
-    def test_generation_recovers_pending_before_requiring_discovery(self) -> None:
+    def test_generation_migrates_legacy_queue_before_pending_recovery(self) -> None:
         with TemporaryDirectory() as temporary:
             config_path = Path(temporary) / "config.toml"
             config_path.write_text(CONFIG)
             config = load_config(config_path)
+            queued = BirdSpecies(42, "Legacy Bird", "Avis vetus", 1, "iNaturalist")
+            config.controller.state_dir.mkdir(parents=True)
+            (config.controller.state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "updated_at": datetime.now(UTC).isoformat(),
+                        "species": [
+                            {
+                                "taxon_id": queued.taxon_id,
+                                "common_name": queued.common_name,
+                                "scientific_name": queued.scientific_name,
+                                "observation_count": queued.observation_count,
+                                "source": queued.source,
+                            }
+                        ],
+                    }
+                )
+            )
             recovered: list[str] = []
 
             def approve(_config: object) -> list[dict[str, object]]:
+                collection = read_collection_state(config.controller.state_dir)
+                self.assertEqual([entry.taxon_id for entry in collection.entries], [42])
+                self.assertIsNotNone(collection.legacy_seed_queue_migrated_at)
                 recovered.append("approved")
                 return []
 
@@ -898,6 +978,7 @@ class ControllerTests(unittest.TestCase):
                     )
                     for taxon_id in (1, 2)
                 ],
+                legacy_seed_queue_migrated_at="2026-08-02T12:00:00+00:00",
             )
             with (
                 patch(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -16,19 +16,33 @@ from inky_bird_frame.birds import (
     EbirdSpecies,
     ObservationWindow,
 )
-from inky_bird_frame.catalog import CatalogEntry, candidate_directory, write_candidate_manifest
+from inky_bird_frame.catalog import (
+    CatalogEntry,
+    CollectionEntry,
+    CollectionOrigin,
+    candidate_directory,
+    read_collection,
+    write_candidate_manifest,
+    write_collection,
+)
 from inky_bird_frame.codex_runner import CodexRunner
 from inky_bird_frame.config import DiscoveryProvider, load_config
 from inky_bird_frame.controller import (
     DiscoveryResult,
     DiscoverySnapshot,
     ProviderStatus,
+    add_collection_member,
+    collection_status,
     discover_species,
     enqueue_seed_species,
+    exclusive_cycle_lock,
     exclusive_refresh_lock,
     generate_candidate,
+    import_approved_collection,
     load_or_create_profile,
     load_or_fetch_references,
+    read_generation_queue_partition,
+    remove_collection_member,
     run_controller_cycle,
     run_generation_cycle,
     run_refresh_cycle,
@@ -173,6 +187,17 @@ class ControllerTests(unittest.TestCase):
     def test_seed_queues_distinct_unapproved_species_without_changing_discovery(self) -> None:
         approved = BirdSpecies(1, "Approved Bird", "Avis approved", 4, "iNaturalist")
         queued = BirdSpecies(2, "Queued Bird", "Avis queued", 3, "iNaturalist")
+        approved_entry = CatalogEntry(
+            1,
+            approved.common_name,
+            approved.scientific_name,
+            "approved-bird",
+            "species/1/portrait.png",
+            "a" * 64,
+            "species/1/display.png",
+            "b" * 64,
+            "2026-07-09T00:00:00+00:00",
+        )
         location = DiscoveryLocation("12345", "Exampleville", "XY", 1.0, 2.0)
         with TemporaryDirectory() as temporary:
             config_path = Path(temporary) / "config.toml"
@@ -187,6 +212,10 @@ class ControllerTests(unittest.TestCase):
                     return_value=[approved, queued],
                 ),
                 patch("inky_bird_frame.controller.approved_taxon_ids", return_value={1}),
+                patch(
+                    "inky_bird_frame.controller.rebuild_catalog_index",
+                    return_value=[approved_entry],
+                ),
             ):
                 result = enqueue_seed_species(
                     config,
@@ -195,14 +224,24 @@ class ControllerTests(unittest.TestCase):
                 )
 
             queue = json.loads((config.controller.state_dir / "generation-queue.json").read_text())
+            collection = json.loads((config.controller.state_dir / "collection.json").read_text())
+            active = json.loads((config.controller.state_dir / "active-catalog.json").read_text())
 
         self.assertEqual(result["discovered_count"], 2)
         self.assertEqual(result["already_approved_count"], 1)
         self.assertEqual(result["added_count"], 1)
+        self.assertEqual(result["collection_added_count"], 2)
+        self.assertEqual(result["collection_count"], 2)
+        self.assertEqual(result["collection_added_taxon_ids"], [1, 2])
         added = cast(list[dict[str, object]], result["added"])
         self.assertEqual(added[0]["source"], "iNaturalist")
         self.assertEqual(queue["species"][0]["taxon_id"], 2)
         self.assertNotIn("zip_code", queue)
+        self.assertEqual([item["taxon_id"] for item in collection["taxa"]], [1, 2])
+        self.assertTrue(all(item["origin"] == "historical_seed" for item in collection["taxa"]))
+        self.assertNotIn("zip_code", collection)
+        self.assertEqual([item["taxon_id"] for item in active["species"]], [1])
+        self.assertNotIn("observation_count", active["species"][0])
 
     def test_seed_dry_run_does_not_create_controller_state(self) -> None:
         species = BirdSpecies(2, "New Bird", "Avis nova", 1, "eBird")
@@ -227,6 +266,7 @@ class ControllerTests(unittest.TestCase):
             state_exists = config.controller.state_dir.exists()
 
         self.assertEqual(result["added_count"], 1)
+        self.assertEqual(result["collection_added_count"], 1)
         self.assertFalse(state_exists)
         self.assertFalse(discover.call_args.kwargs["persist_taxonomy_cache"])
 
@@ -274,6 +314,156 @@ class ControllerTests(unittest.TestCase):
                     sources=(DiscoveryProvider.EBIRD,),
                     dry_run=True,
                 )
+
+    def test_approved_catalog_import_is_explicit_idempotent_and_isolates_later_entries(
+        self,
+    ) -> None:
+        approved = [
+            CatalogEntry(
+                taxon_id,
+                f"Bird {taxon_id}",
+                f"Avis {taxon_id}",
+                f"bird-{taxon_id}",
+                f"species/{taxon_id}/portrait.png",
+                "a" * 64,
+                f"species/{taxon_id}/display.png",
+                "b" * 64,
+                "2026-07-09T00:00:00+00:00",
+            )
+            for taxon_id in (1, 2)
+        ]
+        external = CatalogEntry(
+            3,
+            "External Bird",
+            "Avis externa",
+            "external-bird",
+            "species/3/portrait.png",
+            "a" * 64,
+            "species/3/display.png",
+            "b" * 64,
+            "2026-08-02T00:00:00+00:00",
+        )
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            with (
+                patch("inky_bird_frame.controller.read_catalog_entries", return_value=approved),
+                patch("inky_bird_frame.controller._write_active_catalog", return_value=2),
+            ):
+                preview = import_approved_collection(config, dry_run=True)
+                state_after_preview = config.controller.state_dir.exists()
+                applied = import_approved_collection(config)
+                repeated = import_approved_collection(config)
+            with patch(
+                "inky_bird_frame.controller.read_catalog_entries",
+                return_value=[*approved, external],
+            ):
+                status = collection_status(config)
+            persisted = read_collection(config.controller.state_dir)
+
+        self.assertFalse(state_after_preview)
+        self.assertEqual(preview["added_count"], 2)
+        self.assertEqual(preview["added_taxon_ids"], [1, 2])
+        self.assertEqual(applied["added_count"], 2)
+        self.assertEqual(repeated["added_count"], 0)
+        self.assertEqual([entry.taxon_id for entry in persisted], [1, 2])
+        self.assertEqual(status["collection_count"], 2)
+        members = cast(list[dict[str, object]], status["members"])
+        self.assertNotIn(3, {member["taxon_id"] for member in members})
+
+    def test_collection_remove_preserves_observation_based_activation(self) -> None:
+        approved = CatalogEntry(
+            1,
+            "Observed Bird",
+            "Avis observata",
+            "observed-bird",
+            "species/1/portrait.png",
+            "a" * 64,
+            "species/1/display.png",
+            "b" * 64,
+            "2026-07-09T00:00:00+00:00",
+        )
+        observed = BirdSpecies(1, "Observed Bird", "Avis observata", 3, "BirdWeather")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            write_collection(
+                config.controller.state_dir,
+                [
+                    CollectionEntry(
+                        1,
+                        "2026-08-02T12:00:00+00:00",
+                        CollectionOrigin.MANUAL,
+                    )
+                ],
+            )
+            with (
+                patch(
+                    "inky_bird_frame.controller.read_catalog_entries",
+                    return_value=[approved],
+                ),
+                patch(
+                    "inky_bird_frame.controller._current_discovery_species",
+                    return_value=[observed],
+                ),
+                patch("inky_bird_frame.controller._write_active_catalog", return_value=1),
+            ):
+                result = remove_collection_member(config, 1)
+
+        self.assertEqual(result["removed_count"], 1)
+        self.assertEqual(result["removed_taxon_ids"], [1])
+        self.assertEqual(result["collection_count"], 0)
+        self.assertEqual(result["active_approved_count"], 1)
+
+    def test_collection_mutation_respects_the_controller_cycle_lock(self) -> None:
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+
+            with (
+                exclusive_cycle_lock(config.controller.state_dir),
+                self.assertRaisesRegex(GenerationError, "already running"),
+            ):
+                add_collection_member(config, 1)
+
+    def test_terminal_queue_entries_are_separate_from_actionable_work(self) -> None:
+        actionable = BirdSpecies(1, "Ready Bird", "Avis parata", 2, "iNaturalist")
+        blocked = BirdSpecies(2, "Blocked Bird", "Avis impedita", 1, "iNaturalist")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            (config.controller.state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "updated_at": datetime.now(UTC).isoformat(),
+                        "species": [
+                            {
+                                "taxon_id": species.taxon_id,
+                                "common_name": species.common_name,
+                                "scientific_name": species.scientific_name,
+                                "observation_count": species.observation_count,
+                                "source": species.source,
+                            }
+                            for species in (actionable, blocked)
+                        ],
+                    }
+                )
+            )
+            failed = config.controller.state_dir / "failed/2-blocked-bird"
+            failed.mkdir(parents=True)
+            with patch("inky_bird_frame.controller.approved_taxon_ids", return_value=set()):
+                partition = read_generation_queue_partition(config)
+
+        self.assertEqual([species.taxon_id for species in partition.actionable], [1])
+        self.assertEqual(len(partition.terminal_blocked), 1)
+        self.assertEqual(partition.terminal_blocked[0].species.taxon_id, 2)
+        self.assertEqual(partition.terminal_blocked[0].state, "failed")
 
     def test_generation_prioritizes_current_species_before_seed_queue(self) -> None:
         current = BirdSpecies(1, "Current Bird", "Avis current", 4, "iNaturalist")
@@ -659,6 +849,74 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(len(snapshot["species"]), 2)
         self.assertEqual(snapshot["species"][0]["source"], "BirdWeather")
         self.assertEqual(snapshot["species"][0]["latest_detection_at"], "2026-07-13T08:10:00-04:00")
+
+    def test_refresh_unions_observations_with_private_collection_without_trusting_catalog(
+        self,
+    ) -> None:
+        observed = BirdSpecies(
+            1,
+            "Observed Bird",
+            "Avis observata",
+            7,
+            "BirdWeather",
+            latest_detection_at="2026-08-02T14:21:06-04:00",
+        )
+        location = DiscoveryLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        approved = [
+            CatalogEntry(
+                taxon_id,
+                name,
+                scientific_name,
+                name.lower().replace(" ", "-"),
+                f"species/{taxon_id}/portrait.png",
+                "a" * 64,
+                f"species/{taxon_id}/display.png",
+                "b" * 64,
+                "2026-07-09T00:00:00+00:00",
+            )
+            for taxon_id, name, scientific_name in (
+                (1, "Observed Bird", "Avis observata"),
+                (2, "Collected Bird", "Avis collecta"),
+                (3, "Untrusted Bird", "Avis externa"),
+            )
+        ]
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            write_collection(
+                config.controller.state_dir,
+                [
+                    CollectionEntry(
+                        taxon_id,
+                        "2026-08-02T12:00:00+00:00",
+                        CollectionOrigin.CATALOG_IMPORT,
+                    )
+                    for taxon_id in (1, 2)
+                ],
+            )
+            with (
+                patch(
+                    "inky_bird_frame.controller.discover_species",
+                    return_value=discovery_result(location, [observed]),
+                ),
+                patch(
+                    "inky_bird_frame.controller.rebuild_catalog_index",
+                    return_value=approved,
+                ),
+            ):
+                result = run_refresh_cycle(config)
+            active = json.loads((config.controller.state_dir / "active-catalog.json").read_text())
+
+        self.assertEqual(result["active_approved_count"], 2)
+        self.assertEqual([entry["taxon_id"] for entry in active["species"]], [1, 2])
+        self.assertEqual(active["species"][0]["observation_count"], 7)
+        self.assertEqual(
+            active["species"][0]["latest_detection_at"],
+            "2026-08-02T14:21:06-04:00",
+        )
+        self.assertNotIn("observation_count", active["species"][1])
+        self.assertNotIn("latest_detection_at", active["species"][1])
 
     def test_refresh_preserves_approved_catalog_order(self) -> None:
         first = BirdSpecies(1, "Alpha Bird", "Alpha avis", 2, "iNaturalist")

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
Closes #147.

## Summary

- add a schema-versioned private collection containing only taxon membership provenance
- make active plates the approved union of current observations and collection membership
- add previewable list/import/add/remove collection commands
- persist every historical seed taxon while preserving the separate generation queue
- separate actionable queued work from rejected/failed terminal-blocked work
- keep active-catalog wire schema v1 and preserve live observation metadata when present
- bump the patch release to 0.2.4 and document migration, trust, privacy, and queue semantics

## Compatibility and safety

Catalog synchronization never mutates private membership. Collection-only entries omit observation counts and timestamps; the display's established neutral weight applies. State writes remain atomic and controller/catalog locks serialize mutations. No configuration or active-catalog wire migration is required.

## Validation

- production dry run: 102 additions, 102 approved members, 102 active, 0 removals
- `uv sync --extra dev --locked`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest` — 376 passed, 19 subtests passed
- `uv run inky-bird-frame catalog validate --catalog catalog` — 102 species valid
- actionlint
- ShellCheck
- workflow action pinning

Docker Compose validation is left to CI because Docker is not installed on this workstation.