### PR TITLE
Add explicit approved plate replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,13 @@ inspection rather than publishing. A deliberate `retry` refreshes cached
 research and carries the final corrections into the next cycle. Maintainers can
 select a strong retained plate with `retry TAXON_ID --source-attempt N`; the
 source is archived, checksum-tracked, and edited rather than regenerated from
-scratch. Once a taxon passes, it is never regenerated implicitly.
+scratch. If human visual review rejects a locally approved plate before public
+publication, `retry TAXON_ID --replace-approved --reason "..."` is the explicit
+replacement migration: it records the rejection, archives the plate, removes
+it from local rotation, refreshes research and references, and regenerates from
+scratch while carrying the human rejection reason as a required constraint. It
+never rewrites an existing public catalog entry. Once a taxon passes, it is
+never regenerated implicitly.
 
 Regular application code handles selection, licensing rules, checksums, image
 dimensions, rotation, publishing, downloads, and display state. Codex handles

--- a/README.md
+++ b/README.md
@@ -78,10 +78,11 @@ source is archived, checksum-tracked, and edited rather than regenerated from
 scratch. If human visual review rejects a locally approved plate before public
 publication, `retry TAXON_ID --replace-approved --reason "..."` is the explicit
 replacement migration: it records the rejection, archives the plate, removes
-it from local rotation, refreshes research and references, and regenerates from
-scratch while carrying the human rejection reason as a required constraint. It
-never rewrites an existing public catalog entry. Once a taxon passes, it is
-never regenerated implicitly.
+it from local rotation, requeues historical-only taxa, refreshes research and
+references, and regenerates from scratch while carrying the human rejection
+reason as a required constraint through every correction attempt. The migration
+is safe to resume after interruption and never rewrites an existing public
+catalog entry. Once a taxon passes, it is never regenerated implicitly.
 
 Regular application code handles selection, licensing rules, checksums, image
 dimensions, rotation, publishing, downloads, and display state. Codex handles

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,7 +174,13 @@ corrections as durable input to the first new generation attempt while
 refreshing cached research. `retry TAXON_ID --source-attempt N` additionally
 selects a retained portrait as the edit base. The archive-relative source path
 stays in private retry state, and the passing manifest records its SHA-256 for
-provenance. Approved art is never replaced implicitly.
+provenance. After explicit human review,
+`retry TAXON_ID --replace-approved --reason "..."` withdraws a locally approved
+plate, preserves its rejection audit, rebuilds the local index, and starts a
+source-free replacement constrained by the human rejection reason. The public
+catalog remains add-only; replacing a published artifact requires a separate
+explicit migration and maintainer review. Approved art is never replaced
+implicitly.
 
 ## Privacy and licensing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -176,11 +176,12 @@ selects a retained portrait as the edit base. The archive-relative source path
 stays in private retry state, and the passing manifest records its SHA-256 for
 provenance. After explicit human review,
 `retry TAXON_ID --replace-approved --reason "..."` withdraws a locally approved
-plate, preserves its rejection audit, rebuilds the local index, and starts a
-source-free replacement constrained by the human rejection reason. The public
-catalog remains add-only; replacing a published artifact requires a separate
-explicit migration and maintainer review. Approved art is never replaced
-implicitly.
+plate, preserves its rejection audit, rebuilds the local index, requeues the
+taxon, and starts a source-free replacement constrained by the human rejection
+reason on every correction attempt. The migration is resumable after a partial
+failure. The public catalog remains add-only; replacing a published artifact
+requires a separate explicit migration and maintainer review. Approved art is
+never replaced implicitly.
 
 ## Privacy and licensing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,7 +171,9 @@ unchanged. The next scheduled cycle retries from the current remote branch.
 `retry TAXON_ID` archives incomplete pending, rejected, or failed state and
 makes that taxon eligible. For failed quality reviews, it retains the final actionable
 corrections as durable input to the first new generation attempt while
-refreshing cached research. `retry TAXON_ID --source-attempt N` additionally
+refreshing cached research. Invalid approval debris is archived and removed from
+the local index and active catalog before regeneration; a fully valid approved
+entry remains protected. `retry TAXON_ID --source-attempt N` additionally
 selects a retained portrait as the edit base. The archive-relative source path
 stays in private retry state, and the passing manifest records its SHA-256 for
 provenance. After explicit human review,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -338,6 +338,15 @@ only; they never enter the approved catalog or rotation.
   for the first edit. Omit `--source-attempt` when no retained image should be
   reused. Transient source failures retain the guidance and edit source until
   generation reaches a successful or terminal quality result.
+- Human rejection after local approval: before public publication, run
+  `retry TAXON_ID --replace-approved --reason "..."`. The non-empty reason and
+  replacement flag are mandatory. The command archives the approved artifacts
+  with rejection metadata, atomically rebuilds the local catalog index, clears
+  cached research and references, and makes the taxon eligible for a fresh
+  generation without an edit source. The human rejection reason remains as
+  required correction guidance for that fresh render. This local migration does
+  not replace an immutable public catalog entry; a published correction
+  requires a separate maintainer-reviewed migration.
 - Controller unavailable: the current e-paper image remains visible. Display
   state is not advanced.
 - Checksum mismatch: the display refuses the asset and preserves current state.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -343,10 +343,12 @@ only; they never enter the approved catalog or rotation.
   replacement flag are mandatory. The command archives the approved artifacts
   with rejection metadata, atomically rebuilds the local catalog index, clears
   cached research and references, and makes the taxon eligible for a fresh
-  generation without an edit source. The human rejection reason remains as
-  required correction guidance for that fresh render. This local migration does
-  not replace an immutable public catalog entry; a published correction
-  requires a separate maintainer-reviewed migration.
+  generation without an edit source, including for a historical-only taxon that
+  is no longer in live discovery. The human rejection reason remains required
+  correction guidance on every attempt. Re-running the same command and reason
+  safely resumes an interrupted migration. This local migration does not replace
+  an immutable public catalog entry; a published correction requires a separate
+  maintainer-reviewed migration.
 - Controller unavailable: the current e-paper image remains visible. Display
   state is not advanced.
 - Checksum mismatch: the display refuses the asset and preserves current state.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -337,7 +337,10 @@ only; they never enter the approved catalog or rotation.
   references and profile data, and preserves the selected attempt's corrections
   for the first edit. Omit `--source-attempt` when no retained image should be
   reused. Transient source failures retain the guidance and edit source until
-  generation reaches a successful or terminal quality result.
+  generation reaches a successful or terminal quality result. If retry finds an
+  interrupted, fully invalid approval directory, it archives that debris and
+  removes the stale local catalog entry before regeneration; a valid approved
+  plate still requires the explicit replacement command below.
 - Human rejection after local approval: before public publication, run
   `retry TAXON_ID --replace-approved --reason "..."`. The non-empty reason and
   replacement flag are mandatory. The command archives the approved artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.2.5"
+version = "0.2.6"
 description = "Generate and display reusable bird field-journal plates"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/inky_bird_frame/__init__.py
+++ b/src/inky_bird_frame/__init__.py
@@ -1,3 +1,3 @@
 """Local bird field-journal plates for Pimoroni Inky displays."""
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -479,6 +479,17 @@ def _valid_destination_entry(destination: Path, catalog_dir: Path) -> bool:
     return True
 
 
+def has_valid_approved_candidate(catalog_dir: Path, taxon_id: int) -> bool:
+    destination = find_taxon_directory(catalog_dir / "species", taxon_id)
+    if destination is None:
+        return False
+    try:
+        entry = _manifest_entry(destination / "manifest.json", catalog_dir)
+    except (CatalogError, OSError):
+        return False
+    return entry.taxon_id == taxon_id
+
+
 def approve_candidate(state_dir: Path, catalog_dir: Path, taxon_id: int) -> CatalogEntry:
     source = find_taxon_directory(state_dir / "pending", taxon_id)
     if source is None:

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -530,6 +530,72 @@ def approve_candidate(state_dir: Path, catalog_dir: Path, taxon_id: int) -> Cata
     return next(entry for entry in entries if entry.taxon_id == taxon_id)
 
 
+def _available_rejected_destination(state_dir: Path, name: str) -> Path:
+    destination = state_dir / "rejected" / name
+    counter = 1
+    while destination.exists():
+        destination = destination.with_name(f"{name}-{counter}")
+        counter += 1
+    return destination
+
+
+def withdraw_approved_candidate(
+    state_dir: Path,
+    catalog_dir: Path,
+    taxon_id: int,
+    reason: str,
+) -> Path:
+    rejection_reason = reason.strip()
+    if not rejection_reason:
+        raise CatalogError("Approved replacement requires a non-empty rejection reason")
+    source = find_taxon_directory(catalog_dir / "species", taxon_id)
+    if source is None:
+        raise CatalogError(f"No approved candidate exists for taxon {taxon_id}")
+    manifest_path = source / "manifest.json"
+    manifest = read_json(manifest_path)
+    if (
+        not isinstance(manifest, dict)
+        or manifest.get("taxon_id") != taxon_id
+        or manifest.get("status") != "approved"
+    ):
+        raise CatalogError(f"Approved candidate manifest is invalid: {manifest_path}")
+
+    destination = _available_rejected_destination(state_dir, source.name)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        shutil.copytree(source, destination)
+    except Exception:
+        if destination.exists():
+            shutil.rmtree(destination)
+        with suppress(OSError):
+            destination.parent.rmdir()
+        raise
+    try:
+        rejected_manifest = dict(manifest)
+        rejected_manifest["status"] = "rejected"
+        rejected_manifest["rejected_at"] = utc_now()
+        rejected_manifest["rejection_reason"] = rejection_reason
+        write_json_atomic(destination / "manifest.json", rejected_manifest)
+        shutil.rmtree(source)
+        rebuild_catalog_index(catalog_dir)
+    except Exception as error:
+        try:
+            if source.exists():
+                shutil.rmtree(source)
+            shutil.copytree(destination, source)
+            write_json_atomic(source / "manifest.json", manifest)
+        except Exception as rollback_error:
+            raise CatalogError(
+                "Approved candidate withdrawal failed and could not be rolled back; "
+                f"recovery copy retained at {destination}: {rollback_error}"
+            ) from error
+        shutil.rmtree(destination)
+        with suppress(OSError):
+            destination.parent.rmdir()
+        raise
+    return destination
+
+
 def reject_candidate(state_dir: Path, taxon_id: int, reason: str) -> Path:
     source = find_taxon_directory(state_dir / "pending", taxon_id)
     if source is None:
