### PR TITLE
Fix post-merge review gaps

### DIFF
--- a/.github/scripts/review_gate.py
+++ b/.github/scripts/review_gate.py
@@ -100,6 +100,15 @@ query($owner: String!, $repo: String!, $pr: Int!) {
           commit { oid pushedDate committedDate }
         }
       }
+      readyForReviewEvents: timelineItems(
+        first: 100
+        itemTypes: [READY_FOR_REVIEW_EVENT]
+      ) {
+        pageInfo { hasNextPage }
+        nodes {
+          ... on ReadyForReviewEvent { createdAt }
+        }
+      }
       reviews(first: 100) {
         pageInfo { hasNextPage }
         nodes {
@@ -241,7 +250,13 @@ def _has_next_page(connection: object) -> bool:
 
 def _pagination_overflows(state: dict[str, object]) -> list[str]:
     overflows: list[str] = []
-    for key in ("reviews", "reviewThreads", "comments", "reactions"):
+    for key in (
+        "readyForReviewEvents",
+        "reviews",
+        "reviewThreads",
+        "comments",
+        "reactions",
+    ):
         if _has_next_page(state.get(key)):
             overflows.append(key)
 
@@ -288,33 +303,47 @@ def _comment_request_time(comment: dict[str, object]) -> datetime | None:
     return _parse_iso(created) if isinstance(created, str) else None
 
 
+def _latest_ready_for_review_time(state: dict[str, object]) -> datetime | None:
+    events = state.get("readyForReviewEvents")
+    if not isinstance(events, dict):
+        return None
+    candidates = [
+        parsed
+        for event in events.get("nodes") or []
+        if isinstance(event, dict)
+        for created_at in [event.get("createdAt")]
+        if isinstance(created_at, str)
+        for parsed in [_parse_iso(created_at)]
+        if parsed is not None
+    ]
+    return max(candidates) if candidates else None
+
+
 def _head_time(state: dict[str, object], head_sha: str) -> datetime | None:
-    """Return the timestamp for when the head commit became reviewable.
+    """Return when the current head most recently became reviewable.
 
     Only `pushedDate` is safe for reaction freshness. `committedDate` can be
     arbitrarily old after a force-push or reused commit, which would let a
     thumbs-up from a prior head satisfy the current head's engagement gate. If
     GitHub omits `pushedDate`, fall back to the latest `@codex review` request
-    comment that names this exact head SHA.
+    comment that names this exact head SHA. A later ready-for-review transition
+    supersedes both: draft review signals are provisional until the PR is ready.
     """
+    commit_time: datetime | None = None
     commits_obj = state.get("commits")
-    if not isinstance(commits_obj, dict):
-        return None
-    nodes = commits_obj.get("nodes")
-    if not isinstance(nodes, list) or not nodes:
-        return None
-    last = nodes[-1]
-    if not isinstance(last, dict):
-        return None
-    commit = last.get("commit")
-    if not isinstance(commit, dict):
-        return None
-    pushed = commit.get("pushedDate")
-    if isinstance(pushed, str):
-        parsed = _parse_iso(pushed)
-        if parsed is not None:
-            return parsed
-    return _latest_codex_request_time(state, head_sha)
+    if isinstance(commits_obj, dict):
+        nodes = commits_obj.get("nodes")
+        if isinstance(nodes, list) and nodes:
+            last = nodes[-1]
+            commit = last.get("commit") if isinstance(last, dict) else None
+            pushed = commit.get("pushedDate") if isinstance(commit, dict) else None
+            if isinstance(pushed, str):
+                commit_time = _parse_iso(pushed)
+    if commit_time is None:
+        commit_time = _latest_codex_request_time(state, head_sha)
+    ready_time = _latest_ready_for_review_time(state)
+    candidates = [value for value in (commit_time, ready_time) if value is not None]
+    return max(candidates) if candidates else None
 
 
 def _latest_codex_request_time(state: dict[str, object], head_sha: str) -> datetime | None:
@@ -366,7 +395,9 @@ def _owner_review_cutoff(
     request_time = _owner_codex_request_time(state, owner_login, head_sha)
     if request_time is None:
         return None
-    return max(request_time, head_time) if head_time is not None else request_time
+    if head_time is not None and request_time < head_time:
+        return None
+    return request_time
 
 
 def _codex_setup_required(

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -59,6 +59,10 @@ permissions:
 # full lifecycle without owner action.
 jobs:
   review-gate:
+    # Draft review is useful feedback, but it cannot certify merge readiness.
+    # Skip draft lifecycle runs so they cannot time out and leave a failed
+    # same-head suite that a later ready-for-review run cannot supersede.
+    if: github.event.action == 'ready_for_review' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     # Explicit job-level permissions (mirrors the workflow-level audit) so
     # static review tools can see at a glance that this job has what it needs.

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -3,8 +3,9 @@ name: review-gate
 # Bridges Codex review comments into a required CheckRun. Codex posts findings
 # as PR review comments (not as CheckRuns), so the standard
 # `required_status_checks` mechanism cannot gate on them directly. This
-# workflow runs once per pushed head SHA and fails when Codex has flagged a
-# blocking-severity finding. Codex review submissions are handled by
+# workflow runs for each pushed head and ready-for-review transition, and fails
+# when Codex has flagged a blocking-severity finding. Codex review submissions
+# are handled by
 # `review-gate-retrigger.yml`, which re-runs this workflow's gate job IN PLACE
 # (a new attempt of the same check suite) rather than starting a parallel run.
 #
@@ -13,7 +14,7 @@ name: review-gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   # Deliberately NOT `pull_request_review`: a review-event run creates a
   # second check suite with a same-named check run on the same head SHA, and
   # required-status evaluation demands EVERY suite's run pass. Combined with
@@ -26,12 +27,14 @@ on:
   # auto-fire this gate. To re-evaluate after resolving threads, push any
   # commit (`git commit --allow-empty -m "rerun" && git push`).
 
-# One run per head SHA, never cancelled: a cancelled conclusion on the
-# current head blocks required-status evaluation (the auto-merge stall this
-# group previously caused). Runs for superseded heads exit early on their
-# own. review_gate.py returns success as soon as it sees the PR head move or
-# the PR merge, because a post-merge timeout cannot protect the completed merge,
-# so CI minutes stay bounded without cancel-in-progress.
+# One run per reviewable lifecycle event, never cancelled: ready-for-review
+# intentionally starts a new run on the same head so draft review signals
+# cannot authorize a merge. A cancelled conclusion on the current head blocks
+# required-status evaluation (the auto-merge stall this group previously
+# caused). Runs for superseded heads exit early on their own. review_gate.py
+# returns success as soon as it sees the PR head move or the PR merge, because
+# a post-merge timeout cannot protect the completed merge, so CI minutes stay
+# bounded without cancel-in-progress.
 concurrency:
   group: review-gate-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
   cancel-in-progress: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,11 @@ validation, and the repository review gate. The repository owner controls the
 exact-head Codex review request and production deployment. External pull
 requests never receive those credentials.
 
+For a draft pull request, mark it ready before the owner's final exact-head
+Codex review request. The ready-for-review transition invalidates review signals
+from the draft lifecycle; wait for the post-ready review gate to finish before
+merging or enabling auto-merge.
+
 ## Documentation and agent guidance
 
 Public documentation and examples must be portable. Use placeholders for

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -130,7 +130,9 @@ The active catalog is exactly what the display node can choose from:
 
 ```bash
 # On the controller
-curl --fail --silent "http://127.0.0.1:8793/v1/catalog"
+# Match the reachable address and port in [controller]. These are the defaults.
+CONTROLLER_URL="http://127.0.0.1:8793"
+curl --fail --silent "${CONTROLLER_URL}/v1/catalog"
 
 # On a systemd display node
 journalctl -u inky-bird-frame-display.service -n 100 --no-pager

--- a/src/inky_bird_frame/birdbuddy.py
+++ b/src/inky_bird_frame/birdbuddy.py
@@ -553,9 +553,9 @@ def _parse_postcard(value: object, selected_feeder_id: str) -> BirdBuddyPostcard
             incomplete_recognized_sighting = True
             continue
         species[species_id] = PostcardSpecies(species_id, common_name, scientific_name)
+    if incomplete_recognized_sighting:
+        return None
     if not species:
-        if incomplete_recognized_sighting:
-            return None
         return BirdBuddyPostcard(postcard_id, observed_at, ())
     return BirdBuddyPostcard(
         postcard_id,

--- a/src/inky_bird_frame/birdbuddy.py
+++ b/src/inky_bird_frame/birdbuddy.py
@@ -135,6 +135,10 @@ query InkyBirdBuddyFeed($first: Int!, $after: String) {
 """.strip()
 
 _FEED_QUERIES: Final = (_FEED_RECOGNIZED, _FEED_UNLOCKED)
+_FEED_SIGHTING_TYPES: Final = (
+    "SightingRecognizedBird",
+    "SightingRecognizedBirdUnlocked",
+)
 
 
 @dataclass(frozen=True)
@@ -163,6 +167,7 @@ class BirdBuddyPostcard:
     postcard_id: str
     observed_at: str
     species: tuple[PostcardSpecies, ...]
+    complete: bool = True
 
 
 @dataclass(frozen=True)
@@ -506,7 +511,11 @@ def _feeder_id(value: object) -> str | None:
     return _nonempty_string(value.get("id"))
 
 
-def _parse_postcard(value: object, selected_feeder_id: str) -> BirdBuddyPostcard | None:
+def _parse_postcard(
+    value: object,
+    selected_feeder_id: str,
+    selected_sighting_type: str | None = None,
+) -> BirdBuddyPostcard | None:
     if not isinstance(value, dict) or value.get("__typename") != "FeedItemNewPostcard":
         return None
     postcard_id = _nonempty_string(value.get("id"))
@@ -524,7 +533,7 @@ def _parse_postcard(value: object, selected_feeder_id: str) -> BirdBuddyPostcard
         # A missing preview is an incomplete response, not an explicit
         # withdrawal. Ignore it so a transient schema/backend response cannot
         # delete a previously retained classification during reconciliation.
-        return None
+        return BirdBuddyPostcard(postcard_id, observed_at, (), complete=False)
     # An empty species tuple is a reconciliation tombstone. It lets a complete
     # feed refresh remove a previously accepted classification without storing
     # low-confidence or non-bird results in detection history.
@@ -542,6 +551,11 @@ def _parse_postcard(value: object, selected_feeder_id: str) -> BirdBuddyPostcard
             "SightingRecognizedBirdUnlocked",
         }:
             continue
+        # Each private-API query can select fields for only one union member.
+        # The complementary member therefore has a typename but no species in
+        # this response; its own query variant validates it independently.
+        if selected_sighting_type is not None and typename != selected_sighting_type:
+            continue
         species_value = sighting.get("species")
         if not isinstance(species_value, dict) or species_value.get("__typename") != "SpeciesBird":
             incomplete_recognized_sighting = True
@@ -553,14 +567,18 @@ def _parse_postcard(value: object, selected_feeder_id: str) -> BirdBuddyPostcard
             incomplete_recognized_sighting = True
             continue
         species[species_id] = PostcardSpecies(species_id, common_name, scientific_name)
-    if incomplete_recognized_sighting:
-        return None
     if not species:
-        return BirdBuddyPostcard(postcard_id, observed_at, ())
+        return BirdBuddyPostcard(
+            postcard_id,
+            observed_at,
+            (),
+            complete=not incomplete_recognized_sighting,
+        )
     return BirdBuddyPostcard(
         postcard_id,
         observed_at,
         tuple(sorted(species.values(), key=lambda item: item.species_id)),
+        complete=not incomplete_recognized_sighting,
     )
 
 
@@ -568,6 +586,7 @@ def _fetch_postcard_variant(
     access_token: str,
     feeder_id: str,
     query: str,
+    sighting_type: str | None = None,
 ) -> tuple[list[BirdBuddyPostcard], int, int, int]:
     postcards: dict[str, BirdBuddyPostcard] = {}
     after: str | None = None
@@ -597,12 +616,12 @@ def _fetch_postcard_variant(
         for edge in edges:
             processed += 1
             node = edge.get("node") if isinstance(edge, dict) else None
-            postcard = _parse_postcard(node, feeder_id)
+            postcard = _parse_postcard(node, feeder_id, sighting_type)
             if postcard is None:
                 ignored += 1
             else:
                 postcards[postcard.postcard_id] = postcard
-                if not postcard.species:
+                if not postcard.complete or not postcard.species:
                     ignored += 1
         has_next = page_info.get("hasNextPage")
         if has_next is False:
@@ -632,6 +651,7 @@ def _merge_postcard_variants(
         existing.postcard_id,
         existing.observed_at,
         tuple(sorted(species.values(), key=lambda item: item.species_id)),
+        complete=existing.complete and incoming.complete,
     )
 
 
@@ -640,22 +660,34 @@ def _fetch_postcards(
     feeder_id: str,
 ) -> tuple[list[BirdBuddyPostcard], int, int, int]:
     postcards: dict[str, BirdBuddyPostcard] = {}
+    variant_counts: dict[str, int] = {}
     total_pages = 0
     processed_per_variant: list[int] = []
-    for query in _FEED_QUERIES:
+    for query, sighting_type in zip(
+        _FEED_QUERIES,
+        _FEED_SIGHTING_TYPES,
+        strict=True,
+    ):
         incoming, pages, processed, _ = _fetch_postcard_variant(
             access_token,
             feeder_id,
             query,
+            sighting_type,
         )
         total_pages += pages
         processed_per_variant.append(processed)
         for postcard in incoming:
             _merge_postcard_variants(postcards, postcard)
+            variant_counts[postcard.postcard_id] = variant_counts.get(postcard.postcard_id, 0) + 1
     processed = max(processed_per_variant, default=0)
-    accepted_postcards = sum(bool(postcard.species) for postcard in postcards.values())
+    complete_postcards = [
+        postcard
+        for postcard in postcards.values()
+        if postcard.complete and variant_counts[postcard.postcard_id] == len(_FEED_QUERIES)
+    ]
+    accepted_postcards = sum(bool(postcard.species) for postcard in complete_postcards)
     ignored = max(0, processed - accepted_postcards)
-    return list(postcards.values()), total_pages, processed, ignored
+    return complete_postcards, total_pages, processed, ignored
 
 
 def _parse_postcard_state(value: object) -> BirdBuddyPostcard:

--- a/src/inky_bird_frame/birdbuddy.py
+++ b/src/inky_bird_frame/birdbuddy.py
@@ -518,18 +518,23 @@ def _parse_postcard(value: object, selected_feeder_id: str) -> BirdBuddyPostcard
     ):
         return None
     observed_at = observed.replace(microsecond=0).isoformat()
+    preview = value.get("sightingReportPreview")
+    sightings = preview.get("sightings") if isinstance(preview, dict) else None
+    if not isinstance(sightings, list):
+        # A missing preview is an incomplete response, not an explicit
+        # withdrawal. Ignore it so a transient schema/backend response cannot
+        # delete a previously retained classification during reconciliation.
+        return None
     # An empty species tuple is a reconciliation tombstone. It lets a complete
     # feed refresh remove a previously accepted classification without storing
     # low-confidence or non-bird results in detection history.
     if value.get("inferenceConfidenceLevel") != "HIGH_CONFIDENCE":
         return BirdBuddyPostcard(postcard_id, observed_at, ())
-    preview = value.get("sightingReportPreview")
-    sightings = preview.get("sightings") if isinstance(preview, dict) else None
-    if not isinstance(sightings, list):
-        return BirdBuddyPostcard(postcard_id, observed_at, ())
     species: dict[str, PostcardSpecies] = {}
+    incomplete_recognized_sighting = False
     for sighting in sightings:
         if not isinstance(sighting, dict):
+            incomplete_recognized_sighting = True
             continue
         typename = sighting.get("__typename")
         if typename not in {
@@ -539,13 +544,18 @@ def _parse_postcard(value: object, selected_feeder_id: str) -> BirdBuddyPostcard
             continue
         species_value = sighting.get("species")
         if not isinstance(species_value, dict) or species_value.get("__typename") != "SpeciesBird":
+            incomplete_recognized_sighting = True
             continue
         species_id = _nonempty_string(species_value.get("id"))
         common_name = _nonempty_string(species_value.get("name"))
         scientific_name = _nonempty_string(species_value.get("scientificName"))
-        if species_id is not None and common_name is not None and scientific_name is not None:
-            species[species_id] = PostcardSpecies(species_id, common_name, scientific_name)
+        if species_id is None or common_name is None or scientific_name is None:
+            incomplete_recognized_sighting = True
+            continue
+        species[species_id] = PostcardSpecies(species_id, common_name, scientific_name)
     if not species:
+        if incomplete_recognized_sighting:
+            return None
         return BirdBuddyPostcard(postcard_id, observed_at, ())
     return BirdBuddyPostcard(
         postcard_id,

--- a/tests/test_birdbuddy.py
+++ b/tests/test_birdbuddy.py
@@ -123,6 +123,15 @@ class BirdBuddyTests(unittest.TestCase):
             self.assertFalse((state_dir / "birdbuddy-auth.json").exists())
 
     def test_parse_postcard_accepts_only_high_confidence_recognized_birds(self) -> None:
+        recognized_sighting = {
+            "__typename": "SightingRecognizedBird",
+            "species": {
+                "__typename": "SpeciesBird",
+                "id": "species-bluebird",
+                "name": "Eastern Bluebird",
+                "scientificName": "Sialia sialis",
+            },
+        }
         node = {
             "__typename": "FeedItemNewPostcard",
             "id": "postcard-1",
@@ -131,15 +140,7 @@ class BirdBuddyTests(unittest.TestCase):
             "feeder": {"id": "feeder-1"},
             "sightingReportPreview": {
                 "sightings": [
-                    {
-                        "__typename": "SightingRecognizedBird",
-                        "species": {
-                            "__typename": "SpeciesBird",
-                            "id": "species-bluebird",
-                            "name": "Eastern Bluebird",
-                            "scientificName": "Sialia sialis",
-                        },
-                    },
+                    recognized_sighting,
                     {"__typename": "SightingCantDecideWhichBird"},
                 ]
             },
@@ -206,6 +207,20 @@ class BirdBuddyTests(unittest.TestCase):
         ):
             incomplete = {**node, "sightingReportPreview": incomplete_preview}
             self.assertIsNone(_parse_postcard(incomplete, "feeder-1"))
+
+        partially_incomplete = {
+            **node,
+            "sightingReportPreview": {
+                "sightings": [
+                    recognized_sighting,
+                    {
+                        "__typename": "SightingRecognizedBird",
+                        "species": None,
+                    },
+                ]
+            },
+        }
+        self.assertIsNone(_parse_postcard(partially_incomplete, "feeder-1"))
 
         low_confidence_incomplete = {
             **node,

--- a/tests/test_birdbuddy.py
+++ b/tests/test_birdbuddy.py
@@ -190,6 +190,30 @@ class BirdBuddyTests(unittest.TestCase):
         assert parsed_no_bird is not None
         self.assertEqual(parsed_no_bird.species, ())
 
+        for incomplete_preview in (
+            None,
+            {},
+            {"sightings": None},
+            {"sightings": [None]},
+            {
+                "sightings": [
+                    {
+                        "__typename": "SightingRecognizedBird",
+                        "species": None,
+                    }
+                ]
+            },
+        ):
+            incomplete = {**node, "sightingReportPreview": incomplete_preview}
+            self.assertIsNone(_parse_postcard(incomplete, "feeder-1"))
+
+        low_confidence_incomplete = {
+            **node,
+            "inferenceConfidenceLevel": "LOW_CONFIDENCE",
+            "sightingReportPreview": None,
+        }
+        self.assertIsNone(_parse_postcard(low_confidence_incomplete, "feeder-1"))
+
     def test_feed_rejects_repeated_pagination_cursor(self) -> None:
         page = {
             "me": {
@@ -454,6 +478,72 @@ class BirdBuddyTests(unittest.TestCase):
         self.assertEqual(removed.species, [])
         self.assertEqual(removed.stats.reclassified_postcards, 1)
         self.assertEqual(history["feeders"]["feeder-1"]["postcards"], [])
+
+    def test_sync_preserves_detection_when_postcard_preview_is_incomplete(self) -> None:
+        feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")
+        now = datetime(2026, 8, 3, 12, 0, tzinfo=UTC)
+        original = postcard("postcard-1", now - timedelta(hours=1))
+        incomplete_page = {
+            "me": {
+                "feed": {
+                    "edges": [
+                        {
+                            "node": {
+                                "__typename": "FeedItemNewPostcard",
+                                "id": original.postcard_id,
+                                "createdAt": original.observed_at,
+                                "inferenceConfidenceLevel": "HIGH_CONFIDENCE",
+                                "feeder": {"id": feeder.feeder_id},
+                                "sightingReportPreview": None,
+                            }
+                        }
+                    ],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            with patch(
+                "inky_bird_frame.birdbuddy._authenticate",
+                return_value=("access", "refresh", [feeder]),
+            ):
+                login_birdbuddy(
+                    state_dir,
+                    email="birder@example.test",
+                    password="private-password",
+                    authorization_confirmed=True,
+                    now=now,
+                )
+            with patch(
+                "inky_bird_frame.birdbuddy._refresh_access_token",
+                return_value=("access", "replacement"),
+            ):
+                with patch(
+                    "inky_bird_frame.birdbuddy._fetch_postcards",
+                    return_value=([original], 2, 1, 0),
+                ):
+                    sync_birdbuddy_detections(
+                        state_dir,
+                        window=ObservationWindow.ALL_TIME,
+                        limit=20,
+                        now=now,
+                    )
+                with patch(
+                    "inky_bird_frame.birdbuddy._graphql_request",
+                    return_value=incomplete_page,
+                ):
+                    preserved = sync_birdbuddy_detections(
+                        state_dir,
+                        window=ObservationWindow.ALL_TIME,
+                        limit=20,
+                        now=now,
+                    )
+
+        self.assertEqual(len(preserved.species), 1)
+        self.assertEqual(preserved.species[0].scientific_name, "Sialia sialis")
+        self.assertEqual(preserved.stats.reclassified_postcards, 0)
+        self.assertEqual(preserved.stats.ignored_postcards, 1)
 
     def test_all_time_retains_pruned_detection_while_last_year_excludes_it(self) -> None:
         feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")

--- a/tests/test_birdbuddy.py
+++ b/tests/test_birdbuddy.py
@@ -40,6 +40,21 @@ def postcard(
     )
 
 
+def feed_node(
+    *sightings: object,
+    postcard_id: str = "postcard-1",
+    observed_at: str = "2026-08-03T10:00:00+00:00",
+) -> dict[str, object]:
+    return {
+        "__typename": "FeedItemNewPostcard",
+        "id": postcard_id,
+        "createdAt": observed_at,
+        "inferenceConfidenceLevel": "HIGH_CONFIDENCE",
+        "feeder": {"id": "feeder-1"},
+        "sightingReportPreview": {"sightings": list(sightings)},
+    }
+
+
 class BirdBuddyTests(unittest.TestCase):
     def test_feed_operation_is_read_only_and_metadata_only(self) -> None:
         self.assertEqual(len(_FEED_QUERIES), 2)
@@ -132,19 +147,10 @@ class BirdBuddyTests(unittest.TestCase):
                 "scientificName": "Sialia sialis",
             },
         }
-        node = {
-            "__typename": "FeedItemNewPostcard",
-            "id": "postcard-1",
-            "createdAt": "2026-08-03T10:00:00+00:00",
-            "inferenceConfidenceLevel": "HIGH_CONFIDENCE",
-            "feeder": {"id": "feeder-1"},
-            "sightingReportPreview": {
-                "sightings": [
-                    recognized_sighting,
-                    {"__typename": "SightingCantDecideWhichBird"},
-                ]
-            },
-        }
+        node = feed_node(
+            recognized_sighting,
+            {"__typename": "SightingCantDecideWhichBird"},
+        )
 
         parsed = _parse_postcard(node, "feeder-1")
 
@@ -206,7 +212,10 @@ class BirdBuddyTests(unittest.TestCase):
             },
         ):
             incomplete = {**node, "sightingReportPreview": incomplete_preview}
-            self.assertIsNone(_parse_postcard(incomplete, "feeder-1"))
+            parsed_incomplete = _parse_postcard(incomplete, "feeder-1")
+            self.assertIsNotNone(parsed_incomplete)
+            assert parsed_incomplete is not None
+            self.assertFalse(parsed_incomplete.complete)
 
         partially_incomplete = {
             **node,
@@ -220,14 +229,20 @@ class BirdBuddyTests(unittest.TestCase):
                 ]
             },
         }
-        self.assertIsNone(_parse_postcard(partially_incomplete, "feeder-1"))
+        parsed_partial = _parse_postcard(partially_incomplete, "feeder-1")
+        self.assertIsNotNone(parsed_partial)
+        assert parsed_partial is not None
+        self.assertFalse(parsed_partial.complete)
 
         low_confidence_incomplete = {
             **node,
             "inferenceConfidenceLevel": "LOW_CONFIDENCE",
             "sightingReportPreview": None,
         }
-        self.assertIsNone(_parse_postcard(low_confidence_incomplete, "feeder-1"))
+        parsed_low_confidence = _parse_postcard(low_confidence_incomplete, "feeder-1")
+        self.assertIsNotNone(parsed_low_confidence)
+        assert parsed_low_confidence is not None
+        self.assertFalse(parsed_low_confidence.complete)
 
     def test_feed_rejects_repeated_pagination_cursor(self) -> None:
         page = {
@@ -288,6 +303,122 @@ class BirdBuddyTests(unittest.TestCase):
             [item.species_id for item in postcards[0].species],
             ["species-bluebird", "species-cardinal"],
         )
+
+    def test_feed_combines_complementary_union_variants_before_validation(self) -> None:
+        observed_at = datetime(2026, 8, 3, 10, 0, tzinfo=UTC)
+        recognized = postcard("postcard-1", observed_at)
+        unlocked = postcard(
+            "postcard-1",
+            observed_at,
+            "species-cardinal",
+            "Northern Cardinal",
+            "Cardinalis cardinalis",
+        )
+        recognized_node = feed_node(
+            {
+                "__typename": "SightingRecognizedBird",
+                "species": {
+                    "__typename": "SpeciesBird",
+                    "id": recognized.species[0].species_id,
+                    "name": recognized.species[0].common_name,
+                    "scientificName": recognized.species[0].scientific_name,
+                },
+            },
+            {"__typename": "SightingRecognizedBirdUnlocked"},
+            observed_at=observed_at.isoformat(),
+        )
+        unlocked_node = feed_node(
+            {"__typename": "SightingRecognizedBird"},
+            {
+                "__typename": "SightingRecognizedBirdUnlocked",
+                "species": {
+                    "__typename": "SpeciesBird",
+                    "id": unlocked.species[0].species_id,
+                    "name": unlocked.species[0].common_name,
+                    "scientificName": unlocked.species[0].scientific_name,
+                },
+            },
+            observed_at=observed_at.isoformat(),
+        )
+
+        parsed_recognized = _parse_postcard(
+            recognized_node,
+            "feeder-1",
+            "SightingRecognizedBird",
+        )
+        parsed_unlocked = _parse_postcard(
+            unlocked_node,
+            "feeder-1",
+            "SightingRecognizedBirdUnlocked",
+        )
+
+        self.assertIsNotNone(parsed_recognized)
+        self.assertIsNotNone(parsed_unlocked)
+        assert parsed_recognized is not None
+        assert parsed_unlocked is not None
+        self.assertTrue(parsed_recognized.complete)
+        self.assertTrue(parsed_unlocked.complete)
+
+        with patch(
+            "inky_bird_frame.birdbuddy._fetch_postcard_variant",
+            side_effect=[
+                ([parsed_recognized], 1, 1, 0),
+                ([parsed_unlocked], 1, 1, 0),
+            ],
+        ):
+            postcards, _, _, ignored = _fetch_postcards("access-secret", "feeder-1")
+
+        self.assertEqual(ignored, 0)
+        self.assertEqual(
+            [item.species_id for item in postcards[0].species],
+            ["species-bluebird", "species-cardinal"],
+        )
+
+    def test_feed_rejects_combined_postcard_when_selected_variant_is_incomplete(
+        self,
+    ) -> None:
+        observed_at = datetime(2026, 8, 3, 10, 0, tzinfo=UTC)
+        incomplete = BirdBuddyPostcard(
+            "postcard-1",
+            observed_at.isoformat(),
+            (),
+            complete=False,
+        )
+        unlocked = postcard(
+            "postcard-1",
+            observed_at,
+            "species-cardinal",
+            "Northern Cardinal",
+            "Cardinalis cardinalis",
+        )
+        with patch(
+            "inky_bird_frame.birdbuddy._fetch_postcard_variant",
+            side_effect=[
+                ([incomplete], 1, 1, 1),
+                ([unlocked], 1, 1, 0),
+            ],
+        ):
+            postcards, _, processed, ignored = _fetch_postcards("access-secret", "feeder-1")
+
+        self.assertEqual(postcards, [])
+        self.assertEqual(processed, 1)
+        self.assertEqual(ignored, 1)
+
+    def test_feed_ignores_postcard_missing_from_one_query_variant(self) -> None:
+        observed_at = datetime(2026, 8, 3, 10, 0, tzinfo=UTC)
+        recognized = postcard("postcard-1", observed_at)
+        with patch(
+            "inky_bird_frame.birdbuddy._fetch_postcard_variant",
+            side_effect=[
+                ([recognized], 1, 1, 0),
+                ([], 1, 0, 0),
+            ],
+        ):
+            postcards, _, processed, ignored = _fetch_postcards("access-secret", "feeder-1")
+
+        self.assertEqual(postcards, [])
+        self.assertEqual(processed, 1)
+        self.assertEqual(ignored, 1)
 
     def test_revoked_refresh_token_has_actionable_redacted_error(self) -> None:
         with (

--- a/tests/test_review_gate_script.py
+++ b/tests/test_review_gate_script.py
@@ -890,6 +890,80 @@ def test_owner_request_uses_edit_time_for_current_body() -> None:
     assert cutoff.isoformat() == "2026-06-15T12:04:00+00:00"
 
 
+def test_ready_for_review_invalidates_draft_review_signals() -> None:
+    review_gate = _load_review_gate()
+    state = _state_with_commit(
+        pushed="2026-06-15T11:59:00Z",
+        committed="2026-06-15T11:58:00Z",
+    )
+    state["readyForReviewEvents"] = {"nodes": [{"createdAt": "2026-06-15T12:05:00Z"}]}
+    state["comments"] = {
+        "nodes": [
+            {
+                "body": "@codex review\n\nhead: abc123",
+                "createdAt": "2026-06-15T12:00:00Z",
+                "author": {"login": "owner"},
+            }
+        ]
+    }
+
+    head_time = review_gate._head_time(state, "abc123")
+
+    assert head_time is not None
+    assert head_time.isoformat() == "2026-06-15T12:05:00+00:00"
+    assert (
+        review_gate.engaged_bots(
+            state,
+            "owner/repo",
+            "abc123",
+            head_time,
+            owner_login="owner",
+        )
+        == set()
+    )
+
+
+def test_post_ready_exact_head_request_can_authorize_fresh_review() -> None:
+    review_gate = _load_review_gate()
+    head_sha = "abc1234"
+    state = _state_with_commit(
+        pushed="2026-06-15T11:59:00Z",
+        committed="2026-06-15T11:58:00Z",
+    )
+    state["readyForReviewEvents"] = {"nodes": [{"createdAt": "2026-06-15T12:05:00Z"}]}
+    state["comments"] = {
+        "nodes": [
+            {
+                "body": f"@codex review\n\nhead: {head_sha}",
+                "createdAt": "2026-06-15T12:06:00Z",
+                "author": {"login": "owner"},
+            }
+        ]
+    }
+    state["reviews"] = {
+        "nodes": [
+            {
+                "databaseId": 1,
+                "state": "COMMENTED",
+                "submittedAt": "2026-06-15T12:07:00Z",
+                "body": _full_codex_review_body(head_sha),
+                "author": {"login": "chatgpt-codex-connector"},
+                "commit": {"oid": head_sha},
+            }
+        ]
+    }
+
+    head_time = review_gate._head_time(state, head_sha)
+
+    assert review_gate.engaged_bots(
+        state,
+        "owner/repo",
+        head_sha,
+        head_time,
+        owner_login="owner",
+    ) == {review_gate.CODEX_LOGIN}
+
+
 def test_engagement_poll_refreshes_head_time_from_updated_pr_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1167,9 +1241,14 @@ def test_pagination_overflow_includes_nested_thread_comments() -> None:
             ],
         },
         "reactions": {"pageInfo": {"hasNextPage": False}, "nodes": []},
+        "readyForReviewEvents": {
+            "pageInfo": {"hasNextPage": True},
+            "nodes": [],
+        },
     }
 
     assert review_gate._pagination_overflows(state) == [
+        "readyForReviewEvents",
         "reviewThreads",
         "reviewThreads[0].comments",
     ]

--- a/tests/test_workflow_pinning_script.py
+++ b/tests/test_workflow_pinning_script.py
@@ -115,6 +115,14 @@ def test_current_workflows_are_sha_pinned() -> None:
     assert workflow_pinning.scan_workflows(workflows_dir) == []
 
 
+def test_review_gate_runs_when_draft_becomes_ready() -> None:
+    workflow = (
+        Path(__file__).resolve().parents[1] / ".github/workflows/review-gate.yml"
+    ).read_text()
+
+    assert "types: [opened, synchronize, reopened, ready_for_review]" in workflow
+
+
 def test_review_gate_retrigger_accepts_only_exact_head_owner_requests() -> None:
     workflow = (
         Path(__file__).resolve().parents[1] / ".github/workflows/review-gate-retrigger.yml"

--- a/tests/test_workflow_pinning_script.py
+++ b/tests/test_workflow_pinning_script.py
@@ -121,6 +121,9 @@ def test_review_gate_runs_when_draft_becomes_ready() -> None:
     ).read_text()
 
     assert "types: [opened, synchronize, reopened, ready_for_review]" in workflow
+    assert (
+        "if: github.event.action == 'ready_for_review' || !github.event.pull_request.draft"
+    ) in workflow
 
 
 def test_review_gate_retrigger_accepts_only_exact_head_owner_requests() -> None:


### PR DESCRIPTION
## What changed
- ignore incomplete Bird Buddy postcard previews instead of treating them as classification withdrawals
- make the catalog troubleshooting endpoint explicitly configurable
- invalidate draft-lifecycle review signals when a PR becomes ready for review
- require a fresh exact-head owner request after that transition

## Why
Late Codex reviews on PRs #159 and #162 landed after merge. This fixes both findings and closes the lifecycle race that allowed draft review signals to remain valid after readiness.

## Validation
- Ruff format and lint
- strict MyPy
- full Pytest suite
- catalog validation: 108 species
- package build
- actionlint
- live GitHub GraphQL query against PR #162