### PR TITLE
Preserve research across visual retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,16 +71,20 @@ A failed review returns separate actionable corrections for the next attempt,
 which uses them to edit the failed plate while preserving its successful
 composition and content. Attempts are bounded by configuration, and exhausted
 work stops for
-inspection rather than publishing. A deliberate `retry` refreshes cached
-research and carries the final corrections into the next cycle. Maintainers can
+inspection rather than publishing. A deliberate `retry` preserves validated
+research and references while carrying the final corrections into the next
+cycle. Use `--refresh-research` only when those inputs themselves need to be
+replaced. Maintainers can
 select a strong retained plate with `retry TAXON_ID --source-attempt N`; the
 source is archived, checksum-tracked, and edited rather than regenerated from
 scratch. If human visual review rejects a locally approved plate before public
 publication, `retry TAXON_ID --replace-approved --reason "..."` is the explicit
 replacement migration: it records the rejection, archives the plate, removes
-it from local rotation, requeues historical-only taxa, refreshes research and
-references, and regenerates from scratch while carrying the human rejection
-reason as a required constraint through every correction attempt. The migration
+it from local rotation, requeues historical-only taxa, preserves validated
+research and references, and regenerates the image from scratch while carrying
+the human rejection reason as a required constraint through every correction
+attempt. Add `--refresh-research` when the cached factual inputs are also being
+rejected. The migration
 is safe to resume after interruption and never rewrites an existing public
 catalog entry. Once a taxon passes, it is never regenerated implicitly.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,17 +171,20 @@ unchanged. The next scheduled cycle retries from the current remote branch.
 `retry TAXON_ID` archives incomplete pending, rejected, or failed state and
 makes that taxon eligible. For failed quality reviews, it retains the final actionable
 corrections as durable input to the first new generation attempt while
-refreshing cached research. Invalid approval debris is archived and removed from
-the local index and active catalog before regeneration; a fully valid approved
-entry remains protected. `retry TAXON_ID --source-attempt N` additionally
+preserving cached research and references. Add `--refresh-research` when those
+inputs themselves need to be replaced. Invalid approval debris is archived and
+removed from the local index and active catalog before regeneration; a fully
+valid approved entry remains protected. `retry TAXON_ID --source-attempt N` additionally
 selects a retained portrait as the edit base. The archive-relative source path
 stays in private retry state, and the passing manifest records its SHA-256 for
 provenance. After explicit human review,
 `retry TAXON_ID --replace-approved --reason "..."` withdraws a locally approved
 plate, preserves its rejection audit, rebuilds the local index, requeues the
-taxon, and starts a source-free replacement constrained by the human rejection
-reason on every correction attempt. The migration is resumable after a partial
-failure. The public catalog remains add-only; replacing a published artifact
+taxon, preserves validated research and references, and starts a source-free
+replacement constrained by the human rejection reason on every correction
+attempt. Use `--refresh-research` if the cached factual inputs are also being
+rejected. The migration is resumable after a partial failure. The public catalog
+remains add-only; replacing a published artifact
 requires a separate explicit migration and maintainer review. Approved art is
 never replaced implicitly.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -334,9 +334,11 @@ only; they never enter the approved catalog or rotation.
   correction input. After all configured attempts fail, inspect the retained
   artifacts and use `retry TAXON_ID --source-attempt N` when a specific attempt
   is a strong edit base. The command archives that portrait, refreshes cached
-  references and profile data, and preserves the selected attempt's corrections
-  for the first edit. Omit `--source-attempt` when no retained image should be
-  reused. Transient source failures retain the guidance and edit source until
+  references and profile data only when `--refresh-research` is also supplied,
+  and preserves the selected attempt's corrections for the first edit. By
+  default, validated research and references are reused. Omit `--source-attempt`
+  when no retained image should be reused. Transient source failures retain the
+  guidance and edit source until
   generation reaches a successful or terminal quality result. If retry finds an
   interrupted, fully invalid approval directory, it archives that debris and
   removes the stale local catalog entry before regeneration; a valid approved
@@ -344,14 +346,15 @@ only; they never enter the approved catalog or rotation.
 - Human rejection after local approval: before public publication, run
   `retry TAXON_ID --replace-approved --reason "..."`. The non-empty reason and
   replacement flag are mandatory. The command archives the approved artifacts
