### PR TITLE
Support legacy quality review retries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.2.4"
+version = "0.2.5"
 description = "Generate and display reusable bird field-journal plates"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/inky_bird_frame/__init__.py
+++ b/src/inky_bird_frame/__init__.py
@@ -1,3 +1,3 @@
 """Local bird field-journal plates for Pimoroni Inky displays."""
 
-__version__ = "0.2.3"
+__version__ = "0.2.5"

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -436,7 +436,9 @@ def _retry_quality_guidance(
         raise SpeciesStateError(f"Invalid quality review: {review_path}") from exc
     if not isinstance(review, dict) or review.get("passed") is not False:
         raise SpeciesStateError(f"Invalid failed quality review: {review_path}")
-    findings = review.get("correction_findings", review.get("findings"))
+    findings = review.get("correction_findings")
+    if findings is None:
+        findings = review.get("findings")
     if not isinstance(findings, list) or any(
         not isinstance(finding, str) or not finding.strip() for finding in findings
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,11 +7,13 @@ import unittest
 from argparse import Namespace
 from contextlib import redirect_stdout
 from datetime import date
+from importlib.metadata import version
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import inky_bird_frame
 from inky_bird_frame.birds import BirdSpecies, DateRange
 from inky_bird_frame.cli import (
     build_parser,
@@ -39,6 +41,9 @@ from inky_bird_frame.retry import RetryStore
 
 
 class CliTests(unittest.TestCase):
+    def test_runtime_version_matches_package_metadata(self) -> None:
+        self.assertEqual(inky_bird_frame.__version__, version("inky-bird-frame"))
+
     def test_status_requires_explicit_config(self) -> None:
         args = build_parser().parse_args(["status", "--config", "instance.toml"])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -530,6 +530,34 @@ rotation_mode = "shuffle_bag"
         if guidance is not None:
             self.assertEqual(guidance.findings, (REVIEW_FAILURE_FALLBACK,))
 
+    def test_retry_reads_findings_from_legacy_null_correction_field(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            review = state_dir / "failed/42-example-bird/attempt-01/quality-review.json"
+            review.parent.mkdir(parents=True)
+            review.write_text(
+                json.dumps(
+                    {
+                        "passed": False,
+                        "findings": ["Correct the measurement ranges"],
+                        "correction_findings": None,
+                    }
+                )
+            )
+            config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(io.StringIO()),
+            ):
+                retry_command(Namespace(taxon_id=42))
+
+            guidance = RetryStore(state_dir / "generation-retries.json").quality_guidance(42)
+
+        self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(guidance.findings, ("Correct the measurement ranges",))
+
     def test_retry_archives_incomplete_pending_candidate(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary

- fall back to legacy general findings when `correction_findings` is explicitly null
- preserve fail-closed validation for malformed non-list findings
- release the compatibility fix as 0.2.5

## Why

Pre-0.2.4 retained failures include the newer field with a null value. Retry treated that as malformed instead of using the populated legacy `findings` list, preventing safe correction attempts before any state was archived.

## Validation

- `uv sync --extra dev --locked`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest` (380 passed, 19 subtests)
- catalog validation (103 species)
- workflow pinning, actionlint, and ShellCheck