### PR TITLE
Improve plate correction retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,18 @@ cycle. Use `--refresh-research` only when those inputs themselves need to be
 replaced. Maintainers can
 select a strong retained plate with `retry TAXON_ID --source-attempt N`; the
 source is archived, checksum-tracked, and edited rather than regenerated from
-scratch. If human visual review rejects a locally approved plate before public
+scratch. If a stronger attempt belongs to an older archived generation run,
+select it with `retry TAXON_ID --source-run RUN_NAME --source-attempt N`; the
+command validates the private archive boundary, failed review, and portrait
+before preserving that exact edit source. When human inspection accepts some
+traits but adjudicates a review finding, repeat `--correction "..."` with a
+selected source to replace only the current automated findings; durable human
+invariants still apply. A later retry can reuse a human-rejected candidate
+already in the private archive with
+`retry TAXON_ID --source-candidate ARCHIVE_NAME`; the command verifies its taxon
+identity, rejection reason, and portrait checksum before using that rejection
+as the targeted edit contract. If human visual review rejects a locally approved
+plate before public
 publication, `retry TAXON_ID --replace-approved --reason "..."` is the explicit
 replacement migration: it records the rejection, archives the plate, removes
 it from local rotation, requeues historical-only taxa, preserves validated

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,16 @@ inventing evidence.
 
 Plate rulers are vertical schematic body-length keys: they show the sourced
 range and units, are labeled as not to scale, remain separate from the specimen,
-and never claim that display pixels reproduce physical size.
+and never claim that display pixels reproduce physical size. Range rulers span
+only the published endpoints, increase bottom-to-top, and use four unlabeled
+interior ticks as proportional subdivisions; they do not add a zero-based axis
+or a second range marker. Independent review checks the same contract.
+
+Species field marks that depend on relative anatomy are reference-matched rather
+than reduced to a binary direction check. Generation and review compare the
+base-to-tip relationship against the clearest attached side-profile references
+and require consistent proportions across the primary specimen and anatomical
+studies without encoding an arbitrary universal ratio.
 
 Transient per-taxon failures are written to a durable retry schedule with capped
 exponential backoff. Deferred taxa are skipped without consuming the successful
@@ -177,7 +186,18 @@ removed from the local index and active catalog before regeneration; a fully
 valid approved entry remains protected. `retry TAXON_ID --source-attempt N` additionally
 selects a retained portrait as the edit base. The archive-relative source path
 stays in private retry state, and the passing manifest records its SHA-256 for
-provenance. After explicit human review,
+provenance. `retry TAXON_ID --source-run RUN_NAME --source-attempt N` selects a
+specific attempt from an older archived failed run after validating archive
+containment, the profile identity, failed review, and portrait. The archived run stays
+immutable while its relative portrait path becomes the private correction
+source. A repeatable `--correction "..."` on a source-selected retry replaces
+the current automated correction list after operator adjudication. It does not
+remove earlier human invariants, bypass source validation, or alter provenance.
+`retry TAXON_ID --source-candidate ARCHIVE_NAME` reuses a complete,
+human-rejected candidate that is already in the private archive. The command
+validates archive containment, manifest identity, rejected status, human
+rejection guidance, and portrait integrity before preserving it as the edit
+source. After explicit human review,
 `retry TAXON_ID --replace-approved --reason "..."` withdraws a locally approved
 plate, preserves its rejection audit, rebuilds the local index, requeues the
 taxon, preserves validated research and references, and starts a source-free

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -342,7 +342,26 @@ only; they never enter the approved catalog or rotation.
   generation reaches a successful or terminal quality result. If retry finds an
   interrupted, fully invalid approval directory, it archives that debris and
   removes the stale local catalog entry before regeneration; a valid approved
-  plate still requires the explicit replacement command below.
+  plate still requires the explicit replacement command below. When a
+  stronger portrait belongs to an older archived generation run, use
+  `retry TAXON_ID --source-run RUN_NAME --source-attempt N`. `RUN_NAME` is the
+  archive directory name, not a path. The command validates archive containment,
+  the generation-run identity, the selected failed review, and the portrait
+  before preserving the exact archive-relative edit source; it does not move or
+  rewrite the older run. If human inspection accepts some source traits and adjudicates
+  one or more automated findings, add repeatable `--correction "..."` values to
+  a retry with `--source-attempt` or `--source-candidate`. These values replace
+  only the current review corrections; prior human-rejection invariants remain
+  mandatory, and the selected source still passes the same containment and
+  integrity checks. When a human-rejected candidate in the private archive is
+  the strongest edit base,
+  use `retry TAXON_ID --source-candidate ARCHIVE_NAME`. This selector accepts an
+  archive directory name, not a path, and verifies the candidate's taxon ID,
+  rejected status, human rejection reason, and portrait checksum before changing
+  terminal state. Its rejection reason—not findings from an unrelated later
+  attempt—becomes the targeted correction contract. It may run immediately
+  after `--replace-approved`; the human rejection remains an invariant while
+  the archived plate becomes the first edit source.
 - Human rejection after local approval: before public publication, run
   `retry TAXON_ID --replace-approved --reason "..."`. The non-empty reason and
   replacement flag are mandatory. The command archives the approved artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.2.7"
+version = "0.2.8"
 description = "Generate and display reusable bird field-journal plates"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/inky_bird_frame/__init__.py
+++ b/src/inky_bird_frame/__init__.py
@@ -1,3 +1,3 @@
 """Local bird field-journal plates for Pimoroni Inky displays."""
 