@@ -541,11 +607,7 @@ def reject_candidate(state_dir: Path, taxon_id: int, reason: str) -> Path:
     manifest["rejected_at"] = utc_now()
     manifest["rejection_reason"] = reason
     write_json_atomic(source / "manifest.json", manifest)
-    destination = state_dir / "rejected" / source.name
-    if destination.exists():
-        destination = destination.with_name(
-            f"{destination.name}-{datetime.now(UTC).timestamp():.0f}"
-        )
+    destination = _available_rejected_destination(state_dir, source.name)
     destination.parent.mkdir(parents=True, exist_ok=True)
     source.replace(destination)
     return destination

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -490,6 +490,52 @@ def has_valid_approved_candidate(catalog_dir: Path, taxon_id: int) -> bool:
     return entry.taxon_id == taxon_id
 
 
+def archive_invalid_approved_candidate(
+    state_dir: Path,
+    catalog_dir: Path,
+    taxon_id: int,
+) -> Path | None:
+    source = find_taxon_directory(catalog_dir / "species", taxon_id)
+    if source is None:
+        return None
+    if has_valid_approved_candidate(catalog_dir, taxon_id):
+        raise CatalogError(f"Taxon {taxon_id} has a valid approved candidate")
+
+    archive = state_dir / "archive"
+    destination = archive / f"invalid-approved-{source.name}"
+    counter = 1
+    while destination.exists():
+        destination = archive / f"invalid-approved-{source.name}-{counter}"
+        counter += 1
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        shutil.copytree(source, destination)
+    except Exception:
+        if destination.exists():
+            shutil.rmtree(destination)
+        with suppress(OSError):
+            destination.parent.rmdir()
+        raise
+    try:
+        shutil.rmtree(source)
+        rebuild_catalog_index(catalog_dir)
+    except Exception as error:
+        try:
+            if source.exists():
+                shutil.rmtree(source)
+            shutil.copytree(destination, source)
+        except Exception as rollback_error:
+            raise CatalogError(
+                "Invalid approved candidate archival failed and could not be rolled back; "
+                f"recovery copy retained at {destination}: {rollback_error}"
+            ) from error
+        shutil.rmtree(destination)
+        with suppress(OSError):
+            destination.parent.rmdir()
+        raise
+    return destination
+
+
 def approve_candidate(state_dir: Path, catalog_dir: Path, taxon_id: int) -> CatalogEntry:
     source = find_taxon_directory(state_dir / "pending", taxon_id)
     if source is None:

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -19,6 +19,7 @@ from .catalog import (
     approve_candidate,
     catalog_state_lock,
     find_taxon_directory,
+    has_valid_approved_candidate,
     read_json,
     rebuild_catalog_index,
     reject_candidate,
@@ -47,7 +48,7 @@ from .controller import (
 )
 from .display import show_on_inky
 from .display_node import run_display_cycle
-from .errors import CatalogError, InkyBirdFrameError, SpeciesStateError
+from .errors import InkyBirdFrameError, SpeciesStateError
 from .images import prepare_uploaded_image
 from .installation import InstallationRole, doctor, setup
 from .notifications import (
@@ -454,20 +455,6 @@ def _retry_quality_guidance(
     return tuple(findings) or (REVIEW_FAILURE_FALLBACK,), source_plate
 
 
-def _is_approved_candidate(path: Path | None, taxon_id: int) -> bool:
-    if path is None:
-        return False
-    try:
-        manifest = read_json(path / "manifest.json")
-    except CatalogError:
-        return False
-    return (
-        isinstance(manifest, dict)
-        and manifest.get("taxon_id") == taxon_id
-        and manifest.get("status") == "approved"
-    )
-
-
 def retry_command(args: argparse.Namespace) -> int:
     config = _config(args)
     replace_approved = bool(getattr(args, "replace_approved", False))
@@ -488,11 +475,7 @@ def retry_command(args: argparse.Namespace) -> int:
         pending = find_taxon_directory(config.controller.state_dir / "pending", args.taxon_id)
         if pending is not None and (pending / "manifest.json").is_file():
             raise ValueError("Pending candidates must be approved or rejected before retrying")
-        approved_path = find_taxon_directory(
-            config.controller.catalog_dir / "species",
-            args.taxon_id,
-        )
-        if _is_approved_candidate(approved_path, args.taxon_id):
+        if has_valid_approved_candidate(config.controller.catalog_dir, args.taxon_id):
             raise ValueError(
                 f"Taxon {args.taxon_id} is already approved; use --replace-approved "
                 "with --reason after human review"

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -34,6 +34,7 @@ from .config import (
 from .controller import (
     REVIEW_FAILURE_FALLBACK,
     add_collection_member,
+    archive_invalid_approved_catalog_state,
     collection_status,
     discover_species,
     enqueue_seed_species,
@@ -475,11 +476,12 @@ def retry_command(args: argparse.Namespace) -> int:
         pending = find_taxon_directory(config.controller.state_dir / "pending", args.taxon_id)
         if pending is not None and (pending / "manifest.json").is_file():
             raise ValueError("Pending candidates must be approved or rejected before retrying")
-        if has_valid_approved_candidate(config.controller.catalog_dir, args.taxon_id):
-            raise ValueError(
-                f"Taxon {args.taxon_id} is already approved; use --replace-approved "
-                "with --reason after human review"
-            )
+        with catalog_state_lock(config.controller.state_dir):
+            if has_valid_approved_candidate(config.controller.catalog_dir, args.taxon_id):
+                raise ValueError(
+                    f"Taxon {args.taxon_id} is already approved; use --replace-approved "
+                    "with --reason after human review"
+                )
         failed_directories = sorted(
             (config.controller.state_dir / "failed").glob(f"{args.taxon_id}-*")
         )
@@ -517,9 +519,13 @@ def retry_command(args: argparse.Namespace) -> int:
         )
         if correction_source is not None and correction_owner is None:
             raise SpeciesStateError("The selected correction source is outside retained state")
+        invalid_approved_archive = archive_invalid_approved_catalog_state(
+            config,
+            args.taxon_id,
+        )
         archive = config.controller.state_dir / "archive"
         archive.mkdir(parents=True, exist_ok=True)
-        moved: list[str] = []
+        moved = [str(invalid_approved_archive)] if invalid_approved_archive is not None else []
         archived_correction_source: Path | None = None
         for source in sources:
             destination = archive / source.name

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -22,6 +22,7 @@ from .catalog import (
     read_json,
     rebuild_catalog_index,
     reject_candidate,
+    withdraw_approved_candidate,
 )
 from .config import (
     AppConfig,
@@ -455,23 +456,57 @@ def _retry_quality_guidance(
 
 def retry_command(args: argparse.Namespace) -> int:
     config = _config(args)
+    replace_approved = bool(getattr(args, "replace_approved", False))
+    raw_reason = getattr(args, "reason", None)
+    reason = raw_reason.strip() if isinstance(raw_reason, str) else None
+    source_attempt = getattr(args, "source_attempt", None)
+    if replace_approved and source_attempt is not None:
+        raise ValueError("--replace-approved cannot be combined with --source-attempt")
+    if replace_approved and not reason:
+        raise ValueError("--replace-approved requires a non-empty --reason")
+    if not replace_approved and raw_reason is not None:
+        raise ValueError("--reason requires --replace-approved")
+
     with exclusive_cycle_lock(config.controller.state_dir):
         pending = find_taxon_directory(config.controller.state_dir / "pending", args.taxon_id)
         if pending is not None and (pending / "manifest.json").is_file():
             raise ValueError("Pending candidates must be approved or rejected before retrying")
+        approved = find_taxon_directory(
+            config.controller.catalog_dir / "species",
+            args.taxon_id,
+        )
+        if approved is not None and not replace_approved:
+            raise ValueError(
+                f"Taxon {args.taxon_id} is already approved; use --replace-approved "
+                "with --reason after human review"
+            )
+        if approved is None and replace_approved:
+            raise ValueError(f"No approved candidate exists for taxon {args.taxon_id}")
         failed_directories = sorted(
             (config.controller.state_dir / "failed").glob(f"{args.taxon_id}-*")
         )
-        source_attempt = getattr(args, "source_attempt", None)
-        quality_findings, correction_source = _retry_quality_guidance(
-            failed_directories,
-            source_attempt,
-        )
+        quality_findings: tuple[str, ...]
+        correction_source: Path | None
+        if replace_approved:
+            quality_findings, correction_source = (reason or "",), None
+        else:
+            quality_findings, correction_source = _retry_quality_guidance(
+                failed_directories,
+                source_attempt,
+            )
         sources = [pending] if pending is not None else []
         sources.extend(failed_directories)
-        rejected = find_taxon_directory(config.controller.state_dir / "rejected", args.taxon_id)
-        if rejected is not None:
-            sources.append(rejected)
+        if replace_approved:
+            with catalog_state_lock(config.controller.state_dir):
+                withdraw_approved_candidate(
+                    config.controller.state_dir,
+                    config.controller.catalog_dir,
+                    args.taxon_id,
+                    reason or "",
+                )
+        sources.extend(
+            sorted((config.controller.state_dir / "rejected").glob(f"{args.taxon_id}-*"))
+        )
         retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
         deferred = retry_store.get(args.taxon_id) is not None
         if not sources and not deferred:
@@ -511,7 +546,8 @@ def retry_command(args: argparse.Namespace) -> int:
             shutil.move(str(source), destination)
             moved.append(str(destination))
         retry_store.clear(args.taxon_id)
-        guidance = retry_store.quality_guidance(args.taxon_id)
+        retry_store.clear_quality_guidance(args.taxon_id)
+        guidance = None
         if quality_findings:
             guidance = retry_store.set_quality_guidance(
                 args.taxon_id,
@@ -533,6 +569,7 @@ def retry_command(args: argparse.Namespace) -> int:
             "preserved_quality_findings_count": (
                 len(guidance.findings) if guidance is not None else 0
             ),
+            "replaced_approved": replace_approved,
             "source_attempt": source_attempt,
             "preserved_correction_source": archived_correction_source is not None,
         }
@@ -1006,6 +1043,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--source-attempt",
         type=int,
         help="Edit a selected retained attempt instead of generating the first retry from scratch",
+    )
+    retry_parser.add_argument(
+        "--replace-approved",
+        action="store_true",
+        help="Withdraw a locally approved plate after human review and regenerate from scratch",
+    )
+    retry_parser.add_argument(
+        "--reason",
+        help="Human rejection reason required with --replace-approved",
     )
     retry_parser.set_defaults(func=retry_command)
 

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -22,7 +22,6 @@ from .catalog import (
     read_json,
     rebuild_catalog_index,
     reject_candidate,
-    withdraw_approved_candidate,
 )
 from .config import (
     AppConfig,
@@ -41,6 +40,7 @@ from .controller import (
     import_approved_collection,
     read_generation_queue_partition,
     remove_collection_member,
+    retry_approved_candidate,
     run_controller_cycle,
     run_generation_cycle,
     run_refresh_cycle,
@@ -460,11 +460,14 @@ def retry_command(args: argparse.Namespace) -> int:
     raw_reason = getattr(args, "reason", None)
     reason = raw_reason.strip() if isinstance(raw_reason, str) else None
     source_attempt = getattr(args, "source_attempt", None)
-    if replace_approved and source_attempt is not None:
-        raise ValueError("--replace-approved cannot be combined with --source-attempt")
-    if replace_approved and not reason:
-        raise ValueError("--replace-approved requires a non-empty --reason")
-    if not replace_approved and raw_reason is not None:
+    if replace_approved:
+        if source_attempt is not None:
+            raise ValueError("--replace-approved cannot be combined with --source-attempt")
+        if not reason:
+            raise ValueError("--replace-approved requires a non-empty --reason")
+        print_result(retry_approved_candidate(config, args.taxon_id, reason))
+        return 0
+    if raw_reason is not None:
         raise ValueError("--reason requires --replace-approved")
 
     with exclusive_cycle_lock(config.controller.state_dir):
@@ -475,39 +478,25 @@ def retry_command(args: argparse.Namespace) -> int:
             config.controller.catalog_dir / "species",
             args.taxon_id,
         )
-        if approved is not None and not replace_approved:
+        if approved is not None:
             raise ValueError(
                 f"Taxon {args.taxon_id} is already approved; use --replace-approved "
                 "with --reason after human review"
             )
-        if approved is None and replace_approved:
-            raise ValueError(f"No approved candidate exists for taxon {args.taxon_id}")
         failed_directories = sorted(
             (config.controller.state_dir / "failed").glob(f"{args.taxon_id}-*")
         )
-        quality_findings: tuple[str, ...]
-        correction_source: Path | None
-        if replace_approved:
-            quality_findings, correction_source = (reason or "",), None
-        else:
-            quality_findings, correction_source = _retry_quality_guidance(
-                failed_directories,
-                source_attempt,
-            )
+        quality_findings, correction_source = _retry_quality_guidance(
+            failed_directories,
+            source_attempt,
+        )
         sources = [pending] if pending is not None else []
         sources.extend(failed_directories)
-        if replace_approved:
-            with catalog_state_lock(config.controller.state_dir):
-                withdraw_approved_candidate(
-                    config.controller.state_dir,
-                    config.controller.catalog_dir,
-                    args.taxon_id,
-                    reason or "",
-                )
         sources.extend(
             sorted((config.controller.state_dir / "rejected").glob(f"{args.taxon_id}-*"))
         )
         retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
+        existing_guidance = retry_store.quality_guidance(args.taxon_id)
         deferred = retry_store.get(args.taxon_id) is not None
         if not sources and not deferred:
             raise ValueError(
@@ -546,16 +535,18 @@ def retry_command(args: argparse.Namespace) -> int:
             shutil.move(str(source), destination)
             moved.append(str(destination))
         retry_store.clear(args.taxon_id)
-        retry_store.clear_quality_guidance(args.taxon_id)
-        guidance = None
+        final_guidance = existing_guidance
         if quality_findings:
-            guidance = retry_store.set_quality_guidance(
+            final_guidance = retry_store.set_quality_guidance(
                 args.taxon_id,
                 quality_findings,
                 source_plate=(
                     archived_correction_source.relative_to(config.controller.state_dir).as_posix()
                     if archived_correction_source is not None
                     else None
+                ),
+                invariant_findings=(
+                    existing_guidance.invariant_findings if existing_guidance is not None else ()
                 ),
             )
     print_result(
@@ -567,11 +558,13 @@ def retry_command(args: argparse.Namespace) -> int:
             "cleared_cached_profile": cleared_cached_profile,
             "cleared_cached_references": cleared_cached_references,
             "preserved_quality_findings_count": (
-                len(guidance.findings) if guidance is not None else 0
+                len(final_guidance.findings) if final_guidance is not None else 0
             ),
-            "replaced_approved": replace_approved,
+            "replaced_approved": False,
             "source_attempt": source_attempt,
-            "preserved_correction_source": archived_correction_source is not None,
+            "preserved_correction_source": (
+                final_guidance is not None and final_guidance.source_plate is not None
+            ),
         }
     )
     return 0

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -47,7 +47,7 @@ from .controller import (
 )
 from .display import show_on_inky
 from .display_node import run_display_cycle
-from .errors import InkyBirdFrameError, SpeciesStateError
+from .errors import CatalogError, InkyBirdFrameError, SpeciesStateError
 from .images import prepare_uploaded_image
 from .installation import InstallationRole, doctor, setup
 from .notifications import (
@@ -454,6 +454,20 @@ def _retry_quality_guidance(
     return tuple(findings) or (REVIEW_FAILURE_FALLBACK,), source_plate
 
 
+def _is_approved_candidate(path: Path | None, taxon_id: int) -> bool:
+    if path is None:
+        return False
+    try:
+        manifest = read_json(path / "manifest.json")
+    except CatalogError:
+        return False
+    return (
+        isinstance(manifest, dict)
+        and manifest.get("taxon_id") == taxon_id
+        and manifest.get("status") == "approved"
+    )
+
+
 def retry_command(args: argparse.Namespace) -> int:
     config = _config(args)
     replace_approved = bool(getattr(args, "replace_approved", False))
@@ -474,11 +488,11 @@ def retry_command(args: argparse.Namespace) -> int:
         pending = find_taxon_directory(config.controller.state_dir / "pending", args.taxon_id)
         if pending is not None and (pending / "manifest.json").is_file():
             raise ValueError("Pending candidates must be approved or rejected before retrying")
-        approved = find_taxon_directory(
+        approved_path = find_taxon_directory(
             config.controller.catalog_dir / "species",
             args.taxon_id,
         )
-        if approved is not None:
+        if _is_approved_candidate(approved_path, args.taxon_id):
             raise ValueError(
                 f"Taxon {args.taxon_id} is already approved; use --replace-approved "
                 "with --reason after human review"

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -35,11 +35,13 @@ from .catalog import (
     add_collection_taxa,
     approve_candidate,
     approved_taxon_ids,
+    archive_invalid_approved_candidate,
     candidate_directory,
     catalog_state_lock,
     clear_catalog_staging,
     find_taxon_directory,
     has_passing_sourced_review,
+    has_valid_approved_candidate,
     is_bounded_generation,
     read_catalog_entries,
     read_collection,
@@ -719,6 +721,33 @@ def _current_discovery_species(config: AppConfig) -> list[BirdSpecies]:
     return _read_discovery_snapshot(config).species
 
 
+def archive_invalid_approved_catalog_state(
+    config: AppConfig,
+    taxon_id: int,
+) -> Path | None:
+    with catalog_state_lock(config.controller.state_dir):
+        observed = _current_discovery_species(config)
+        approved_path = find_taxon_directory(
+            config.controller.catalog_dir / "species",
+            taxon_id,
+        )
+        if approved_path is None:
+            _write_active_catalog(config, observed)
+            return None
+        if has_valid_approved_candidate(config.controller.catalog_dir, taxon_id):
+            raise ValueError(
+                f"Taxon {taxon_id} is already approved; use --replace-approved "
+                "with --reason after human review"
+            )
+        archived = archive_invalid_approved_candidate(
+            config.controller.state_dir,
+            config.controller.catalog_dir,
+            taxon_id,
+        )
+        _write_active_catalog(config, observed)
+        return archived
+
+
 def _replacement_species(
     taxon_id: int,
     common_name: object,
@@ -799,6 +828,24 @@ def _archive_controller_paths(state_dir: Path, sources: list[Path]) -> list[str]
     return moved
 
 
+def _migrate_legacy_queue_before_replacement(
+    config: AppConfig,
+    queued_species: list[BirdSpecies],
+    taxon_id: int,
+) -> None:
+    pre_replacement_queue = [species for species in queued_species if species.taxon_id != taxon_id]
+    collection, _, migrated_at, migration_applied = _migrate_legacy_seed_queue(
+        read_collection_state(config.controller.state_dir),
+        pre_replacement_queue,
+    )
+    if migration_applied:
+        write_collection(
+            config.controller.state_dir,
+            collection,
+            legacy_seed_queue_migrated_at=migrated_at,
+        )
+
+
 def retry_approved_candidate(
     config: AppConfig,
     taxon_id: int,
@@ -828,7 +875,6 @@ def retry_approved_candidate(
             retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
             queued_species = read_generation_queue(config)
             observed = _current_discovery_species(config)
-            read_collection_state(config.controller.state_dir)
             resumable = (
                 _resumable_approved_replacement(
                     config.controller.state_dir,
@@ -853,6 +899,7 @@ def retry_approved_candidate(
                 )
                 if not already_prepared:
                     raise ValueError(f"No approved candidate exists for taxon {taxon_id}")
+                _migrate_legacy_queue_before_replacement(config, queued_species, taxon_id)
                 assert guidance is not None
                 active_count = _write_active_catalog(
                     config,
@@ -892,6 +939,7 @@ def retry_approved_candidate(
                 or queued.scientific_name != species.scientific_name
             ):
                 raise CatalogError(f"Generation queue identity differs for taxon {taxon_id}")
+            _migrate_legacy_queue_before_replacement(config, queued_species, taxon_id)
 
             rejected_paths = sorted(
                 (config.controller.state_dir / "rejected").glob(f"{taxon_id}-*")

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -833,7 +833,11 @@ def _migrate_legacy_queue_before_replacement(
     queued_species: list[BirdSpecies],
     taxon_id: int,
 ) -> None:
-    pre_replacement_queue = [species for species in queued_species if species.taxon_id != taxon_id]
+    pre_replacement_queue = [
+        species
+        for species in queued_species
+        if species.taxon_id != taxon_id or HUMAN_REVIEW_SOURCE not in species.sources
+    ]
     collection, _, migrated_at, migration_applied = _migrate_legacy_seed_queue(
         read_collection_state(config.controller.state_dir),
         pre_replacement_queue,

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -44,10 +44,12 @@ from .catalog import (
     read_catalog_entries,
     read_collection,
     read_collection_state,
+    read_json,
     rebuild_catalog_index,
     remove_collection_taxa,
     sha256_file,
     utc_now,
+    withdraw_approved_candidate,
     write_candidate_manifest,
     write_collection,
 )
@@ -74,6 +76,14 @@ from .retry import RetryStore
 from .timeutil import parse_utc_timestamp
 
 REVIEW_FAILURE_FALLBACK = "The previous attempt did not meet every automated review threshold."
+HUMAN_REVIEW_SOURCE = "human-review"
+
+
+def _merge_correction_findings(
+    invariant_findings: tuple[str, ...],
+    current_findings: tuple[str, ...],
+) -> tuple[str, ...]:
+    return tuple(dict.fromkeys((*invariant_findings, *current_findings)))
 
 
 @dataclass(frozen=True)
@@ -709,6 +719,236 @@ def _current_discovery_species(config: AppConfig) -> list[BirdSpecies]:
     return _read_discovery_snapshot(config).species
 
 
+def _replacement_species(
+    taxon_id: int,
+    common_name: object,
+    scientific_name: object,
+    source: Path,
+) -> BirdSpecies:
+    if (
+        not isinstance(common_name, str)
+        or not common_name.strip()
+        or not isinstance(scientific_name, str)
+        or not scientific_name.strip()
+    ):
+        raise CatalogError(f"Replacement candidate identity is invalid: {source}")
+    return BirdSpecies(
+        taxon_id=taxon_id,
+        common_name=common_name,
+        scientific_name=scientific_name,
+        observation_count=0,
+        source=HUMAN_REVIEW_SOURCE,
+    )
+
+
+def _resumable_approved_replacement(
+    state_dir: Path,
+    taxon_id: int,
+    reason: str,
+) -> tuple[Path, BirdSpecies] | None:
+    matches: list[tuple[Path, BirdSpecies]] = []
+    for path in sorted((state_dir / "rejected").glob(f"{taxon_id}-*")):
+        manifest_path = path / "manifest.json"
+        if not manifest_path.is_file():
+            continue
+        manifest = read_json(manifest_path)
+        if not isinstance(manifest, dict):
+            raise CatalogError(f"Rejected candidate manifest is invalid: {manifest_path}")
+        if (
+            manifest.get("taxon_id") != taxon_id
+            or manifest.get("status") != "rejected"
+            or not isinstance(manifest.get("approved_at"), str)
+            or manifest.get("rejection_reason") != reason
+        ):
+            continue
+        matches.append(
+            (
+                path,
+                _replacement_species(
+                    taxon_id,
+                    manifest.get("common_name"),
+                    manifest.get("scientific_name"),
+                    manifest_path,
+                ),
+            )
+        )
+    if len(matches) > 1:
+        raise CatalogError(f"Multiple resumable replacements exist for taxon {taxon_id}")
+    return matches[0] if matches else None
+
+
+def _archive_controller_paths(state_dir: Path, sources: list[Path]) -> list[str]:
+    archive = state_dir / "archive"
+    archive.mkdir(parents=True, exist_ok=True)
+    moved: list[str] = []
+    seen: set[Path] = set()
+    for source in sources:
+        if not source.exists():
+            continue
+        resolved = source.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        destination = archive / source.name
+        counter = 1
+        while destination.exists():
+            destination = archive / f"{source.name}-{counter}"
+            counter += 1
+        shutil.move(str(source), destination)
+        moved.append(str(destination))
+    return moved
+
+
+def retry_approved_candidate(
+    config: AppConfig,
+    taxon_id: int,
+    reason: str,
+) -> dict[str, object]:
+    rejection_reason = reason.strip()
+    if not rejection_reason:
+        raise ValueError("Approved replacement requires a non-empty rejection reason")
+
+    with exclusive_cycle_lock(config.controller.state_dir):
+        pending = find_taxon_directory(config.controller.state_dir / "pending", taxon_id)
+        if pending is not None and (pending / "manifest.json").is_file():
+            raise ValueError("Pending candidates must be approved or rejected before retrying")
+        with catalog_state_lock(config.controller.state_dir):
+            approved_entries = read_catalog_entries(config.controller.catalog_dir)
+            approved_entry = next(
+                (entry for entry in approved_entries if entry.taxon_id == taxon_id),
+                None,
+            )
+            approved_path = find_taxon_directory(
+                config.controller.catalog_dir / "species",
+                taxon_id,
+            )
+            if (approved_entry is None) != (approved_path is None):
+                raise CatalogError(f"Approved catalog state is inconsistent for taxon {taxon_id}")
+
+            retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
+            queued_species = read_generation_queue(config)
+            observed = _current_discovery_species(config)
+            read_collection_state(config.controller.state_dir)
+            resumable = (
+                _resumable_approved_replacement(
+                    config.controller.state_dir,
+                    taxon_id,
+                    rejection_reason,
+                )
+                if approved_entry is None
+                else None
+            )
+            queued = next(
+                (species for species in queued_species if species.taxon_id == taxon_id),
+                None,
+            )
+            guidance = retry_store.quality_guidance(taxon_id)
+            if approved_entry is None and resumable is None:
+                already_prepared = (
+                    queued is not None
+                    and guidance is not None
+                    and rejection_reason in guidance.invariant_findings
+                    and guidance.source_plate is None
+                    and not _has_terminal_state(config.controller.state_dir, taxon_id)
+                )
+                if not already_prepared:
+                    raise ValueError(f"No approved candidate exists for taxon {taxon_id}")
+                assert guidance is not None
+                active_count = _write_active_catalog(
+                    config,
+                    observed,
+                    approved=approved_entries,
+                )
+                return {
+                    "taxon_id": taxon_id,
+                    "status": "eligible",
+                    "archived": [],
+                    "cleared_deferred_retry": False,
+                    "cleared_cached_profile": False,
+                    "cleared_cached_references": False,
+                    "preserved_quality_findings_count": len(guidance.findings),
+                    "replaced_approved": True,
+                    "resumed": True,
+                    "source_attempt": None,
+                    "preserved_correction_source": False,
+                    "active_approved_count": active_count,
+                    "queued_for_generation": True,
+                }
+
+            if approved_entry is not None and approved_path is not None:
+                species = _replacement_species(
+                    taxon_id,
+                    approved_entry.common_name,
+                    approved_entry.scientific_name,
+                    approved_path / "manifest.json",
+                )
+                withdrawn: Path | None = None
+            else:
+                assert resumable is not None
+                withdrawn, species = resumable
+
+            if queued is not None and (
+                queued.common_name != species.common_name
+                or queued.scientific_name != species.scientific_name
+            ):
+                raise CatalogError(f"Generation queue identity differs for taxon {taxon_id}")
+
+            rejected_paths = sorted(
+                (config.controller.state_dir / "rejected").glob(f"{taxon_id}-*")
+            )
+            old_sources = [pending] if pending is not None else []
+            old_sources.extend(
+                sorted((config.controller.state_dir / "failed").glob(f"{taxon_id}-*"))
+            )
+            old_sources.extend(path for path in rejected_paths if path != withdrawn)
+            profile_cache = config.controller.state_dir / "profiles" / str(taxon_id)
+            reference_cache = config.controller.state_dir / "references" / str(taxon_id)
+            cleared_cached_profile = profile_cache.exists()
+            cleared_cached_references = reference_cache.exists()
+            if cleared_cached_profile:
+                old_sources.append(profile_cache)
+            if cleared_cached_references:
+                old_sources.append(reference_cache)
+            moved = _archive_controller_paths(config.controller.state_dir, old_sources)
+
+            if queued is None:
+                queued_species.append(species)
+                _write_generation_queue(config, queued_species)
+            deferred = retry_store.get(taxon_id) is not None
+            retry_store.clear(taxon_id)
+            guidance = retry_store.set_quality_guidance(
+                taxon_id,
+                (rejection_reason,),
+                invariant_findings=(rejection_reason,),
+            )
+
+            if withdrawn is None:
+                withdrawn = withdraw_approved_candidate(
+                    config.controller.state_dir,
+                    config.controller.catalog_dir,
+                    taxon_id,
+                    rejection_reason,
+                )
+            active_count = _write_active_catalog(config, observed)
+            moved.extend(_archive_controller_paths(config.controller.state_dir, [withdrawn]))
+
+    return {
+        "taxon_id": taxon_id,
+        "status": "eligible",
+        "archived": moved,
+        "cleared_deferred_retry": deferred,
+        "cleared_cached_profile": cleared_cached_profile,
+        "cleared_cached_references": cleared_cached_references,
+        "preserved_quality_findings_count": len(guidance.findings),
+        "replaced_approved": True,
+        "resumed": resumable is not None,
+        "source_attempt": None,
+        "preserved_correction_source": False,
+        "active_approved_count": active_count,
+        "queued_for_generation": True,
+    }
+
+
 def _collection_summary(
     entries: list[CollectionEntry],
     approved: list[CatalogEntry],
@@ -991,6 +1231,7 @@ def generate_candidate(
     *,
     initial_correction_findings: tuple[str, ...] = (),
     initial_correction_source: Path | None = None,
+    invariant_correction_findings: tuple[str, ...] = (),
 ) -> Path:
     state_dir = config.controller.state_dir
     if species.taxon_id in approved_taxon_ids(config.controller.catalog_dir):
@@ -1024,7 +1265,10 @@ def generate_candidate(
             profile_output_path,
             logs / "01-profile.log",
         )
-        correction_findings = initial_correction_findings
+        correction_findings = _merge_correction_findings(
+            invariant_correction_findings,
+            initial_correction_findings,
+        )
         correction_source = initial_correction_source
         history: list[dict[str, object]] = []
         for attempt in range(1, config.controller.max_generation_attempts + 1):
@@ -1091,7 +1335,10 @@ def generate_candidate(
                     raise CatalogError(f"Pending destination already exists: {destination}")
                 shutil.copytree(attempt_dir, destination)
                 return destination
-            correction_findings = review.correction_findings or (REVIEW_FAILURE_FALLBACK,)
+            correction_findings = _merge_correction_findings(
+                invariant_correction_findings,
+                review.correction_findings or (REVIEW_FAILURE_FALLBACK,),
+            )
             correction_source = portrait_path
 
         failed = state_dir / "failed" / f"{species.taxon_id}-{_timestamp()}"
@@ -1255,8 +1502,8 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
             if not retry_store.due(species.taxon_id, datetime.now(UTC)):
                 continue
             attempted_count += 1
+            guidance = retry_store.quality_guidance(species.taxon_id)
             try:
-                guidance = retry_store.quality_guidance(species.taxon_id)
                 if guidance is None:
                     generate_candidate(config, species, config.controller.workspace_dir)
                 else:
@@ -1266,7 +1513,14 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                             guidance.source_plate,
                         )
                     except SpeciesStateError:
-                        retry_store.clear_quality_guidance(species.taxon_id)
+                        if guidance.invariant_findings:
+                            retry_store.set_quality_guidance(
+                                species.taxon_id,
+                                guidance.invariant_findings,
+                                invariant_findings=guidance.invariant_findings,
+                            )
+                        else:
+                            retry_store.clear_quality_guidance(species.taxon_id)
                         raise
                     generate_candidate(
                         config,
@@ -1274,6 +1528,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                         config.controller.workspace_dir,
                         initial_correction_findings=guidance.findings,
                         initial_correction_source=correction_source,
+                        invariant_correction_findings=guidance.invariant_findings,
                     )
                 with catalog_state_lock(config.controller.state_dir):
                     entry = approve_candidate(
@@ -1327,7 +1582,14 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 )
             except QualityReviewError as exc:
                 retry_store.clear(species.taxon_id)
-                retry_store.clear_quality_guidance(species.taxon_id)
+                if guidance is not None and guidance.invariant_findings:
+                    retry_store.set_quality_guidance(
+                        species.taxon_id,
+                        guidance.invariant_findings,
+                        invariant_findings=guidance.invariant_findings,
+                    )
+                else:
+                    retry_store.clear_quality_guidance(species.taxon_id)
                 failure_path = record_failure(config.controller.state_dir, species, exc)
                 failures.append(
                     {

--- a/src/inky_bird_frame/retry.py
+++ b/src/inky_bird_frame/retry.py
@@ -6,6 +6,7 @@ import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path, PurePosixPath
+from typing import cast
 
 from .catalog import utc_now
 from .errors import CatalogError
@@ -40,6 +41,7 @@ class RetryGuidance:
     taxon_id: int
     findings: tuple[str, ...]
     source_plate: str | None = None
+    invariant_findings: tuple[str, ...] = ()
 
     def as_dict(self) -> dict[str, object]:
         value: dict[str, object] = {
@@ -48,6 +50,8 @@ class RetryGuidance:
         }
         if self.source_plate is not None:
             value["source_plate"] = self.source_plate
+        if self.invariant_findings:
+            value["invariant_findings"] = list(self.invariant_findings)
         return value
 
 
@@ -135,12 +139,14 @@ class RetryStore:
         findings: tuple[str, ...],
         *,
         source_plate: str | None = None,
+        invariant_findings: tuple[str, ...] = (),
     ) -> RetryGuidance:
         guidance = _parse_guidance(
             {
                 "taxon_id": taxon_id,
                 "findings": list(findings),
                 "source_plate": source_plate,
+                "invariant_findings": list(invariant_findings),
             },
             self.path,
         )
@@ -235,6 +241,7 @@ def _parse_guidance(raw: object, source: Path) -> RetryGuidance:
     taxon_id = raw.get("taxon_id")
     findings = raw.get("findings")
     source_plate = raw.get("source_plate")
+    invariant_findings = raw.get("invariant_findings", [])
     if (
         not isinstance(taxon_id, int)
         or isinstance(taxon_id, bool)
@@ -242,6 +249,10 @@ def _parse_guidance(raw: object, source: Path) -> RetryGuidance:
         or not isinstance(findings, list)
         or not findings
         or any(not isinstance(finding, str) or not finding.strip() for finding in findings)
+        or not isinstance(invariant_findings, list)
+        or any(
+            not isinstance(finding, str) or not finding.strip() for finding in invariant_findings
+        )
     ):
         raise CatalogError(f"Invalid retry quality guidance: {source}")
     if source_plate is not None:
@@ -257,8 +268,12 @@ def _parse_guidance(raw: object, source: Path) -> RetryGuidance:
         ):
             raise CatalogError(f"Invalid retry quality guidance: {source}")
         source_plate = source_path.as_posix()
+    merged_findings = tuple(
+        dict.fromkeys((*cast(list[str], invariant_findings), *cast(list[str], findings)))
+    )
     return RetryGuidance(
         taxon_id=taxon_id,
-        findings=tuple(findings),
+        findings=merged_findings,
         source_plate=source_plate,
+        invariant_findings=tuple(cast(list[str], invariant_findings)),
     )

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -15,6 +15,7 @@ from inky_bird_frame.catalog import (
     add_collection_taxa,
     approve_candidate,
     candidate_directory,
+    has_valid_approved_candidate,
     read_catalog_entries,
     read_collection,
     read_collection_state,
@@ -206,6 +207,23 @@ class CatalogTests(unittest.TestCase):
             self.assertFalse(candidate.exists())
             with self.assertRaises(CatalogError):
                 approve_candidate(state, catalog, species.taxon_id)
+
+    def test_valid_approved_candidate_requires_complete_checked_assets(self) -> None:
+        species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")
+        review = QualityReview(True, 4, 4, 4, 4, True, ())
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            state = root / "state"
+            catalog = root / "catalog"
+            make_candidate(state, species, review)
+            approve_candidate(state, catalog, species.taxon_id)
+
+            complete = has_valid_approved_candidate(catalog, species.taxon_id)
+            (catalog / "species/7513-carolina-wren/display.png").unlink()
+            incomplete = has_valid_approved_candidate(catalog, species.taxon_id)
+
+        self.assertTrue(complete)
+        self.assertFalse(incomplete)
 
     def test_approved_candidate_withdrawal_preserves_human_rejection_audit(self) -> None:
         species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -6,6 +6,7 @@ import unittest
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from inky_bird_frame.birds import BirdSpecies
 from inky_bird_frame.catalog import (
@@ -20,6 +21,7 @@ from inky_bird_frame.catalog import (
     read_json,
     rebuild_catalog_index,
     remove_collection_taxa,
+    withdraw_approved_candidate,
     write_candidate_manifest,
     write_collection,
 )
@@ -204,6 +206,74 @@ class CatalogTests(unittest.TestCase):
             self.assertFalse(candidate.exists())
             with self.assertRaises(CatalogError):
                 approve_candidate(state, catalog, species.taxon_id)
+
+    def test_approved_candidate_withdrawal_preserves_human_rejection_audit(self) -> None:
+        species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")
+        review = QualityReview(True, 4, 4, 4, 4, True, ())
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            state = root / "state"
+            catalog = root / "catalog"
+            make_candidate(state, species, review)
+            approved = approve_candidate(state, catalog, species.taxon_id)
+
+            destination = withdraw_approved_candidate(
+                state,
+                catalog,
+                species.taxon_id,
+                "The eyes are not visually credible.",
+            )
+
+            manifest = read_json(destination / "manifest.json")
+            index = read_json(catalog / "index.json")
+            portrait_exists = (destination / "portrait.png").is_file()
+
+        self.assertIsInstance(manifest, dict)
+        if isinstance(manifest, dict):
+            self.assertEqual(manifest["status"], "rejected")
+            self.assertEqual(manifest["rejection_reason"], "The eyes are not visually credible.")
+            self.assertEqual(manifest["approved_at"], approved.approved_at)
+            self.assertIn("rejected_at", manifest)
+        self.assertTrue(portrait_exists)
+        self.assertIsInstance(index, dict)
+        if isinstance(index, dict):
+            self.assertEqual(index["species"], [])
+
+    def test_approved_candidate_withdrawal_rolls_back_on_index_failure(self) -> None:
+        species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")
+        review = QualityReview(True, 4, 4, 4, 4, True, ())
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            state = root / "state"
+            catalog = root / "catalog"
+            make_candidate(state, species, review)
+            approve_candidate(state, catalog, species.taxon_id)
+            source = catalog / "species/7513-carolina-wren"
+
+            with (
+                patch(
+                    "inky_bird_frame.catalog.rebuild_catalog_index",
+                    side_effect=CatalogError("index failure"),
+                ),
+                self.assertRaisesRegex(CatalogError, "index failure"),
+            ):
+                withdraw_approved_candidate(
+                    state,
+                    catalog,
+                    species.taxon_id,
+                    "Human review failed.",
+                )
+
+            manifest = read_json(source / "manifest.json")
+            source_exists = source.is_dir()
+            rejected_exists = (state / "rejected").exists()
+
+        self.assertTrue(source_exists)
+        self.assertIsInstance(manifest, dict)
+        if isinstance(manifest, dict):
+            self.assertEqual(manifest["status"], "approved")
+            self.assertNotIn("rejection_reason", manifest)
+        self.assertFalse(rejected_exists)
 
     def test_interrupted_approval_with_leftover_pending_candidate_completes(self) -> None:
         species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -14,6 +14,7 @@ from inky_bird_frame.catalog import (
     CollectionOrigin,
     add_collection_taxa,
     approve_candidate,
+    archive_invalid_approved_candidate,
     candidate_directory,
     has_valid_approved_candidate,
     read_catalog_entries,
@@ -224,6 +225,32 @@ class CatalogTests(unittest.TestCase):
 
         self.assertTrue(complete)
         self.assertFalse(incomplete)
+
+    def test_invalid_approved_archival_rolls_back_on_index_failure(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            state = root / "state"
+            catalog = root / "catalog"
+            source = catalog / "species/7513-carolina-wren"
+            source.mkdir(parents=True)
+            (source / "manifest.json").write_text(
+                json.dumps({"taxon_id": 7513, "status": "approved"})
+            )
+
+            with (
+                patch(
+                    "inky_bird_frame.catalog.rebuild_catalog_index",
+                    side_effect=CatalogError("index failure"),
+                ),
+                self.assertRaisesRegex(CatalogError, "index failure"),
+            ):
+                archive_invalid_approved_candidate(state, catalog, 7513)
+
+            source_exists = source.is_dir()
+            archive_exists = (state / "archive").exists()
+
+        self.assertTrue(source_exists)
+        self.assertFalse(archive_exists)
 
     def test_approved_candidate_withdrawal_preserves_human_rejection_audit(self) -> None:
         species = BirdSpecies(7513, "Carolina Wren", "Thryothorus ludovicianus", 5, "test")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ import stat
 import unittest
 from argparse import Namespace
 from contextlib import redirect_stdout
-from datetime import date
+from datetime import UTC, date, datetime
 from importlib.metadata import version
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -560,6 +560,40 @@ rotation_mode = "shuffle_bag"
         if guidance is not None:
             self.assertEqual(guidance.findings, (REVIEW_FAILURE_FALLBACK,))
 
+    def test_retry_preserves_guidance_when_clearing_only_deferred_backoff(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            state_dir.mkdir(parents=True, exist_ok=True)
+            store = RetryStore(state_dir / "generation-retries.json")
+            store.record_failure(
+                42,
+                GenerationError("transient failure"),
+                now=datetime(2026, 8, 2, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+            )
+            expected = store.set_quality_guidance(
+                42,
+                ("Keep the visible eye correction.",),
+                source_plate="archive/42-source/portrait.png",
+                invariant_findings=("Keep the visible eye correction.",),
+            )
+            config = controller_config(state_dir)
+            output = io.StringIO()
+
+            with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
+                retry_command(Namespace(taxon_id=42))
+
+            reloaded = RetryStore(state_dir / "generation-retries.json")
+            guidance = reloaded.quality_guidance(42)
+            retry = reloaded.get(42)
+            result = json.loads(output.getvalue())["data"]
+
+        self.assertIsNone(retry)
+        self.assertEqual(guidance, expected)
+        self.assertEqual(result["preserved_quality_findings_count"], 1)
+        self.assertTrue(result["preserved_correction_source"])
+
     def test_retry_reads_findings_from_legacy_null_correction_field(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)
@@ -672,33 +706,21 @@ rotation_mode = "shuffle_bag"
     def test_retry_withdraws_approved_candidate_and_starts_from_scratch(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)
-            catalog_dir = state_dir / "catalog"
-            approved = catalog_dir / "species/42-example-bird"
-            approved.mkdir(parents=True)
-            (approved / "portrait.png").write_bytes(b"rejected portrait")
-            config = controller_config(state_dir, catalog_dir)
-            RetryStore(state_dir / "generation-retries.json").set_quality_guidance(
-                42,
-                ("Reuse the rejected plate.",),
-            )
+            config = controller_config(state_dir)
+            expected = {
+                "taxon_id": 42,
+                "status": "eligible",
+                "replaced_approved": True,
+                "queued_for_generation": True,
+            }
             output = io.StringIO()
-
-            def withdraw(
-                state: Path,
-                catalog: Path,
-                taxon_id: int,
-                reason: str,
-            ) -> Path:
-                self.assertEqual((state, catalog, taxon_id), (state_dir, catalog_dir, 42))
-                self.assertEqual(reason, "Human review rejected the eyes.")
-                destination = state / "rejected" / approved.name
-                destination.parent.mkdir(parents=True)
-                approved.replace(destination)
-                return destination
 
             with (
                 patch("inky_bird_frame.cli._config", return_value=config),
-                patch("inky_bird_frame.cli.withdraw_approved_candidate", side_effect=withdraw),
+                patch(
+                    "inky_bird_frame.cli.retry_approved_candidate",
+                    return_value=expected,
+                ) as replace,
                 redirect_stdout(output),
             ):
                 retry_command(
@@ -711,19 +733,9 @@ rotation_mode = "shuffle_bag"
                 )
 
             result = json.loads(output.getvalue())["data"]
-            archived = state_dir / "archive/42-example-bird"
-            archived_portrait = (archived / "portrait.png").read_bytes()
-            guidance = RetryStore(state_dir / "generation-retries.json").quality_guidance(42)
 
-        self.assertTrue(result["replaced_approved"])
-        self.assertEqual(result["preserved_quality_findings_count"], 1)
-        self.assertFalse(result["preserved_correction_source"])
-        self.assertEqual(result["archived"], [str(archived)])
-        self.assertEqual(archived_portrait, b"rejected portrait")
-        self.assertIsNotNone(guidance)
-        if guidance is not None:
-            self.assertEqual(guidance.findings, ("Human review rejected the eyes.",))
-            self.assertIsNone(guidance.source_plate)
+        self.assertEqual(result, expected)
+        replace.assert_called_once_with(config, 42, "Human review rejected the eyes.")
 
     def test_retry_preserves_selected_attempt_as_correction_source(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,15 @@ from inky_bird_frame.errors import (
 from inky_bird_frame.retry import RetryStore
 
 
+def controller_config(state_dir: Path, catalog_dir: Path | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        controller=SimpleNamespace(
+            state_dir=state_dir,
+            catalog_dir=catalog_dir if catalog_dir is not None else state_dir / "catalog",
+        )
+    )
+
+
 class CliTests(unittest.TestCase):
     def test_runtime_version_matches_package_metadata(self) -> None:
         self.assertEqual(inky_bird_frame.__version__, version("inky-bird-frame"))
@@ -56,6 +65,22 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(str(args.config), "instance.toml")
         self.assertTrue(args.dry_run)
+
+    def test_retry_parses_explicit_approved_replacement(self) -> None:
+        args = build_parser().parse_args(
+            [
+                "retry",
+                "42",
+                "--config",
+                "instance.toml",
+                "--replace-approved",
+                "--reason",
+                "Human review rejected the plate.",
+            ]
+        )
+
+        self.assertTrue(args.replace_approved)
+        self.assertEqual(args.reason, "Human review rejected the plate.")
 
     def test_catalog_contribution_commands_use_explicit_catalog_paths(self) -> None:
         prepare = build_parser().parse_args(
@@ -495,7 +520,7 @@ rotation_mode = "shuffle_bag"
             references = state_dir / "references/42/references.json"
             references.parent.mkdir(parents=True)
             references.write_text("{}")
-            config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
+            config = controller_config(state_dir)
             output = io.StringIO()
 
             with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
@@ -521,7 +546,7 @@ rotation_mode = "shuffle_bag"
             review = state_dir / "failed/42-example-bird/attempt-01/quality-review.json"
             review.parent.mkdir(parents=True)
             review.write_text(json.dumps({"passed": False, "findings": []}))
-            config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
+            config = controller_config(state_dir)
             output = io.StringIO()
 
             with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
@@ -549,7 +574,7 @@ rotation_mode = "shuffle_bag"
                     }
                 )
             )
-            config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
+            config = controller_config(state_dir)
 
             with (
                 patch("inky_bird_frame.cli._config", return_value=config),
@@ -569,7 +594,7 @@ rotation_mode = "shuffle_bag"
             pending = state_dir / "pending/42-example-bird"
             pending.mkdir(parents=True)
             (pending / "portrait.png").write_bytes(b"partial")
-            config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
+            config = controller_config(state_dir)
             output = io.StringIO()
 
             with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
@@ -591,7 +616,7 @@ rotation_mode = "shuffle_bag"
             pending = state_dir / "pending/42-example-bird"
             pending.mkdir(parents=True)
             (pending / "manifest.json").write_text("{}")
-            config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
+            config = controller_config(state_dir)
 
             with (
                 patch("inky_bird_frame.cli._config", return_value=config),
@@ -601,6 +626,104 @@ rotation_mode = "shuffle_bag"
             pending_exists = pending.is_dir()
 
         self.assertTrue(pending_exists)
+
+    def test_retry_requires_explicit_replacement_for_approved_candidate(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            catalog_dir = state_dir / "catalog"
+            approved = catalog_dir / "species/42-example-bird"
+            approved.mkdir(parents=True)
+            config = controller_config(state_dir, catalog_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(ValueError, "use --replace-approved"),
+            ):
+                retry_command(Namespace(taxon_id=42))
+
+            approved_exists = approved.is_dir()
+
+        self.assertTrue(approved_exists)
+
+    def test_retry_approved_replacement_requires_reason_and_fresh_source(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            config = controller_config(state_dir)
+            with patch("inky_bird_frame.cli._config", return_value=config):
+                with self.assertRaisesRegex(ValueError, "requires a non-empty --reason"):
+                    retry_command(
+                        Namespace(
+                            taxon_id=42,
+                            replace_approved=True,
+                            reason=" ",
+                            source_attempt=None,
+                        )
+                    )
+                with self.assertRaisesRegex(ValueError, "cannot be combined"):
+                    retry_command(
+                        Namespace(
+                            taxon_id=42,
+                            replace_approved=True,
+                            reason="Human review rejected the plate.",
+                            source_attempt=1,
+                        )
+                    )
+
+    def test_retry_withdraws_approved_candidate_and_starts_from_scratch(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            catalog_dir = state_dir / "catalog"
+            approved = catalog_dir / "species/42-example-bird"
+            approved.mkdir(parents=True)
+            (approved / "portrait.png").write_bytes(b"rejected portrait")
+            config = controller_config(state_dir, catalog_dir)
+            RetryStore(state_dir / "generation-retries.json").set_quality_guidance(
+                42,
+                ("Reuse the rejected plate.",),
+            )
+            output = io.StringIO()
+
+            def withdraw(
+                state: Path,
+                catalog: Path,
+                taxon_id: int,
+                reason: str,
+            ) -> Path:
+                self.assertEqual((state, catalog, taxon_id), (state_dir, catalog_dir, 42))
+                self.assertEqual(reason, "Human review rejected the eyes.")
+                destination = state / "rejected" / approved.name
+                destination.parent.mkdir(parents=True)
+                approved.replace(destination)
+                return destination
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                patch("inky_bird_frame.cli.withdraw_approved_candidate", side_effect=withdraw),
+                redirect_stdout(output),
+            ):
+                retry_command(
+                    Namespace(
+                        taxon_id=42,
+                        replace_approved=True,
+                        reason="Human review rejected the eyes.",
+                        source_attempt=None,
+                    )
+                )
+
+            result = json.loads(output.getvalue())["data"]
+            archived = state_dir / "archive/42-example-bird"
+            archived_portrait = (archived / "portrait.png").read_bytes()
+            guidance = RetryStore(state_dir / "generation-retries.json").quality_guidance(42)
+
+        self.assertTrue(result["replaced_approved"])
+        self.assertEqual(result["preserved_quality_findings_count"], 1)
+        self.assertFalse(result["preserved_correction_source"])
+        self.assertEqual(result["archived"], [str(archived)])
+        self.assertEqual(archived_portrait, b"rejected portrait")
+        self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(guidance.findings, ("Human review rejected the eyes.",))
+            self.assertIsNone(guidance.source_plate)
 
     def test_retry_preserves_selected_attempt_as_correction_source(self) -> None:
         with TemporaryDirectory() as temporary:
@@ -619,7 +742,7 @@ rotation_mode = "shuffle_bag"
                         }
                     )
                 )
-            config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
+            config = controller_config(state_dir)
             output = io.StringIO()
 
             with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
@@ -647,7 +770,7 @@ rotation_mode = "shuffle_bag"
             review = state_dir / "failed/42-example-bird/attempt-01/quality-review.json"
             review.parent.mkdir(parents=True)
             review.write_text(json.dumps({"passed": False, "findings": ["Fix the tail"]}))
-            config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
+            config = controller_config(state_dir)
 
             with (
                 patch("inky_bird_frame.cli._config", return_value=config),
@@ -665,7 +788,7 @@ rotation_mode = "shuffle_bag"
             review = failed / "attempt-03/quality-review.json"
             review.parent.mkdir(parents=True)
             review.write_text("not json")
-            config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
+            config = controller_config(state_dir)
 
             with (
                 patch("inky_bird_frame.cli._config", return_value=config),
@@ -679,7 +802,7 @@ rotation_mode = "shuffle_bag"
     def test_retry_is_excluded_by_running_generation_cycle(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)
-            config = SimpleNamespace(controller=SimpleNamespace(state_dir=state_dir))
+            config = controller_config(state_dir)
             with (
                 patch("inky_bird_frame.cli._config", return_value=config),
                 exclusive_cycle_lock(state_dir),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -540,6 +540,27 @@ rotation_mode = "shuffle_bag"
         if guidance is not None:
             self.assertEqual(guidance.findings, ("Correct the ruler scale",))
 
+    def test_retry_allows_recovery_past_incomplete_catalog_directory(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-example-bird"
+            failed.mkdir(parents=True)
+            catalog_dir = state_dir / "catalog"
+            debris = catalog_dir / "species/42-example-bird"
+            debris.mkdir(parents=True)
+            (debris / "portrait.png").write_bytes(b"incomplete approval")
+            config = controller_config(state_dir, catalog_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(io.StringIO()),
+            ):
+                retry_command(Namespace(taxon_id=42))
+
+            archived = (state_dir / "archive/42-example-bird").is_dir()
+
+        self.assertTrue(archived)
+
     def test_retry_preserves_fallback_for_empty_quality_findings(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)
@@ -667,6 +688,9 @@ rotation_mode = "shuffle_bag"
             catalog_dir = state_dir / "catalog"
             approved = catalog_dir / "species/42-example-bird"
             approved.mkdir(parents=True)
+            (approved / "manifest.json").write_text(
+                json.dumps({"taxon_id": 42, "status": "approved"})
+            )
             config = controller_config(state_dir, catalog_dir)
 
             with (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -549,6 +549,9 @@ rotation_mode = "shuffle_bag"
             debris = catalog_dir / "species/42-example-bird"
             debris.mkdir(parents=True)
             (debris / "portrait.png").write_bytes(b"incomplete approval")
+            (debris / "manifest.json").write_text(
+                json.dumps({"taxon_id": 42, "status": "approved"})
+            )
             config = controller_config(state_dir, catalog_dir)
 
             with (
@@ -688,13 +691,14 @@ rotation_mode = "shuffle_bag"
             catalog_dir = state_dir / "catalog"
             approved = catalog_dir / "species/42-example-bird"
             approved.mkdir(parents=True)
-            (approved / "manifest.json").write_text(
-                json.dumps({"taxon_id": 42, "status": "approved"})
-            )
             config = controller_config(state_dir, catalog_dir)
 
             with (
                 patch("inky_bird_frame.cli._config", return_value=config),
+                patch(
+                    "inky_bird_frame.cli.has_valid_approved_candidate",
+                    return_value=True,
+                ),
                 self.assertRaisesRegex(ValueError, "use --replace-approved"),
             ):
                 retry_command(Namespace(taxon_id=42))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -553,16 +553,23 @@ rotation_mode = "shuffle_bag"
                 json.dumps({"taxon_id": 42, "status": "approved"})
             )
             config = controller_config(state_dir, catalog_dir)
+            output = io.StringIO()
 
             with (
                 patch("inky_bird_frame.cli._config", return_value=config),
-                redirect_stdout(io.StringIO()),
+                redirect_stdout(output),
             ):
                 retry_command(Namespace(taxon_id=42))
 
             archived = (state_dir / "archive/42-example-bird").is_dir()
+            invalid_archived = (state_dir / "archive/invalid-approved-42-example-bird").is_dir()
+            debris_exists = debris.exists()
+            result = json.loads(output.getvalue())["data"]
 
         self.assertTrue(archived)
+        self.assertTrue(invalid_archived)
+        self.assertFalse(debris_exists)
+        self.assertEqual(len(result["archived"]), 2)
 
     def test_retry_preserves_fallback_for_empty_quality_findings(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -30,6 +30,7 @@ from inky_bird_frame.catalog import (
 from inky_bird_frame.codex_runner import CodexRunner
 from inky_bird_frame.config import AppConfig, DiscoveryProvider, load_config
 from inky_bird_frame.controller import (
+    HUMAN_REVIEW_SOURCE,
     DiscoveryResult,
     DiscoverySnapshot,
     ProviderStatus,
@@ -547,7 +548,14 @@ class ControllerTests(unittest.TestCase):
                                 "scientific_name": queued.scientific_name,
                                 "observation_count": queued.observation_count,
                                 "source": queued.source,
-                            }
+                            },
+                            {
+                                "taxon_id": species.taxon_id,
+                                "common_name": species.common_name,
+                                "scientific_name": species.scientific_name,
+                                "observation_count": species.observation_count,
+                                "source": HUMAN_REVIEW_SOURCE,
+                            },
                         ],
                     }
                 )
@@ -565,6 +573,45 @@ class ControllerTests(unittest.TestCase):
             [entry.taxon_id for entry in queue],
             [queued.taxon_id, species.taxon_id],
         )
+
+    def test_approved_replacement_migrates_a_preexisting_target_seed(self) -> None:
+        species = BirdSpecies(
+            9083,
+            "Northern Cardinal",
+            "Cardinalis cardinalis",
+            1,
+            "iNaturalist",
+        )
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            (config.controller.state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "updated_at": datetime.now(UTC).isoformat(),
+                        "species": [
+                            {
+                                "taxon_id": species.taxon_id,
+                                "common_name": species.common_name,
+                                "scientific_name": species.scientific_name,
+                                "observation_count": species.observation_count,
+                                "source": species.source,
+                            }
+                        ],
+                    }
+                )
+            )
+            approve_test_species(config, species)
+
+            retry_approved_candidate(config, species.taxon_id, "Replace the uncanny eyes.")
+
+            collection = read_collection_state(config.controller.state_dir)
+
+        self.assertEqual([entry.taxon_id for entry in collection.entries], [species.taxon_id])
+        self.assertIsNotNone(collection.legacy_seed_queue_migrated_at)
 
     def test_collection_remove_is_preserved_after_legacy_queue_migration(self) -> None:
         queued = BirdSpecies(1, "Queued Bird", "Avis queued", 1, "iNaturalist")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -20,6 +20,7 @@ from inky_bird_frame.catalog import (
     CatalogEntry,
     CollectionEntry,
     CollectionOrigin,
+    approve_candidate,
     candidate_directory,
     read_collection,
     read_collection_state,
@@ -27,7 +28,7 @@ from inky_bird_frame.catalog import (
     write_collection,
 )
 from inky_bird_frame.codex_runner import CodexRunner
-from inky_bird_frame.config import DiscoveryProvider, load_config
+from inky_bird_frame.config import AppConfig, DiscoveryProvider, load_config
 from inky_bird_frame.controller import (
     DiscoveryResult,
     DiscoverySnapshot,
@@ -42,8 +43,10 @@ from inky_bird_frame.controller import (
     import_approved_collection,
     load_or_create_profile,
     load_or_fetch_references,
+    read_generation_queue,
     read_generation_queue_partition,
     remove_collection_member,
+    retry_approved_candidate,
     run_controller_cycle,
     run_generation_cycle,
     run_refresh_cycle,
@@ -86,6 +89,29 @@ PROFILE = SpeciesProfileData(
         {"title": "Source two", "url": "https://example.test/two"},
     ],
 )
+
+
+def approve_test_species(config: AppConfig, species: BirdSpecies) -> CatalogEntry:
+    review = QualityReview(True, 5, 5, 5, 5, True, ())
+    candidate = candidate_directory(config.controller.state_dir, species)
+    candidate.mkdir(parents=True)
+    (candidate / "portrait.png").write_bytes(b"portrait")
+    (candidate / "display.png").write_bytes(b"display")
+    write_candidate_manifest(
+        candidate,
+        species,
+        PROFILE,
+        [],
+        review,
+        generator="test",
+        prompt_version="test-v1",
+    )
+    return approve_candidate(
+        config.controller.state_dir,
+        config.controller.catalog_dir,
+        species.taxon_id,
+    )
+
 
 CONFIG = """
 [discovery]
@@ -418,6 +444,88 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(result["removed_taxon_ids"], [1])
         self.assertEqual(result["collection_count"], 0)
         self.assertEqual(result["active_approved_count"], 1)
+
+    def test_approved_replacement_requeues_historical_taxon_and_updates_active_catalog(
+        self,
+    ) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 0, "test")
+        reason = "Render clearly visible, natural eyes with the correct pupil shape."
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            approve_test_species(config, species)
+            add_collection_member(config, species.taxon_id)
+            active_before = json.loads(
+                (config.controller.state_dir / "active-catalog.json").read_text()
+            )
+
+            result = retry_approved_candidate(config, species.taxon_id, reason)
+
+            active_after = json.loads(
+                (config.controller.state_dir / "active-catalog.json").read_text()
+            )
+            queue = read_generation_queue(config)
+            partition = read_generation_queue_partition(config)
+            guidance = RetryStore(
+                config.controller.state_dir / "generation-retries.json"
+            ).quality_guidance(species.taxon_id)
+            archived_manifests = list(
+                (config.controller.state_dir / "archive").glob("9083-*/manifest.json")
+            )
+            archived_manifest = json.loads(archived_manifests[0].read_text())
+            approved_exists = (
+                config.controller.catalog_dir / "species/9083-northern-cardinal"
+            ).exists()
+
+        self.assertEqual(len(active_before["species"]), 1)
+        self.assertEqual(active_after["species"], [])
+        self.assertFalse(approved_exists)
+        self.assertEqual([item.taxon_id for item in queue], [species.taxon_id])
+        self.assertEqual(queue[0].source, "human-review")
+        self.assertEqual([item.taxon_id for item in partition.actionable], [species.taxon_id])
+        self.assertEqual(partition.terminal_blocked, [])
+        self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(guidance.findings, (reason,))
+            self.assertEqual(guidance.invariant_findings, (reason,))
+            self.assertIsNone(guidance.source_plate)
+        self.assertEqual(len(archived_manifests), 1)
+        self.assertEqual(archived_manifest["rejection_reason"], reason)
+        self.assertEqual(result["active_approved_count"], 0)
+        self.assertTrue(result["queued_for_generation"])
+        self.assertFalse(result["resumed"])
+
+    def test_approved_replacement_resumes_after_active_catalog_write_failure(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 0, "test")
+        reason = "Render clearly visible, natural eyes with the correct pupil shape."
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            approve_test_species(config, species)
+            add_collection_member(config, species.taxon_id)
+
+            with (
+                patch(
+                    "inky_bird_frame.controller._write_active_catalog",
+                    side_effect=CatalogError("active catalog write failed"),
+                ),
+                self.assertRaisesRegex(CatalogError, "active catalog write failed"),
+            ):
+                retry_approved_candidate(config, species.taxon_id, reason)
+
+            rejected_before_resume = list((config.controller.state_dir / "rejected").glob("9083-*"))
+            queued_before_resume = read_generation_queue(config)
+            result = retry_approved_candidate(config, species.taxon_id, reason)
+            rejected_after_resume = list((config.controller.state_dir / "rejected").glob("9083-*"))
+            active = json.loads((config.controller.state_dir / "active-catalog.json").read_text())
+
+        self.assertEqual(len(rejected_before_resume), 1)
+        self.assertEqual([item.taxon_id for item in queued_before_resume], [species.taxon_id])
+        self.assertEqual(rejected_after_resume, [])
+        self.assertEqual(active["species"], [])
+        self.assertTrue(result["resumed"])
 
     def test_collection_remove_is_preserved_after_legacy_queue_migration(self) -> None:
         queued = BirdSpecies(1, "Queued Bird", "Avis queued", 1, "iNaturalist")
@@ -1161,7 +1269,11 @@ class ControllerTests(unittest.TestCase):
             config.controller.state_dir.mkdir(parents=True)
             RetryStore(
                 config.controller.state_dir / "generation-retries.json"
-            ).set_quality_guidance(species.taxon_id, ("Keep the bill proportion accurate",))
+            ).set_quality_guidance(
+                species.taxon_id,
+                ("Keep the bill proportion accurate",),
+                invariant_findings=("Keep the bill proportion accurate",),
+            )
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",
@@ -1186,6 +1298,10 @@ class ControllerTests(unittest.TestCase):
         self.assertIsNotNone(guidance)
         self.assertEqual(
             generate.call_args.kwargs["initial_correction_findings"],
+            ("Keep the bill proportion accurate",),
+        )
+        self.assertEqual(
+            generate.call_args.kwargs["invariant_correction_findings"],
             ("Keep the bill proportion accurate",),
         )
 
@@ -1279,6 +1395,7 @@ class ControllerTests(unittest.TestCase):
                     config.controller.workspace_dir,
                     initial_correction_findings=("Preserve the previous scale correction",),
                     initial_correction_source=source_plate,
+                    invariant_correction_findings=("Render clearly visible natural eyes",),
                 )
             manifest = json.loads((candidate / "manifest.json").read_text())
             private_histories = list(
@@ -1287,7 +1404,10 @@ class ControllerTests(unittest.TestCase):
 
         self.assertEqual(
             FakeRunner.corrections,
-            [("Preserve the previous scale correction",), ("Crest is too short",)],
+            [
+                ("Render clearly visible natural eyes", "Preserve the previous scale correction"),
+                ("Render clearly visible natural eyes", "Crest is too short"),
+            ],
         )
         self.assertEqual(len(FakeRunner.generated_paths), 2)
         self.assertEqual(len(FakeRunner.review_paths), 2)
@@ -1312,7 +1432,11 @@ class ControllerTests(unittest.TestCase):
             config.controller.state_dir.mkdir(parents=True)
             RetryStore(
                 config.controller.state_dir / "generation-retries.json"
-            ).set_quality_guidance(species.taxon_id, ("Correct the ruler scale",))
+            ).set_quality_guidance(
+                species.taxon_id,
+                ("Keep the eyes clearly visible", "Correct the ruler scale"),
+                invariant_findings=("Keep the eyes clearly visible",),
+            )
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",
@@ -1338,9 +1462,18 @@ class ControllerTests(unittest.TestCase):
             self.assertEqual(first_failure["error"], "profile failed")
             self.assertFalse(first_failure["terminal"])
         self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(
+                guidance.invariant_findings,
+                ("Keep the eyes clearly visible",),
+            )
         self.assertEqual(
             generate.call_args.kwargs["initial_correction_findings"],
-            ("Correct the ruler scale",),
+            ("Keep the eyes clearly visible", "Correct the ruler scale"),
+        )
+        self.assertEqual(
+            generate.call_args.kwargs["invariant_correction_findings"],
+            ("Keep the eyes clearly visible",),
         )
 
     def test_catalog_wide_error_still_aborts_the_cycle(self) -> None:
@@ -1571,7 +1704,11 @@ class ControllerTests(unittest.TestCase):
             config.controller.state_dir.mkdir(parents=True)
             RetryStore(
                 config.controller.state_dir / "generation-retries.json"
-            ).set_quality_guidance(species.taxon_id, ("Correct the ruler scale",))
+            ).set_quality_guidance(
+                species.taxon_id,
+                ("Correct the ruler scale",),
+                invariant_findings=("Keep the eyes clearly visible",),
+            )
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",
@@ -1592,10 +1729,13 @@ class ControllerTests(unittest.TestCase):
         self.assertIsInstance(failure_results, list)
         if isinstance(failure_results, list):
             self.assertTrue(failure_results[0]["terminal"])
-        self.assertIsNone(guidance)
+        self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(guidance.findings, ("Keep the eyes clearly visible",))
+            self.assertEqual(guidance.invariant_findings, ("Keep the eyes clearly visible",))
         self.assertEqual(
             generate.call_args.kwargs["initial_correction_findings"],
-            ("Correct the ruler scale",),
+            ("Keep the eyes clearly visible", "Correct the ruler scale"),
         )
 
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -527,6 +527,45 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(active["species"], [])
         self.assertTrue(result["resumed"])
 
+    def test_approved_replacement_migrates_only_the_preexisting_legacy_queue(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 0, "test")
+        queued = BirdSpecies(1, "Queued Bird", "Avis queued", 1, "iNaturalist")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            (config.controller.state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "updated_at": datetime.now(UTC).isoformat(),
+                        "species": [
+                            {
+                                "taxon_id": queued.taxon_id,
+                                "common_name": queued.common_name,
+                                "scientific_name": queued.scientific_name,
+                                "observation_count": queued.observation_count,
+                                "source": queued.source,
+                            }
+                        ],
+                    }
+                )
+            )
+            approve_test_species(config, species)
+
+            retry_approved_candidate(config, species.taxon_id, "Replace the uncanny eyes.")
+
+            collection = read_collection_state(config.controller.state_dir)
+            queue = read_generation_queue(config)
+
+        self.assertEqual([entry.taxon_id for entry in collection.entries], [queued.taxon_id])
+        self.assertIsNotNone(collection.legacy_seed_queue_migrated_at)
+        self.assertEqual(
+            [entry.taxon_id for entry in queue],
+            [queued.taxon_id, species.taxon_id],
+        )
+
     def test_collection_remove_is_preserved_after_legacy_queue_migration(self) -> None:
         queued = BirdSpecies(1, "Queued Bird", "Avis queued", 1, "iNaturalist")
         with TemporaryDirectory() as temporary:

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -104,6 +104,27 @@ class RetryStoreTests(unittest.TestCase):
         self.assertEqual(guidance, reloaded)
         self.assertEqual(guidance.source_plate, "archive/42-bird/attempt-03/portrait.png")
 
+    def test_invariant_findings_are_durable_and_merged_into_guidance(self) -> None:
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "retries.json"
+            guidance = RetryStore(path).set_quality_guidance(
+                42,
+                ("Correct the wing.",),
+                invariant_findings=("Render clearly visible natural eyes.",),
+            )
+
+            reloaded = RetryStore(path).quality_guidance(42)
+
+        self.assertEqual(
+            guidance.findings,
+            ("Render clearly visible natural eyes.", "Correct the wing."),
+        )
+        self.assertEqual(
+            guidance.invariant_findings,
+            ("Render clearly visible natural eyes.",),
+        )
+        self.assertEqual(reloaded, guidance)
+
     def test_correction_source_must_remain_in_archive(self) -> None:
         with TemporaryDirectory() as temporary:
             path = Path(temporary) / "retries.json"

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary

- add an explicit `retry --replace-approved --reason` migration for plates rejected by human visual review after local approval
- withdraw and audit the plate under the existing cycle/catalog locks, rebuild the local index, clear cached research/reference state, and regenerate without using the rejected bitmap
- retain the human rejection reason as required guidance for the clean render
- document the local-only workflow and bump the patch release to 0.2.6

Public catalog entries remain immutable and add-only. This operation changes only trusted local controller state; a published correction still requires a separate maintainer-reviewed migration.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest` (387 passed, 19 subtests passed)
- `uv run inky-bird-frame catalog validate --catalog catalog` (104 species)
- `actionlint`
- `shellcheck deploy/*.sh`
- `uv run python .github/scripts/check_workflow_pinning.py`

Closes #152