### PR TITLE
Document BirdWeather detection troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,37 +68,25 @@ candidate:
    neutrality; and
 4. returns structured scores and concrete findings.
 
-A failed review returns separate actionable corrections for the next attempt,
-which uses them to edit the failed plate while preserving its successful
-composition and content. Attempts are bounded by configuration, and exhausted
-work stops for
-inspection rather than publishing. A deliberate `retry` preserves validated
-research and references while carrying the final corrections into the next
-cycle. Use `--refresh-research` only when those inputs themselves need to be
-replaced. Maintainers can
-select a strong retained plate with `retry TAXON_ID --source-attempt N`; the
-source is archived, checksum-tracked, and edited rather than regenerated from
-scratch. If a stronger attempt belongs to an older archived generation run,
-select it with `retry TAXON_ID --source-run RUN_NAME --source-attempt N`; the
-command validates the private archive boundary, failed review, and portrait
-before preserving that exact edit source. When human inspection accepts some
-traits but adjudicates a review finding, repeat `--correction "..."` with a
-selected source to replace only the current automated findings; durable human
-invariants still apply. A later retry can reuse a human-rejected candidate
-already in the private archive with
-`retry TAXON_ID --source-candidate ARCHIVE_NAME`; the command verifies its taxon
-identity, rejection reason, and portrait checksum before using that rejection
-as the targeted edit contract. If human visual review rejects a locally approved
-plate before public
-publication, `retry TAXON_ID --replace-approved --reason "..."` is the explicit
-replacement migration: it records the rejection, archives the plate, removes
-it from local rotation, requeues historical-only taxa, preserves validated
-research and references, and regenerates the image from scratch while carrying
-the human rejection reason as a required constraint through every correction
-attempt. Add `--refresh-research` when the cached factual inputs are also being
-rejected. The migration
-is safe to resume after interruption and never rewrites an existing public
-catalog entry. Once a taxon passes, it is never regenerated implicitly.
+A failed review returns actionable corrections. The next attempt edits the
+failed plate while keeping the composition and content that passed. Attempts
+are bounded by configuration, and exhausted work stops for inspection rather
+than publishing.
+
+`retry TAXON_ID` keeps validated research and references by default. A
+maintainer can also resume from a retained attempt or archived candidate, or
+replace an automated finding with a specific human correction. Each path
+verifies the selected source and records its checksum before editing. Use
+`--refresh-research` only when the factual inputs are also suspect. The
+[operations guide](docs/operations.md#failure-recovery) lists those commands
+and the checks each one performs.
+
+A locally approved plate is protected from ordinary retries. Before public
+publication, `retry TAXON_ID --replace-approved --reason "..."` records a human
+rejection, archives the plate, removes it from local rotation, and starts a
+fresh replacement while keeping that rejection as a required correction. The
+migration is safe to resume after interruption and never rewrites an existing
+public catalog entry. Once a taxon passes, it is never regenerated implicitly.
 
 Regular application code handles selection, licensing rules, checksums, image
 dimensions, rotation, publishing, downloads, and display state. Codex handles
@@ -281,6 +269,8 @@ one station; it does not receive recordings or manage microphones. Bird Buddy
 is an opt-in private-API integration that requires the user to obtain Bird
 Buddy's permission and confirm it during login. Every provider result is
 matched to the same iNaturalist species identity before it enters the catalog.
+By default, the frame shows the newest station detection once, then returns to
+its normal rotation.
 
 Choose `last-day`, `last-week`, `last-30-days`, `last-year`, or `all-time` for
 the observation window. Provider limits still apply. The

--- a/README.md
+++ b/README.md
@@ -269,9 +269,9 @@ one station; it does not receive recordings or manage microphones. Bird Buddy
 is an opt-in private-API integration that requires the user to obtain Bird
 Buddy's permission and confirm it during login. Every provider result is
 matched to the same iNaturalist species identity before it enters the catalog.
-By default, the frame gives the newest station detection one turn when that
-species already has a plate in the active catalog, then returns to its normal
-rotation.
+By default, the frame gives the newest eligible detection across BirdWeather
+and Bird Buddy one turn when that species already has a plate in the active
+catalog, then returns to its normal rotation.
 
 Choose `last-day`, `last-week`, `last-30-days`, `last-year`, or `all-time` for
 the observation window. Provider limits still apply. The

--- a/README.md
+++ b/README.md
@@ -269,8 +269,9 @@ one station; it does not receive recordings or manage microphones. Bird Buddy
 is an opt-in private-API integration that requires the user to obtain Bird
 Buddy's permission and confirm it during login. Every provider result is
 matched to the same iNaturalist species identity before it enters the catalog.
-By default, the frame shows the newest station detection once, then returns to
-its normal rotation.
+By default, the frame gives the newest station detection one turn when that
+species already has a plate in the active catalog, then returns to its normal
+rotation.
 
 Choose `last-day`, `last-week`, `last-30-days`, `last-year`, or `all-time` for
 the observation window. Provider limits still apply. The

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -98,20 +98,25 @@ inky-bird-frame status --config /path/to/config.toml
 ```
 
 Find the `birdweather` entry in the `providers` array. A status of `ok` means
-the station request succeeded. `species_count` is the number of distinct avian
-species in the station summary, not the number of recordings, and
-`unresolved_count` reports species that could not be matched to the catalog's
-iNaturalist taxonomy. An error on that provider points to the station token,
-outbound HTTPS, the controller clock, or a BirdWeather outage.
+the station request and taxonomy step completed without a provider-level
+error. `species_count` is the number of distinct avian species matched to the
+catalog's iNaturalist taxonomy, not the number of recordings.
+`unresolved_count` reports otherwise usable station species that could not be
+matched. Read the provider's `error` field before changing configuration.
+Common causes include the station token, outbound HTTPS, the controller clock,
+a BirdWeather outage, iNaturalist availability, or a taxonomy mismatch.
 
 The station API returns one row per species, not one row per recording.
 Detection counts use the configured time window, and the row count is capped
 by `species_limit` and BirdWeather's 100-species maximum. Species are also
 deduplicated against the other discovery providers. Repeated detections update
 one species record; they do not create more plates. If a detected species is
-absent from `approved`, the next generation cycle still needs to create its
-plate. Check `deferred` and `failed` for work that needs attention. If the
-species appears in neither, let the scheduled generator run or invoke
+absent from `approved`, it still needs a plate before it can appear. Check
+`pending`, `deferred`, `terminal_blocked`, and `failed` before forcing a run. A
+plate you previously rejected is also terminal; for a live-only detection, it
+may not appear in those lists. Inspect it and run `retry TAXON_ID` to make the
+taxon eligible again. When no deferred or terminal state exists, let the
+scheduled generator run or invoke
 `inky-bird-frame generate --config /path/to/config.toml` for an immediate
 attempt.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -97,14 +97,19 @@ inky-bird-frame refresh --config /path/to/config.toml
 inky-bird-frame status --config /path/to/config.toml
 ```
 
-Find the `birdweather` entry in the `providers` array. A status of `ok` means
-the station request and taxonomy step completed without a provider-level
-error. `species_count` is the number of distinct avian species matched to the
-catalog's iNaturalist taxonomy, not the number of recordings.
-`unresolved_count` reports otherwise usable station species that could not be
-matched. Read the provider's `error` field before changing configuration.
-Common causes include the station token, outbound HTTPS, the controller clock,
-a BirdWeather outage, iNaturalist availability, or a taxonomy mismatch.
+If the command returns `"ok": false`, start with its top-level `error`. When
+every configured provider fails, the command stops before it can return a
+`providers` array. A successful command may still report one failed provider.
+In that case, find the `birdweather` entry and read its `error` field before
+changing configuration.
+
+A BirdWeather status of `ok` means the station request and taxonomy step
+completed without a provider-level error. `species_count` is the number of
+distinct avian species matched to the catalog's iNaturalist taxonomy, not the
+number of recordings. `unresolved_count` reports otherwise usable station
+species that could not be matched. Common error causes include the station
+token, outbound HTTPS, the controller clock, a BirdWeather outage, iNaturalist
+availability, or a taxonomy mismatch.
 
 The station API returns one row per species, not one row per recording.
 Detection counts use the configured time window, and the row count is capped

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -118,10 +118,11 @@ deduplicated against the other discovery providers. Repeated detections update
 one species record; they do not create more plates. If a detected species is
 absent from `approved`, it still needs a plate before it can appear. Check
 `pending`, `deferred`, `terminal_blocked`, and `failed` before forcing a run. A
-plate you previously rejected is also terminal; for a live-only detection, it
-may not appear in those lists. Inspect it and run `retry TAXON_ID` to make the
-taxon eligible again. When no deferred or terminal state exists, let the
-scheduled generator run or invoke
+plate you previously rejected or an interrupted pending directory without a
+manifest is also terminal; for a live-only detection, either state may be
+absent from those lists. Inspect the taxon and run `retry TAXON_ID` to make it
+eligible again. When no deferred or terminal state exists, let the scheduled
+generator run or invoke
 `inky-bird-frame generate --config /path/to/config.toml` for an immediate
 attempt.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -85,6 +85,53 @@ A multi-provider refresh reports each provider independently and continues when
 at least one configured provider is healthy. A refresh failure does not remove
 the existing active catalog.
 
+### BirdWeather shows detections, but the frame does not change
+
+Start at the controller. `discover` queries the configured providers
+interactively, `refresh` saves the result and rebuilds the active catalog, and
+`status` shows the approved catalog and any retained generation work:
+
+```bash
+inky-bird-frame discover --config /path/to/config.toml
+inky-bird-frame refresh --config /path/to/config.toml
+inky-bird-frame status --config /path/to/config.toml
+```
+
+Find the `birdweather` entry in the `providers` array. A status of `ok` means
+the station request succeeded. `species_count` is the number of distinct avian
+species in the station summary, not the number of recordings, and
+`unresolved_count` reports species that could not be matched to the catalog's
+iNaturalist taxonomy. An error on that provider points to the station token,
+outbound HTTPS, the controller clock, or a BirdWeather outage.
+
+The station API returns one row per species, not one row per recording.
+Detection counts use the configured time window, and the row count is capped
+by `species_limit` and BirdWeather's 100-species maximum. Species are also
+deduplicated against the other discovery providers. Repeated detections update
+one species record; they do not create more plates. If a detected species is
+absent from `approved`, the next generation cycle still needs to create its
+plate. Check `deferred` and `failed` for work that needs attention. If the
+species appears in neither, let the scheduled generator run or invoke
+`inky-bird-frame generate --config /path/to/config.toml` for an immediate
+attempt.
+
+The active catalog is exactly what the display node can choose from:
+
+```bash
+# On the controller
+curl --fail --silent "http://127.0.0.1:8793/v1/catalog"
+
+# On a systemd display node
+journalctl -u inky-bird-frame-display.service -n 100 --no-pager
+```
+
+When `prioritize_latest_detection` is enabled, the display shows the newest
+unconsumed detection once and then resumes normal rotation. Its successful
+cycle reports `"selection_reason": "latest_detection"`; `display_update` may
+be `unchanged` when that plate is already on the panel. A station
+classification that looks wrong must be corrected at the detector. Inky Bird
+Frame does not download the audio or apply a second confidence filter.
+
 ### TLS or certificate errors right after boot
 
 Raspberry Pi computers have no battery-backed real-time clock. After a power


### PR DESCRIPTION
## What changed

- add a station-to-frame troubleshooting path for BirdWeather detections
- explain the one-time latest-detection priority in the README
- shorten the README retry section and leave the command details in the operations guide

## Why

The existing guides describe the individual pieces, but they did not give an operator a clear way to trace a station detection through discovery, generation, the active catalog, and the display node. The README had also accumulated low-level retry detail that was already maintained elsewhere.

## Impact

Documentation only. Runtime behavior, configuration, catalog contents, and the application version are unchanged.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest` (415 passed, 19 subtests passed)
- `uv run inky-bird-frame catalog validate --catalog catalog` (107 species, valid)
- `git diff --check`