-__version__ = "0.2.7"
+__version__ = "0.2.8"

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -23,6 +23,7 @@ from .catalog import (
     read_json,
     rebuild_catalog_index,
     reject_candidate,
+    sha256_file,
 )
 from .config import (
     AppConfig,
@@ -456,6 +457,114 @@ def _retry_quality_guidance(
     return tuple(findings) or (REVIEW_FAILURE_FALLBACK,), source_plate
 
 
+def _retry_archived_quality_guidance(
+    state_dir: Path,
+    taxon_id: int,
+    source_run: str,
+    source_attempt: int,
+) -> tuple[tuple[str, ...], Path]:
+    run_name = source_run.strip()
+    if (
+        not run_name
+        or Path(run_name).is_absolute()
+        or Path(run_name).parts != (run_name,)
+        or not run_name.startswith(f"{taxon_id}-")
+    ):
+        raise ValueError("--source-run must be an archive directory name for the requested taxon")
+    archive = (state_dir / "archive").resolve()
+    run = state_dir / "archive" / run_name
+    profile_path = run / "profile.json"
+    if (
+        run.is_symlink()
+        or not run.is_dir()
+        or run.resolve().parent != archive
+        or profile_path.is_symlink()
+        or not profile_path.is_file()
+        or profile_path.resolve().parent != run.resolve()
+    ):
+        raise ValueError(f"Retained generation run is unavailable: {run_name}")
+    profile = read_json(profile_path)
+    if not isinstance(profile, dict) or profile.get("taxon_id") != taxon_id:
+        raise SpeciesStateError(
+            f"Retained generation profile identity does not match taxon {taxon_id}: {profile_path}"
+        )
+    for attempt_path in run.glob("attempt-*"):
+        if (
+            attempt_path.is_symlink()
+            or not attempt_path.is_dir()
+            or attempt_path.resolve().parent != run.resolve()
+        ):
+            raise SpeciesStateError(
+                f"Retained generation attempt escapes its archive run: {attempt_path}"
+            )
+        for filename in ("quality-review.json", "portrait.png"):
+            artifact_path = attempt_path / filename
+            if artifact_path.is_symlink() or (
+                artifact_path.exists() and artifact_path.resolve().parent != attempt_path.resolve()
+            ):
+                raise SpeciesStateError(
+                    f"Retained generation artifact escapes its attempt: {artifact_path}"
+                )
+    findings, source_plate = _retry_quality_guidance([run], source_attempt)
+    if source_plate is None:
+        raise SpeciesStateError(f"Retained generation attempt is unavailable: {run_name}")
+    return findings, source_plate
+
+
+def _retry_candidate_guidance(
+    state_dir: Path,
+    taxon_id: int,
+    source_candidate: str,
+) -> tuple[tuple[str, ...], Path]:
+    candidate_name = source_candidate.strip()
+    if (
+        not candidate_name
+        or Path(candidate_name).is_absolute()
+        or Path(candidate_name).parts != (candidate_name,)
+        or not candidate_name.startswith(f"{taxon_id}-")
+    ):
+        raise ValueError(
+            "--source-candidate must be the archive directory name for the requested taxon"
+        )
+    archive = (state_dir / "archive").resolve()
+    candidate = state_dir / "archive" / candidate_name
+    if candidate.is_symlink() or not candidate.is_dir() or candidate.resolve().parent != archive:
+        raise ValueError(f"Retained candidate is unavailable: {candidate_name}")
+    manifest_path = candidate / "manifest.json"
+    if (
+        manifest_path.is_symlink()
+        or not manifest_path.is_file()
+        or manifest_path.resolve().parent != candidate.resolve()
+    ):
+        raise SpeciesStateError(f"Retained candidate has no valid manifest: {candidate}")
+    manifest = read_json(manifest_path)
+    rejection_reason = manifest.get("rejection_reason") if isinstance(manifest, dict) else None
+    assets = manifest.get("assets") if isinstance(manifest, dict) else None
+    portrait_asset = assets.get("portrait") if isinstance(assets, dict) else None
+    if (
+        not isinstance(manifest, dict)
+        or manifest.get("schema_version") != 1
+        or manifest.get("status") != "rejected"
+        or manifest.get("taxon_id") != taxon_id
+        or not isinstance(rejection_reason, str)
+        or not rejection_reason.strip()
+        or not isinstance(portrait_asset, dict)
+        or portrait_asset.get("filename") != "portrait.png"
+        or not isinstance(portrait_asset.get("sha256"), str)
+    ):
+        raise SpeciesStateError(f"Invalid retained candidate manifest: {manifest_path}")
+    portrait = candidate / "portrait.png"
+    if (
+        portrait.is_symlink()
+        or not portrait.is_file()
+        or portrait.resolve().parent != candidate.resolve()
+    ):
+        raise SpeciesStateError(f"Retained candidate has no portrait: {candidate}")
+    if sha256_file(portrait) != portrait_asset["sha256"]:
+        raise SpeciesStateError(f"Retained candidate portrait checksum mismatch: {portrait}")
+    return (rejection_reason.strip(),), portrait
+
+
 def retry_command(args: argparse.Namespace) -> int:
     config = _config(args)
     replace_approved = bool(getattr(args, "replace_approved", False))
@@ -463,9 +572,37 @@ def retry_command(args: argparse.Namespace) -> int:
     raw_reason = getattr(args, "reason", None)
     reason = raw_reason.strip() if isinstance(raw_reason, str) else None
     source_attempt = getattr(args, "source_attempt", None)
+    source_candidate = getattr(args, "source_candidate", None)
+    source_run = getattr(args, "source_run", None)
+    raw_corrections = getattr(args, "correction", None)
+    correction_override: tuple[str, ...] = ()
+    if raw_corrections is not None:
+        if not isinstance(raw_corrections, list) or any(
+            not isinstance(correction, str) or not correction.strip()
+            for correction in raw_corrections
+        ):
+            raise ValueError("--correction values must be non-empty")
+        correction_override = tuple(correction.strip() for correction in raw_corrections)
+        if len(set(correction_override)) != len(correction_override):
+            raise ValueError("--correction values must not repeat")
+    if source_attempt is not None and source_candidate is not None:
+        raise ValueError("--source-attempt cannot be combined with --source-candidate")
+    if source_run is not None and source_candidate is not None:
+        raise ValueError("--source-run cannot be combined with --source-candidate")
+    if source_run is not None and source_attempt is None:
+        raise ValueError("--source-run requires --source-attempt")
+    if correction_override and source_attempt is None and source_candidate is None:
+        raise ValueError("--correction requires --source-attempt or --source-candidate")
     if replace_approved:
-        if source_attempt is not None:
-            raise ValueError("--replace-approved cannot be combined with --source-attempt")
+        if (
+            source_attempt is not None
+            or source_candidate is not None
+            or source_run is not None
+            or correction_override
+        ):
+            raise ValueError(
+                "--replace-approved cannot be combined with a correction source selector"
+            )
         if not reason:
             raise ValueError("--replace-approved requires a non-empty --reason")
         print_result(
@@ -493,10 +630,28 @@ def retry_command(args: argparse.Namespace) -> int:
         failed_directories = sorted(
             (config.controller.state_dir / "failed").glob(f"{args.taxon_id}-*")
         )
-        quality_findings, correction_source = _retry_quality_guidance(
-            failed_directories,
-            source_attempt,
-        )
+        quality_findings: tuple[str, ...]
+        correction_source: Path | None
+        if source_run is not None and source_attempt is not None:
+            quality_findings, correction_source = _retry_archived_quality_guidance(
+                config.controller.state_dir,
+                args.taxon_id,
+                source_run,
+                source_attempt,
+            )
+        elif source_candidate is None:
+            quality_findings, correction_source = _retry_quality_guidance(
+                failed_directories,
+                source_attempt,
+            )
+        else:
+            quality_findings, correction_source = _retry_candidate_guidance(
+                config.controller.state_dir,
+                args.taxon_id,
+                source_candidate,
+            )
+        if correction_override:
+            quality_findings = correction_override
         sources = [pending] if pending is not None else []
         sources.extend(failed_directories)
         sources.extend(
@@ -505,7 +660,7 @@ def retry_command(args: argparse.Namespace) -> int:
         retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
         existing_guidance = retry_store.quality_guidance(args.taxon_id)
         deferred = retry_store.get(args.taxon_id) is not None
-        if not sources and not deferred:
+        if not sources and not deferred and source_candidate is None and source_run is None:
             raise ValueError(
                 f"No failed, rejected, or deferred candidate exists for taxon {args.taxon_id}"
             )
@@ -525,7 +680,14 @@ def retry_command(args: argparse.Namespace) -> int:
             if correction_source is not None
             else None
         )
-        if correction_source is not None and correction_owner is None:
+        retained_correction_source = (
+            correction_source if source_candidate is not None or source_run is not None else None
+        )
+        if (
+            correction_source is not None
+            and correction_owner is None
+            and retained_correction_source is None
+        ):
             raise SpeciesStateError("The selected correction source is outside retained state")
         invalid_approved_archive = archive_invalid_approved_catalog_state(
             config,
@@ -534,7 +696,7 @@ def retry_command(args: argparse.Namespace) -> int:
         archive = config.controller.state_dir / "archive"
         archive.mkdir(parents=True, exist_ok=True)
         moved = [str(invalid_approved_archive)] if invalid_approved_archive is not None else []
-        archived_correction_source: Path | None = None
+        archived_correction_source = retained_correction_source
         for source in sources:
             destination = archive / source.name
             counter = 1
@@ -573,6 +735,9 @@ def retry_command(args: argparse.Namespace) -> int:
             ),
             "replaced_approved": False,
             "source_attempt": source_attempt,
+            "source_candidate": source_candidate,
+            "source_run": source_run,
+            "correction_override_count": len(correction_override),
             "preserved_correction_source": (
                 final_guidance is not None and final_guidance.source_plate is not None
             ),
@@ -1047,6 +1212,22 @@ def build_parser() -> argparse.ArgumentParser:
         "--source-attempt",
         type=int,
         help="Edit a selected retained attempt instead of generating the first retry from scratch",
+    )
+    retry_parser.add_argument(
+        "--source-candidate",
+        help="Edit a human-rejected candidate retained under the controller archive",
+    )
+    retry_parser.add_argument(
+        "--source-run",
+        help="Select an archived failed generation run with --source-attempt",
+    )
+    retry_parser.add_argument(
+        "--correction",
+        action="append",
+        help=(
+            "Replace selected review findings with an operator-adjudicated correction; "
+            "repeatable and requires a correction source"
+        ),
     )
     retry_parser.add_argument(
         "--replace-approved",

--- a/src/inky_bird_frame/codex_runner.py
+++ b/src/inky_bird_frame/codex_runner.py
@@ -210,6 +210,7 @@ class CodexRunner:
         correction_findings: tuple[str, ...] = (),
         *,
         correction_source_path: Path | None = None,
+        invariant_findings: tuple[str, ...] = (),
     ) -> Path:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         command = self._base_command(writable=True)
@@ -226,6 +227,7 @@ class CodexRunner:
                 references,
                 output_path,
                 correction_findings,
+                invariant_findings=invariant_findings,
                 has_correction_source=correction_source_path is not None,
             ),
             log_path,

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -81,13 +81,6 @@ REVIEW_FAILURE_FALLBACK = "The previous attempt did not meet every automated rev
 HUMAN_REVIEW_SOURCE = "human-review"
 
 
-def _merge_correction_findings(
-    invariant_findings: tuple[str, ...],
-    current_findings: tuple[str, ...],
-) -> tuple[str, ...]:
-    return tuple(dict.fromkeys((*invariant_findings, *current_findings)))
-
-
 @dataclass(frozen=True)
 class DiscoverySnapshot:
     refreshed_at: datetime
@@ -1331,10 +1324,7 @@ def generate_candidate(
             profile_output_path,
             logs / "01-profile.log",
         )
-        correction_findings = _merge_correction_findings(
-            invariant_correction_findings,
-            initial_correction_findings,
-        )
+        correction_findings = initial_correction_findings
         correction_source = initial_correction_source
         history: list[dict[str, object]] = []
         for attempt in range(1, config.controller.max_generation_attempts + 1):
@@ -1359,6 +1349,7 @@ def generate_candidate(
                     logs / f"02-generation-attempt-{attempt:02d}.log",
                     correction_findings,
                     correction_source_path=correction_source,
+                    invariant_findings=invariant_correction_findings,
                 )
                 prepare_generated_plate(generated_path, portrait_path, display_path)
 
@@ -1401,10 +1392,7 @@ def generate_candidate(
                     raise CatalogError(f"Pending destination already exists: {destination}")
                 shutil.copytree(attempt_dir, destination)
                 return destination
-            correction_findings = _merge_correction_findings(
-                invariant_correction_findings,
-                review.correction_findings or (REVIEW_FAILURE_FALLBACK,),
-            )
+            correction_findings = review.correction_findings or (REVIEW_FAILURE_FALLBACK,)
             correction_source = portrait_path
 
         failed = state_dir / "failed" / f"{species.taxon_id}-{_timestamp()}"
@@ -1588,11 +1576,17 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                         else:
                             retry_store.clear_quality_guidance(species.taxon_id)
                         raise
+                    invariant_findings = set(guidance.invariant_findings)
+                    current_findings = tuple(
+                        finding
+                        for finding in guidance.findings
+                        if finding not in invariant_findings
+                    )
                     generate_candidate(
                         config,
                         species,
                         config.controller.workspace_dir,
-                        initial_correction_findings=guidance.findings,
+                        initial_correction_findings=current_findings,
                         initial_correction_source=correction_source,
                         invariant_correction_findings=guidance.invariant_findings,
                     )

--- a/src/inky_bird_frame/prompts.py
+++ b/src/inky_bird_frame/prompts.py
@@ -81,14 +81,22 @@ def plate_prompt(
     output_path: Path,
     correction_findings: tuple[str, ...] = (),
     *,
+    invariant_findings: tuple[str, ...] = (),
     has_correction_source: bool = False,
 ) -> str:
     measurements = profile["measurements"]
     field_marks = "\n".join(f"  - {mark}" for mark in profile["field_marks"])
     palette = ", ".join(profile["palette"])
     correction = ""
-    if correction_findings:
-        issues = "\n".join(f"- {finding}" for finding in correction_findings)
+    if correction_findings or invariant_findings:
+        issues = (
+            "\n".join(f"- {finding}" for finding in correction_findings)
+            or "- No new defect beyond the non-regression constraints below."
+        )
+        invariants = (
+            "\n".join(f"- {finding}" for finding in invariant_findings)
+            or "- No separate non-regression constraints."
+        )
         if has_correction_source:
             correction = f"""
 Image 1 is the previous plate and the edit target. Images 2 onward are species-accuracy
@@ -97,23 +105,31 @@ successful content, visual identity, typography, and large specimen footprint. K
 unflagged factual statement and design element unchanged. Do not shrink the bird or create new
 empty space to make room for corrections.
 
-Corrections required after an independent review:
+Current actionable corrections required after an independent review:
 {issues}
+
+Non-regression constraints from earlier human review:
+{invariants}
 
 Use the supplied current profile as the authority for visible facts, including any text that the
 review requires changing. Preserve correct anatomy and composition from Image 1 while making the
-smallest complete edit that resolves every correction. Legacy review records may include
-statements confirming correct traits; preserve those traits as invariants rather than treating
-them as changes.
+smallest complete edit that resolves every current correction. A non-regression constraint remains
+mandatory, but it is not a request to redraw a feature that Image 1 already satisfies. Inspect each
+one: preserve an already-correct feature exactly, and change it only if Image 1 still violates the
+constraint.
 """
         else:
             correction = f"""
-Corrections required after an independent review of an earlier generation cycle:
+Current actionable corrections required after an independent review of an earlier generation
+cycle:
 {issues}
 
+Mandatory constraints from earlier human review:
+{invariants}
+
 Create a new image that resolves every correction while preserving the supplied correct facts and
-the required large-specimen composition. Legacy review records may include statements confirming
-correct traits; preserve those traits as invariants rather than treating them as changes.
+the required large-specimen composition. Implement every mandatory constraint in a source-free
+generation; do not treat it as optional merely because it originated in an earlier review.
 """
     reference_start = 2 if has_correction_source else 1
     reference_roles = (
@@ -149,7 +165,16 @@ Reference images, in attachment order:
 
 {reference_roles} Synthesize the consistent anatomy, proportions, posture, plumage pattern, and
 colors across the reference photographs. Do not reproduce any photograph's background, pose,
-crop, or composition.
+crop, or composition. When a field mark depends on unequal paired structures such as mandibles,
+identify each structure before editing it. For an open skimmer bill, the lower mandible is the jaw
+below the gape line: when the references show it projecting, its tip must be farther from the
+shared bill base than the upper tip. Match both the direction and degree of that difference to the
+clearest side-profile references. Preserve the near-full length of the shorter structure; do not
+substitute a wider gape, lengthen the wrong jaw, truncate the upper mandible, or exaggerate a
+qualitative field mark. In a side-profile skimmer with an open bill, keep the difference visually
+legible: the lower tip must also reach farther forward in the bird's facing direction when the
+references show that projection; do not rely on a steeper gape angle or lower tip position. Use the
+same plausible proportional relationship in the primary specimen and every supplementary study.
 {correction}
 
 Style and composition:
@@ -159,17 +184,33 @@ Style and composition:
 - The bird remains the dominant page element and confidently uses the available space.
 - Left margin contains compact handwritten measurements and field marks.
 - Bottom margin contains a small wing-pattern study, a bill/head study, and color swatches.
-- Right edge contains a thin, self-contained vertical schematic ruler keyed to the body-length
-  range "{measurements["length"]}". Use proportionally spaced ticks with explicit units, visibly
-  mark the published range, and label it "BODY LENGTH: {measurements["length"]}" and
-  "SCHEMATIC — NOT TO SCALE". Keep it separate from the bird; never imply that it measures the
-  printed illustration.
+- Right edge contains a thin, self-contained vertical schematic range ruler representing exactly
+  the published body length "{measurements["length"]}". For a range, the ruler itself spans only
+  the published endpoints, with the minimum at the bottom and maximum at the top, plus exactly
+  four evenly spaced unlabeled interior ticks creating five equal proportional segments. Those
+  ticks are subdivisions, not one-unit increments. For a single value, use one dimension line
+  labeled with that value. Use explicit units. Do not draw a zero-based or wider full-range axis,
+  and do not add a separate range bracket whose endpoints could disagree with the ruler. Label it
+  "BODY LENGTH: {measurements["length"]}" and "SCHEMATIC — NOT TO SCALE". Keep it separate from
+  the bird; never imply that it measures the printed illustration.
 - It should look like a carefully scanned scientific field-journal page, not Audubon, not a
   decorative poster, not a collage, and not photorealistic.
 - Quiet margins. No scenery, map, location, ZIP code, coordinates, date, logo, or watermark.
 - Preserve the exact 3:4 portrait aspect ratio and keep all text inside safe page margins.
-- Exactly one bird, one head, one beak, two wings, two legs, and one tail. Feet must be plausible.
+- Exactly one complete primary bird specimen, with one head, one beak, two wings, two legs, and
+  one tail. The detached bottom-margin wing and bill/head studies are supplementary anatomical
+  details, not additional birds; keep them spatially separate from the primary specimen and make
+  each anatomically accurate. Do not depict a second complete bird. Feet must be plausible.
+- Render the primary bird's tail as a distinct anatomical structure matching the supplied field
+  mark; do not let folded wing tips obscure or impersonate it.
+- When a supplied field mark calls an eye dark and inconspicuous while specifying its pupil shape,
+  keep the iris dark enough to blend into the surrounding plumage while making the pupil readable;
+  render the specified pupil itself as a thin black vertical slit in every depicted head, never a
+  round or oval pupil, and do not substitute a conspicuous amber, gold, or yellow iris ring.
 - Render only the exact species name and supplied factual notes. Do not invent extra prose.
+- Before finishing, compare every visible text line character-for-character with the supplied
+  field notes and confirm that the requested edit did not alter unrelated anatomy or design. Undo
+  any incidental spelling, number, punctuation, anatomy, or composition drift.
 
 Generate exactly one image using the built-in image generation tool. After generation, copy the
 selected final bitmap to this exact path inside the current workspace:
@@ -197,15 +238,36 @@ and the attached references. Do not assume the proposed facts are correct. Restr
 these domains: {", ".join(allowed_domains)}. Do not rely on search snippets. Inspect the candidate
 for correct plumage, proportions, bill, eye, wings, tail, legs, feet, and species field marks
 against the attached field-reference photos. Compare every visible factual claim to the
-independently verified facts. Confirm that no place name, ZIP code, coordinates, map, or
-local-observation detail appears. Use findings for the complete review record, including verified
-strengths and concrete issues. Put only required, actionable changes in correction_findings; do not
-repeat positive observations, source confirmations, or already-correct traits there. Return at
-least two direct HTTPS source URLs from distinct configured domains used for verification.
+independently verified facts. Do not infer a seasonal-plumage correction from one image or an
+unstated assumption; require explicit agreement from at least two direct allowed source pages
+before requesting a seasonal qualifier or color-pattern rewrite. Inspect every ruler, scale, and
+measurement diagram for internal
+consistency: values must increase from bottom to top, its endpoints, ticks, and units must match the
+published value or range, no separate marker may disagree with it, and it must be clearly
+schematic rather than presented as the printed bird's size. A range ruler must contain exactly
+four evenly spaced unlabeled interior ticks; treat them as five proportional segments, not
+one-unit increments. Treat any mismatch as a material text error with a specific correction.
+Read every visible text line in full rather than summarizing it. Compare its spelling, numbers,
+and word order to the proposed facts; treat duplicated, omitted, substituted, or nonsensical words
+as material text errors and give the exact replacement. When unequal mandibles are a field mark,
+trace each one independently from its shared bill base to its tip in every depicted head; do not
+confuse the open-gape angle with base-to-tip length. Compare both the direction and degree of the
+projection with the clearest attached side-profile references. Fail an ambiguous, co-terminal, or
+reversed rendering, an exaggerated or materially understated projection, a truncated-looking
+upper mandible, or inconsistent proportions between heads—even when the lower mandible is
+technically longer. Confirm that no place name, ZIP code, coordinates, map, or local-observation
+detail appears. Use findings for the complete review record, including verified strengths and
+concrete issues. Put only required, actionable changes in correction_findings; do not repeat
+positive observations, source confirmations, or already-correct traits there. Return at least two
+direct HTTPS source URLs from distinct configured domains used for verification.
 
 Set passed=true only when all four scores are at least 4, location_free is true, the bird has
-exactly one head, one beak, two wings, two legs, and one tail, and there are no material species or
-text errors. When passed=false, correction_findings must contain at least one specific change.
+exactly one complete primary specimen with one head, one beak, two wings, two legs, and one tail,
+and there are no material species or text errors. Clearly detached wing and bill/head studies are
+intentional supplementary anatomy, not duplicate parts or additional birds; do not fail them for
+their presence, but validate each study independently and fail malformed anatomy or a study that
+appears attached to the primary specimen. When passed=false, correction_findings must contain at
+least one specific change.
 When passed=true, correction_findings must be empty. Return only the requested JSON.
 
 Reference provenance:

--- a/src/inky_bird_frame/prompts.py
+++ b/src/inky_bird_frame/prompts.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from .birds import BirdSpecies, TaxonContext
 from .models import ReferencePhoto, SpeciesProfileData
 
-PROMPT_VERSION = "field-journal-v3"
+PROMPT_VERSION = "field-journal-v4"
 
 
 class _TextExtractor(HTMLParser):
@@ -204,9 +204,11 @@ Style and composition:
 - Render the primary bird's tail as a distinct anatomical structure matching the supplied field
   mark; do not let folded wing tips obscure or impersonate it.
 - When a supplied field mark calls an eye dark and inconspicuous while specifying its pupil shape,
-  keep the iris dark enough to blend into the surrounding plumage while making the pupil readable;
-  render the specified pupil itself as a thin black vertical slit in every depicted head, never a
-  round or oval pupil, and do not substitute a conspicuous amber, gold, or yellow iris ring.
+  keep the iris dark enough to blend into the surrounding plumage while making the pupil readable,
+  and render the supplied pupil shape precisely in every depicted head. When the supplied shape is
+  vertical, use a thin black vertical slit rather than a round or oval pupil. Never invent a
+  vertical slit for a species whose supplied facts specify another shape, and do not substitute a
+  conspicuous amber, gold, or yellow iris ring.
 - Render only the exact species name and supplied factual notes. Do not invent extra prose.
 - Before finishing, compare every visible text line character-for-character with the supplied
   field notes and confirm that the requested edit did not alter unrelated anatomy or design. Undo

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 
 import inky_bird_frame
 from inky_bird_frame.birds import BirdSpecies, DateRange
+from inky_bird_frame.catalog import sha256_file
 from inky_bird_frame.cli import (
     build_parser,
     catalog_sync_command,
@@ -363,6 +364,62 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(retry.taxon_id, 42)
         self.assertEqual(retry.source_attempt, 3)
+        self.assertEqual(str(retry.config), "instance.toml")
+
+    def test_retry_parser_accepts_archived_source_run(self) -> None:
+        retry = build_parser().parse_args(
+            [
+                "retry",
+                "42",
+                "--source-run",
+                "42-20260803T060207Z",
+                "--source-attempt",
+                "3",
+                "--config",
+                "instance.toml",
+            ]
+        )
+
+        self.assertEqual(retry.taxon_id, 42)
+        self.assertEqual(retry.source_run, "42-20260803T060207Z")
+        self.assertEqual(retry.source_attempt, 3)
+        self.assertEqual(str(retry.config), "instance.toml")
+
+    def test_retry_parser_accepts_operator_corrections(self) -> None:
+        retry = build_parser().parse_args(
+            [
+                "retry",
+                "42",
+                "--source-attempt",
+                "2",
+                "--correction",
+                "Correct only the ruler text.",
+                "--correction",
+                "Preserve the accepted bill.",
+                "--config",
+                "instance.toml",
+            ]
+        )
+
+        self.assertEqual(
+            retry.correction,
+            ["Correct only the ruler text.", "Preserve the accepted bill."],
+        )
+
+    def test_retry_parser_accepts_selected_source_candidate(self) -> None:
+        retry = build_parser().parse_args(
+            [
+                "retry",
+                "42",
+                "--source-candidate",
+                "42-example-bird-2",
+                "--config",
+                "instance.toml",
+            ]
+        )
+
+        self.assertEqual(retry.taxon_id, 42)
+        self.assertEqual(retry.source_candidate, "42-example-bird-2")
         self.assertEqual(str(retry.config), "instance.toml")
 
     def test_notifications_dispatch_checks_display_heartbeat(self) -> None:
@@ -851,6 +908,395 @@ rotation_mode = "shuffle_bag"
             self.assertEqual(guidance.findings, ("Fix the tail",))
             self.assertIsNotNone(guidance.source_plate)
         self.assertEqual(source_bytes, b"portrait-1")
+
+    def test_retry_preserves_selected_attempt_from_archived_run(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            run = state_dir / "archive/42-20260803T060207Z"
+            attempt = run / "attempt-03"
+            attempt.mkdir(parents=True)
+            (run / "profile.json").write_text(json.dumps({"taxon_id": 42}))
+            (attempt / "portrait.png").write_bytes(b"best earlier portrait")
+            (attempt / "quality-review.json").write_text(
+                json.dumps(
+                    {
+                        "passed": False,
+                        "findings": ["Verified bill", "Darken both irises"],
+                        "correction_findings": ["Darken both irises"],
+                    }
+                )
+            )
+            config = controller_config(state_dir)
+            output = io.StringIO()
+
+            with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
+                retry_command(
+                    Namespace(
+                        taxon_id=42,
+                        source_run=run.name,
+                        source_attempt=3,
+                    )
+                )
+
+            result = json.loads(output.getvalue())["data"]
+            guidance = RetryStore(state_dir / "generation-retries.json").quality_guidance(42)
+            source_bytes = (
+                (state_dir / guidance.source_plate).read_bytes()
+                if guidance is not None and guidance.source_plate is not None
+                else None
+            )
+
+        self.assertTrue(result["preserved_correction_source"])
+        self.assertEqual(result["source_run"], run.name)
+        self.assertEqual(result["source_attempt"], 3)
+        self.assertEqual(result["archived"], [])
+        self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(guidance.findings, ("Darken both irises",))
+        self.assertEqual(source_bytes, b"best earlier portrait")
+
+    def test_retry_rejects_symlinked_attempt_from_archived_run(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            run = state_dir / "archive/42-20260803T060207Z"
+            run.mkdir(parents=True)
+            (run / "profile.json").write_text(json.dumps({"taxon_id": 42}))
+            external_attempt = state_dir / "external-attempt"
+            external_attempt.mkdir()
+            (external_attempt / "portrait.png").write_bytes(b"external portrait")
+            (external_attempt / "quality-review.json").write_text(
+                json.dumps(
+                    {
+                        "passed": False,
+                        "findings": ["Correct the ruler"],
+                        "correction_findings": ["Correct the ruler"],
+                    }
+                )
+            )
+            (run / "attempt-01").symlink_to(external_attempt, target_is_directory=True)
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(SpeciesStateError, "escapes its archive run"),
+            ):
+                retry_command(
+                    Namespace(
+                        taxon_id=42,
+                        source_run=run.name,
+                        source_attempt=1,
+                    )
+                )
+
+    def test_retry_rejects_mismatched_archived_run_profile(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            run = state_dir / "archive/42-20260803T060207Z"
+            attempt = run / "attempt-01"
+            attempt.mkdir(parents=True)
+            (run / "profile.json").write_text(json.dumps({"taxon_id": 43}))
+            (attempt / "portrait.png").write_bytes(b"wrong species portrait")
+            (attempt / "quality-review.json").write_text(
+                json.dumps(
+                    {
+                        "passed": False,
+                        "findings": ["Correct the ruler"],
+                        "correction_findings": ["Correct the ruler"],
+                    }
+                )
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(SpeciesStateError, "identity does not match taxon 42"),
+            ):
+                retry_command(
+                    Namespace(
+                        taxon_id=42,
+                        source_run=run.name,
+                        source_attempt=1,
+                    )
+                )
+
+    def test_retry_rejects_invalid_source_run_before_archiving(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-example-bird/attempt-01"
+            failed.mkdir(parents=True)
+            (failed / "quality-review.json").write_text(
+                json.dumps({"passed": False, "findings": ["Fix the tail"]})
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(ValueError, "archive directory name"),
+            ):
+                retry_command(
+                    Namespace(
+                        taxon_id=42,
+                        source_run="../42-20260803T060207Z",
+                        source_attempt=1,
+                    )
+                )
+
+            self.assertTrue((state_dir / "failed/42-example-bird").is_dir())
+            self.assertFalse((state_dir / "archive").exists())
+
+    def test_retry_operator_correction_overrides_review_and_preserves_invariant(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-example-bird/attempt-02"
+            failed.mkdir(parents=True)
+            (failed / "portrait.png").write_bytes(b"accepted anatomy")
+            (failed / "quality-review.json").write_text(
+                json.dumps(
+                    {
+                        "passed": False,
+                        "findings": ["Redraw the accepted bill", "Correct the ruler"],
+                        "correction_findings": [
+                            "Redraw the accepted bill",
+                            "Correct the ruler",
+                        ],
+                    }
+                )
+            )
+            invariant = "Keep the source-matched bill proportion."
+            RetryStore(state_dir / "generation-retries.json").set_quality_guidance(
+                42,
+                (invariant,),
+                invariant_findings=(invariant,),
+            )
+            config = controller_config(state_dir)
+            output = io.StringIO()
+
+            with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
+                retry_command(
+                    Namespace(
+                        taxon_id=42,
+                        source_attempt=2,
+                        correction=["Correct only the ruler text."],
+                    )
+                )
+
+            result = json.loads(output.getvalue())["data"]
+            guidance = RetryStore(state_dir / "generation-retries.json").quality_guidance(42)
+
+        self.assertEqual(result["correction_override_count"], 1)
+        self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(
+                guidance.findings,
+                (invariant, "Correct only the ruler text."),
+            )
+            self.assertEqual(guidance.invariant_findings, (invariant,))
+
+    def test_retry_operator_correction_requires_source_and_unique_values(self) -> None:
+        with TemporaryDirectory() as temporary:
+            config = controller_config(Path(temporary))
+            with patch("inky_bird_frame.cli._config", return_value=config):
+                with self.assertRaisesRegex(ValueError, "requires --source-attempt"):
+                    retry_command(
+                        Namespace(
+                            taxon_id=42,
+                            correction=["Correct only the ruler text."],
+                        )
+                    )
+                with self.assertRaisesRegex(ValueError, "must not repeat"):
+                    retry_command(
+                        Namespace(
+                            taxon_id=42,
+                            source_attempt=2,
+                            correction=["Fix the ruler", "Fix the ruler"],
+                        )
+                    )
+
+    def test_retry_source_run_requires_attempt(self) -> None:
+        with TemporaryDirectory() as temporary:
+            config = controller_config(Path(temporary))
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(ValueError, "requires --source-attempt"),
+            ):
+                retry_command(Namespace(taxon_id=42, source_run="42-retained-run"))
+
+    def test_retry_preserves_human_rejected_candidate_as_correction_source(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            candidate = state_dir / "archive/42-example-bird-2"
+            candidate.mkdir(parents=True)
+            portrait = candidate / "portrait.png"
+            portrait.write_bytes(b"strong source")
+            rejection_reason = "Correct the bill while preserving the legs and composition."
+            (candidate / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "status": "rejected",
+                        "taxon_id": 42,
+                        "rejection_reason": rejection_reason,
+                        "assets": {
+                            "portrait": {
+                                "filename": "portrait.png",
+                                "sha256": sha256_file(portrait),
+                            }
+                        },
+                    }
+                )
+            )
+            failed = state_dir / "failed/42-example-bird/attempt-01"
+            failed.mkdir(parents=True)
+            (failed / "quality-review.json").write_text(
+                json.dumps({"passed": False, "findings": ["Ignore this other attempt"]})
+            )
+            config = controller_config(state_dir)
+            output = io.StringIO()
+
+            with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
+                retry_command(Namespace(taxon_id=42, source_candidate="42-example-bird-2"))
+
+            result = json.loads(output.getvalue())["data"]
+            guidance = RetryStore(state_dir / "generation-retries.json").quality_guidance(42)
+
+        self.assertEqual(result["source_candidate"], "42-example-bird-2")
+        self.assertTrue(result["preserved_correction_source"])
+        self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(guidance.findings, (rejection_reason,))
+            self.assertEqual(
+                guidance.source_plate,
+                "archive/42-example-bird-2/portrait.png",
+            )
+
+    def test_retry_selects_source_candidate_after_approved_replacement(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            candidate = state_dir / "archive/42-example-bird-2"
+            candidate.mkdir(parents=True)
+            portrait = candidate / "portrait.png"
+            portrait.write_bytes(b"rejected approved source")
+            rejection_reason = "Correct the bill while preserving the accepted anatomy."
+            (candidate / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "status": "rejected",
+                        "taxon_id": 42,
+                        "rejection_reason": rejection_reason,
+                        "assets": {
+                            "portrait": {
+                                "filename": "portrait.png",
+                                "sha256": sha256_file(portrait),
+                            }
+                        },
+                    }
+                )
+            )
+            RetryStore(state_dir / "generation-retries.json").set_quality_guidance(
+                42,
+                (rejection_reason,),
+                invariant_findings=(rejection_reason,),
+            )
+            config = controller_config(state_dir)
+            output = io.StringIO()
+
+            with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
+                retry_command(Namespace(taxon_id=42, source_candidate="42-example-bird-2"))
+
+            result = json.loads(output.getvalue())["data"]
+            guidance = RetryStore(state_dir / "generation-retries.json").quality_guidance(42)
+
+        self.assertEqual(result["archived"], [])
+        self.assertTrue(result["preserved_correction_source"])
+        self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(guidance.findings, (rejection_reason,))
+            self.assertEqual(guidance.invariant_findings, (rejection_reason,))
+            self.assertEqual(
+                guidance.source_plate,
+                "archive/42-example-bird-2/portrait.png",
+            )
+
+    def test_retry_rejects_invalid_source_candidate_before_archiving(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-example-bird/attempt-01"
+            failed.mkdir(parents=True)
+            (failed / "quality-review.json").write_text(
+                json.dumps({"passed": False, "findings": ["Fix the tail"]})
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(ValueError, "archive directory name"),
+            ):
+                retry_command(Namespace(taxon_id=42, source_candidate="../42-example-bird"))
+
+            self.assertTrue((state_dir / "failed/42-example-bird").is_dir())
+            self.assertFalse((state_dir / "archive").exists())
+
+    def test_retry_rejects_symlinked_source_candidate_manifest(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            candidate = state_dir / "archive/42-example-bird-2"
+            candidate.mkdir(parents=True)
+            external_manifest = state_dir / "manifest.json"
+            external_manifest.write_text("{}")
+            (candidate / "manifest.json").symlink_to(external_manifest)
+            failed = state_dir / "failed/42-example-bird/attempt-01"
+            failed.mkdir(parents=True)
+            (failed / "quality-review.json").write_text(
+                json.dumps({"passed": False, "findings": ["Fix the tail"]})
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(SpeciesStateError, "no valid manifest"),
+            ):
+                retry_command(Namespace(taxon_id=42, source_candidate=candidate.name))
+
+            self.assertTrue((state_dir / "failed/42-example-bird").is_dir())
+
+    def test_retry_rejects_modified_source_candidate_before_archiving(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            candidate = state_dir / "archive/42-example-bird-2"
+            candidate.mkdir(parents=True)
+            (candidate / "portrait.png").write_bytes(b"modified")
+            (candidate / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "status": "rejected",
+                        "taxon_id": 42,
+                        "rejection_reason": "Correct the bill.",
+                        "assets": {
+                            "portrait": {
+                                "filename": "portrait.png",
+                                "sha256": "0" * 64,
+                            }
+                        },
+                    }
+                )
+            )
+            failed = state_dir / "failed/42-example-bird/attempt-01"
+            failed.mkdir(parents=True)
+            (failed / "quality-review.json").write_text(
+                json.dumps({"passed": False, "findings": ["Fix the tail"]})
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(SpeciesStateError, "checksum mismatch"),
+            ):
+                retry_command(Namespace(taxon_id=42, source_candidate="42-example-bird-2"))
+
+            self.assertTrue((state_dir / "failed/42-example-bird").is_dir())
+            self.assertTrue(candidate.is_dir())
 
     def test_retry_rejects_missing_source_attempt_before_archiving(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -187,6 +187,7 @@ class CodexRunnerSubprocessTests(unittest.TestCase):
                     root / "plate.log",
                     ("Shorten the tail",),
                     correction_source_path=source,
+                    invariant_findings=("Keep the correct wing pattern",),
                 )
 
         command = execute.call_args.args[0]
@@ -195,6 +196,9 @@ class CodexRunnerSubprocessTests(unittest.TestCase):
         self.assertIn(
             "Image 1 is the previous plate and the edit target", execute.call_args.args[1]
         )
+        self.assertIn("Shorten the tail", execute.call_args.args[1])
+        self.assertIn("Keep the correct wing pattern", execute.call_args.args[1])
+        self.assertIn("Non-regression constraints", execute.call_args.args[1])
 
     def test_create_profile_rejects_mismatched_taxon_identity(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1424,7 +1424,7 @@ class ControllerTests(unittest.TestCase):
         self.assertIsNotNone(guidance)
         self.assertEqual(
             generate.call_args.kwargs["initial_correction_findings"],
-            ("Keep the bill proportion accurate",),
+            (),
         )
         self.assertEqual(
             generate.call_args.kwargs["invariant_correction_findings"],
@@ -1459,6 +1459,7 @@ class ControllerTests(unittest.TestCase):
 
         class FakeRunner:
             corrections: list[tuple[str, ...]] = []
+            invariants: list[tuple[str, ...]] = []
             generated_paths: list[Path] = []
             review_paths: list[Path] = []
             correction_sources: list[Path | None] = []
@@ -1482,6 +1483,9 @@ class ControllerTests(unittest.TestCase):
                 self.generated_paths.append(output_path)
                 assert output_path.resolve().is_relative_to(self.workspace)
                 self.corrections.append(correction)
+                invariants = _kwargs.get("invariant_findings")
+                assert isinstance(invariants, tuple)
+                self.invariants.append(invariants)
                 source = _kwargs.get("correction_source_path")
                 assert source is None or isinstance(source, Path)
                 self.correction_sources.append(source)
@@ -1531,8 +1535,15 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(
             FakeRunner.corrections,
             [
-                ("Render clearly visible natural eyes", "Preserve the previous scale correction"),
-                ("Render clearly visible natural eyes", "Crest is too short"),
+                ("Preserve the previous scale correction",),
+                ("Crest is too short",),
+            ],
+        )
+        self.assertEqual(
+            FakeRunner.invariants,
+            [
+                ("Render clearly visible natural eyes",),
+                ("Render clearly visible natural eyes",),
             ],
         )
         self.assertEqual(len(FakeRunner.generated_paths), 2)
@@ -1595,7 +1606,7 @@ class ControllerTests(unittest.TestCase):
             )
         self.assertEqual(
             generate.call_args.kwargs["initial_correction_findings"],
-            ("Keep the eyes clearly visible", "Correct the ruler scale"),
+            ("Correct the ruler scale",),
         )
         self.assertEqual(
             generate.call_args.kwargs["invariant_correction_findings"],
@@ -1861,7 +1872,7 @@ class ControllerTests(unittest.TestCase):
             self.assertEqual(guidance.invariant_findings, ("Keep the eyes clearly visible",))
         self.assertEqual(
             generate.call_args.kwargs["initial_correction_findings"],
-            ("Keep the eyes clearly visible", "Correct the ruler scale"),
+            ("Correct the ruler scale",),
         )
 
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -5,10 +5,13 @@ from pathlib import Path
 
 from inky_bird_frame.birds import BirdSpecies
 from inky_bird_frame.models import ReferencePhoto, SpeciesProfileData
-from inky_bird_frame.prompts import plate_prompt, review_prompt
+from inky_bird_frame.prompts import PROMPT_VERSION, plate_prompt, review_prompt
 
 
 class PromptTests(unittest.TestCase):
+    def test_prompt_contract_version(self) -> None:
+        self.assertEqual(PROMPT_VERSION, "field-journal-v4")
+
     def test_plate_prompt_contains_species_facts_and_excludes_location(self) -> None:
         species = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 26, "iNaturalist")
         profile = SpeciesProfileData(
@@ -129,8 +132,12 @@ class PromptTests(unittest.TestCase):
         self.assertIn("do not rely on a steeper gape angle", normalized_prompt)
         self.assertIn("same plausible proportional relationship", normalized_prompt)
         self.assertIn("keep the iris dark enough to blend", normalized_prompt)
-        self.assertIn("thin black vertical slit in every depicted head", normalized_prompt)
-        self.assertIn("never a round or oval pupil", normalized_prompt)
+        self.assertIn("render the supplied pupil shape precisely", normalized_prompt)
+        self.assertIn("When the supplied shape is vertical", normalized_prompt)
+        self.assertIn(
+            "thin black vertical slit rather than a round or oval pupil", normalized_prompt
+        )
+        self.assertIn("Never invent a vertical slit", normalized_prompt)
         self.assertIn("compare every visible text line character-for-character", normalized_prompt)
         self.assertIn("Undo any incidental spelling, number, punctuation", normalized_prompt)
         self.assertNotIn("Do not copy or lightly edit", prompt)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from inky_bird_frame.birds import BirdSpecies
 from inky_bird_frame.models import ReferencePhoto, SpeciesProfileData
-from inky_bird_frame.prompts import plate_prompt
+from inky_bird_frame.prompts import plate_prompt, review_prompt
 
 
 class PromptTests(unittest.TestCase):
@@ -77,7 +77,7 @@ class PromptTests(unittest.TestCase):
         self.assertIn("Correct the wing bars", prompt)
         self.assertIn("Create a new image", prompt)
 
-    def test_plate_prompt_edits_source_and_uses_schematic_ruler(self) -> None:
+    def test_plate_and_review_prompts_enforce_schematic_ruler(self) -> None:
         species = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 26, "iNaturalist")
         profile = SpeciesProfileData(
             taxon_id=12942,
@@ -101,15 +101,71 @@ class PromptTests(unittest.TestCase):
             [],
             Path("candidate.png"),
             ("Shorten the tail",),
+            invariant_findings=("Keep the accepted body proportions",),
             has_correction_source=True,
         )
+        normalized_prompt = " ".join(prompt.split())
 
         self.assertIn("Use case: precise-object-edit", prompt)
         self.assertIn("Image 1 is the previous plate and the edit target", prompt)
+        self.assertIn("Current actionable corrections", prompt)
+        self.assertIn("Non-regression constraints", prompt)
+        self.assertIn("Keep the accepted body proportions", prompt)
+        self.assertIn("not a request to redraw a feature", normalized_prompt)
         self.assertIn("Do not shrink the bird", prompt)
         self.assertIn("BODY LENGTH: 7 in", prompt)
         self.assertIn("SCHEMATIC — NOT TO SCALE", prompt)
+        self.assertIn("minimum at the bottom and maximum at the top", prompt)
+        self.assertIn("exactly four evenly spaced unlabeled interior ticks", normalized_prompt)
+        self.assertIn("ticks are subdivisions, not one-unit increments", normalized_prompt)
+        self.assertIn("Do not draw a zero-based or wider full-range axis", prompt)
+        self.assertIn("do not add a separate range bracket", normalized_prompt)
+        self.assertIn("Match both the direction and degree", normalized_prompt)
+        self.assertIn("the lower mandible is the jaw below the gape line", normalized_prompt)
+        self.assertIn("its tip must be farther from the shared bill base", normalized_prompt)
+        self.assertIn("Preserve the near-full length of the shorter structure", prompt)
+        self.assertIn("do not substitute a wider gape, lengthen the wrong jaw", normalized_prompt)
+        self.assertIn("the lower tip must also reach farther forward", normalized_prompt)
+        self.assertIn("do not rely on a steeper gape angle", normalized_prompt)
+        self.assertIn("same plausible proportional relationship", normalized_prompt)
+        self.assertIn("keep the iris dark enough to blend", normalized_prompt)
+        self.assertIn("thin black vertical slit in every depicted head", normalized_prompt)
+        self.assertIn("never a round or oval pupil", normalized_prompt)
+        self.assertIn("compare every visible text line character-for-character", normalized_prompt)
+        self.assertIn("Undo any incidental spelling, number, punctuation", normalized_prompt)
         self.assertNotIn("Do not copy or lightly edit", prompt)
+
+        review = review_prompt(species, profile, [], ("example.test", "example.org"))
+        normalized_review = " ".join(review.split())
+
+        self.assertIn("values must increase from bottom to top", review)
+        self.assertIn("no separate marker may disagree with it", review)
+        self.assertIn(
+            "range ruler must contain exactly four evenly spaced unlabeled interior ticks",
+            normalized_review,
+        )
+        self.assertIn("five proportional segments, not one-unit increments", normalized_review)
+        self.assertIn("Treat any mismatch as a material text error", normalized_review)
+        self.assertIn("Read every visible text line in full", normalized_review)
+        self.assertIn("duplicated, omitted, substituted, or nonsensical words", normalized_review)
+        self.assertIn(
+            "trace each one independently from its shared bill base to its tip", normalized_review
+        )
+        self.assertIn("ambiguous, co-terminal, or reversed rendering", normalized_review)
+        self.assertIn("do not confuse the open-gape angle", normalized_review)
+        self.assertIn("Compare both the direction and degree", normalized_review)
+        self.assertIn("truncated-looking upper mandible", normalized_review)
+        self.assertIn("inconsistent proportions between heads", normalized_review)
+        self.assertIn("Do not infer a seasonal-plumage correction", normalized_review)
+        self.assertIn(
+            "explicit agreement from at least two direct allowed source pages", normalized_review
+        )
+        self.assertIn("exactly one complete primary specimen", normalized_review)
+        self.assertIn(
+            "detached wing and bill/head studies are intentional supplementary anatomy",
+            normalized_review,
+        )
+        self.assertIn("validate each study independently", normalized_review)
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.2.7"
+version = "0.2.8"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary
- make the schematic body-length ruler and anatomy review contract deterministic
- separate current automated corrections from durable human non-regression constraints
- allow exact archived-run and rejected-candidate selection with containment, identity, checksum, and provenance validation
- bump the project release version to 0.2.8

## Why
Iterative image corrections could regress already accepted traits, reuse the wrong retained attempt, or produce internally inconsistent rulers. This keeps approved visual decisions stable while allowing a narrowly targeted edit from a verified retained source.

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest` (414 passed, 19 subtests passed)
- `git diff --check`