-  with rejection metadata, atomically rebuilds the local catalog index, clears
-  cached research and references, and makes the taxon eligible for a fresh
+  with rejection metadata, atomically rebuilds the local catalog index, preserves
+  validated research and references, and makes the taxon eligible for a fresh
   generation without an edit source, including for a historical-only taxon that
-  is no longer in live discovery. The human rejection reason remains required
-  correction guidance on every attempt. Re-running the same command and reason
-  safely resumes an interrupted migration. This local migration does not replace
-  an immutable public catalog entry; a published correction requires a separate
-  maintainer-reviewed migration.
+  is no longer in live discovery. Add `--refresh-research` when those cached
+  factual inputs are also being rejected. The human rejection reason remains
+  required correction guidance on every attempt. Re-running the same command and
+  reason safely resumes an interrupted migration. This local migration does not
+  replace an immutable public catalog entry; a published correction requires a
+  separate maintainer-reviewed migration.
 - Controller unavailable: the current e-paper image remains visible. Display
   state is not advanced.
 - Checksum mismatch: the display refuses the asset and preserves current state.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.2.6"
+version = "0.2.7"
 description = "Generate and display reusable bird field-journal plates"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/inky_bird_frame/__init__.py
+++ b/src/inky_bird_frame/__init__.py
@@ -1,3 +1,3 @@
 """Local bird field-journal plates for Pimoroni Inky displays."""
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -459,6 +459,7 @@ def _retry_quality_guidance(
 def retry_command(args: argparse.Namespace) -> int:
     config = _config(args)
     replace_approved = bool(getattr(args, "replace_approved", False))
+    refresh_research = bool(getattr(args, "refresh_research", False))
     raw_reason = getattr(args, "reason", None)
     reason = raw_reason.strip() if isinstance(raw_reason, str) else None
     source_attempt = getattr(args, "source_attempt", None)
@@ -467,7 +468,14 @@ def retry_command(args: argparse.Namespace) -> int:
             raise ValueError("--replace-approved cannot be combined with --source-attempt")
         if not reason:
             raise ValueError("--replace-approved requires a non-empty --reason")
-        print_result(retry_approved_candidate(config, args.taxon_id, reason))
+        print_result(
+            retry_approved_candidate(
+                config,
+                args.taxon_id,
+                reason,
+                refresh_research=refresh_research,
+            )
+        )
         return 0
     if raw_reason is not None:
         raise ValueError("--reason requires --replace-approved")
@@ -502,11 +510,11 @@ def retry_command(args: argparse.Namespace) -> int:
                 f"No failed, rejected, or deferred candidate exists for taxon {args.taxon_id}"
             )
         profile_cache = config.controller.state_dir / "profiles" / str(args.taxon_id)
-        cleared_cached_profile = profile_cache.exists()
+        cleared_cached_profile = refresh_research and profile_cache.exists()
         if cleared_cached_profile:
             sources.append(profile_cache)
         reference_cache = config.controller.state_dir / "references" / str(args.taxon_id)
-        cleared_cached_references = reference_cache.exists()
+        cleared_cached_references = refresh_research and reference_cache.exists()
         if cleared_cached_references:
             sources.append(reference_cache)
         correction_owner = (
@@ -1048,6 +1056,11 @@ def build_parser() -> argparse.ArgumentParser:
     retry_parser.add_argument(
         "--reason",
         help="Human rejection reason required with --replace-approved",
+    )
+    retry_parser.add_argument(
+        "--refresh-research",
+        action="store_true",
+        help="Discard cached species research and reference photos before retrying",
     )
     retry_parser.set_defaults(func=retry_command)
 

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -854,6 +854,8 @@ def retry_approved_candidate(
     config: AppConfig,
     taxon_id: int,
     reason: str,
+    *,
+    refresh_research: bool = False,
 ) -> dict[str, object]:
     rejection_reason = reason.strip()
     if not rejection_reason:
@@ -893,6 +895,10 @@ def retry_approved_candidate(
                 None,
             )
             guidance = retry_store.quality_guidance(taxon_id)
+            profile_cache = config.controller.state_dir / "profiles" / str(taxon_id)
+            reference_cache = config.controller.state_dir / "references" / str(taxon_id)
+            cleared_cached_profile = refresh_research and profile_cache.exists()
+            cleared_cached_references = refresh_research and reference_cache.exists()
             if approved_entry is None and resumable is None:
                 already_prepared = (
                     queued is not None
@@ -905,6 +911,18 @@ def retry_approved_candidate(
                     raise ValueError(f"No approved candidate exists for taxon {taxon_id}")
                 _migrate_legacy_queue_before_replacement(config, queued_species, taxon_id)
                 assert guidance is not None
+                cache_sources = [
+                    path
+                    for path, should_clear in (
+                        (profile_cache, cleared_cached_profile),
+                        (reference_cache, cleared_cached_references),
+                    )
+                    if should_clear
+                ]
+                moved = _archive_controller_paths(
+                    config.controller.state_dir,
+                    cache_sources,
+                )
                 active_count = _write_active_catalog(
                     config,
                     observed,
@@ -913,10 +931,10 @@ def retry_approved_candidate(
                 return {
                     "taxon_id": taxon_id,
                     "status": "eligible",
-                    "archived": [],
+                    "archived": moved,
                     "cleared_deferred_retry": False,
-                    "cleared_cached_profile": False,
-                    "cleared_cached_references": False,
+                    "cleared_cached_profile": cleared_cached_profile,
+                    "cleared_cached_references": cleared_cached_references,
                     "preserved_quality_findings_count": len(guidance.findings),
                     "replaced_approved": True,
                     "resumed": True,
@@ -953,10 +971,6 @@ def retry_approved_candidate(
                 sorted((config.controller.state_dir / "failed").glob(f"{taxon_id}-*"))
             )
             old_sources.extend(path for path in rejected_paths if path != withdrawn)
-            profile_cache = config.controller.state_dir / "profiles" / str(taxon_id)
-            reference_cache = config.controller.state_dir / "references" / str(taxon_id)
-            cleared_cached_profile = profile_cache.exists()
-            cleared_cached_references = reference_cache.exists()
             if cleared_cached_profile:
                 old_sources.append(profile_cache)
             if cleared_cached_references:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,6 +81,14 @@ class CliTests(unittest.TestCase):
 
         self.assertTrue(args.replace_approved)
         self.assertEqual(args.reason, "Human review rejected the plate.")
+        self.assertFalse(args.refresh_research)
+
+    def test_retry_parses_explicit_research_refresh(self) -> None:
+        args = build_parser().parse_args(
+            ["retry", "42", "--config", "instance.toml", "--refresh-research"]
+        )
+
+        self.assertTrue(args.refresh_research)
 
     def test_catalog_contribution_commands_use_explicit_catalog_paths(self) -> None:
         prepare = build_parser().parse_args(
@@ -501,7 +509,35 @@ rotation_mode = "shuffle_bag"
         recovered_keys = [call.kwargs["key"] for call in recover.call_args_list]
         self.assertEqual(recovered_keys, ["generation-cycle"])
 
-    def test_retry_archives_cached_profile(self) -> None:
+    def test_retry_preserves_cached_research_by_default(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-example-bird"
+            review = failed / "attempt-01/quality-review.json"
+            review.parent.mkdir(parents=True)
+            review.write_text(json.dumps({"passed": False, "findings": ["Fix the feet"]}))
+            profile = state_dir / "profiles/42/profile.json"
+            profile.parent.mkdir(parents=True)
+            profile.write_text("{}")
+            references = state_dir / "references/42/references.json"
+            references.parent.mkdir(parents=True)
+            references.write_text("{}")
+            config = controller_config(state_dir)
+            output = io.StringIO()
+
+            with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
+                retry_command(Namespace(taxon_id=42))
+
+            result = json.loads(output.getvalue())["data"]
+            profile_exists = profile.exists()
+            references_exist = references.exists()
+
+        self.assertFalse(result["cleared_cached_profile"])
+        self.assertFalse(result["cleared_cached_references"])
+        self.assertTrue(profile_exists)
+        self.assertTrue(references_exist)
+
+    def test_retry_archives_cached_research_when_refresh_requested(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)
             failed = state_dir / "failed/42-example-bird"
@@ -524,7 +560,7 @@ rotation_mode = "shuffle_bag"
             output = io.StringIO()
 
             with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
-                retry_command(Namespace(taxon_id=42))
+                retry_command(Namespace(taxon_id=42, refresh_research=True))
 
             result = json.loads(output.getvalue())["data"]
             guidance = RetryStore(state_dir / "generation-retries.json").quality_guidance(42)
@@ -770,7 +806,12 @@ rotation_mode = "shuffle_bag"
             result = json.loads(output.getvalue())["data"]
 
         self.assertEqual(result, expected)
-        replace.assert_called_once_with(config, 42, "Human review rejected the eyes.")
+        replace.assert_called_once_with(
+            config,
+            42,
+            "Human review rejected the eyes.",
+            refresh_research=False,
+        )
 
     def test_retry_preserves_selected_attempt_as_correction_source(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -456,6 +456,12 @@ class ControllerTests(unittest.TestCase):
             config_path.write_text(CONFIG)
             config = load_config(config_path)
             approve_test_species(config, species)
+            profile_cache = config.controller.state_dir / "profiles/9083/profile.json"
+            profile_cache.parent.mkdir(parents=True)
+            profile_cache.write_text("{}")
+            reference_cache = config.controller.state_dir / "references/9083/references.json"
+            reference_cache.parent.mkdir(parents=True)
+            reference_cache.write_text("{}")
             add_collection_member(config, species.taxon_id)
             active_before = json.loads(
                 (config.controller.state_dir / "active-catalog.json").read_text()
@@ -478,6 +484,8 @@ class ControllerTests(unittest.TestCase):
             approved_exists = (
                 config.controller.catalog_dir / "species/9083-northern-cardinal"
             ).exists()
+            profile_cache_exists = profile_cache.exists()
+            reference_cache_exists = reference_cache.exists()
 
         self.assertEqual(len(active_before["species"]), 1)
         self.assertEqual(active_after["species"], [])
@@ -496,6 +504,38 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(result["active_approved_count"], 0)
         self.assertTrue(result["queued_for_generation"])
         self.assertFalse(result["resumed"])
+        self.assertFalse(result["cleared_cached_profile"])
+        self.assertFalse(result["cleared_cached_references"])
+        self.assertTrue(profile_cache_exists)
+        self.assertTrue(reference_cache_exists)
+
+    def test_approved_replacement_refreshes_research_only_when_requested(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 0, "test")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            approve_test_species(config, species)
+            profile_cache = config.controller.state_dir / "profiles/9083/profile.json"
+            profile_cache.parent.mkdir(parents=True)
+            profile_cache.write_text("{}")
+            reference_cache = config.controller.state_dir / "references/9083/references.json"
+            reference_cache.parent.mkdir(parents=True)
+            reference_cache.write_text("{}")
+
+            result = retry_approved_candidate(
+                config,
+                species.taxon_id,
+                "Replace the malformed feet.",
+                refresh_research=True,
+            )
+            profile_cache_exists = profile_cache.exists()
+            reference_cache_exists = reference_cache.exists()
+
+        self.assertTrue(result["cleared_cached_profile"])
+        self.assertTrue(result["cleared_cached_references"])
+        self.assertFalse(profile_cache_exists)
+        self.assertFalse(reference_cache_exists)
 
     def test_approved_replacement_resumes_after_active_catalog_write_failure(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 0, "test")

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## What changed

- preserve cached species profiles and licensed reference photos across visual retries by default
- add an explicit `--refresh-research` opt-in when the factual inputs themselves need replacement
- preserve the approved-plate withdrawal, fresh-image, provenance, and quality-review boundaries
- bump the patch release to 0.2.7 and document the behavior

## Why

Human-reviewed plate replacement discarded validated research on every new visual lineage. Repeated image-only corrections could therefore exhaust the per-species research budget even though no factual input had changed.

## Validation

- full pytest suite
- `ruff format --check .`
- `ruff check .`
- strict MyPy
- catalog validation: 104 species
- workflow action pinning