### PR TITLE
Reconcile confirmed Bird Buddy sightings

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,9 @@ Choose any combination of `inaturalist`, `ebird`, `birdweather`, and
 `birdbuddy` in `discovery.sources`. BirdWeather reads detection summaries from
 one station; it does not receive recordings or manage microphones. Bird Buddy
 is an opt-in private-API integration that requires the user to obtain Bird
-Buddy's permission and confirm it during login. Every provider result is
+Buddy's permission and confirm it during login. It follows the selected feeder
+by default; account-level manually added sightings require the explicit
+`birdbuddy_include_manual_sightings = true` option. Every provider result is
 matched to the same iNaturalist species identity before it enters the catalog.
 By default, the frame gives the newest eligible detection across BirdWeather
 and Bird Buddy one turn when that species already has a plate in the active

--- a/config.example.toml
+++ b/config.example.toml
@@ -33,6 +33,9 @@ window = "last-30-days"
 # birdweather_token_env = "BIRDWEATHER_TOKEN"
 # Bird Buddy credentials never belong in this file. Obtain permission from Bird Buddy, add
 # "birdbuddy" to sources, then run `inky-bird-frame birdbuddy login --config config.toml`.
+# Manually added app sightings are account-level and may not belong to the selected feeder's
+# location, so they are excluded unless the operator explicitly accepts that provenance.
+birdbuddy_include_manual_sightings = false
 
 [controller]
 # Keep Codex's writable workspace separate from configuration, catalog, and state.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,9 +43,12 @@ An authorized Bird Buddy provider keeps two additional private files under
 `state_dir`. `birdbuddy-auth.json` contains the user's authorization
 attestation, selected feeder, and rotating refresh token; the email, password,
 and short-lived access token are never stored. `birdbuddy-detections.json`
-deduplicates postcard species for 366 days and retains older all-time totals.
-Both files use atomic mode-`0600` writes and never enter the served or published
-catalog.
+deduplicates postcard species for 366 days, retains older all-time totals, and
+keeps the newest confirmed metadata evidence for each species and provenance.
+Confirmed evidence closes the transient-feed gap without counting several
+media files as several visits. Account-level manual evidence affects discovery
+only when `birdbuddy_include_manual_sightings` is enabled. Both files use atomic
+mode-`0600` writes and never enter the served or published catalog.
 
 A locked generation cycle completes that migration, recovers passing pending
 work, and then reads the latest non-stale snapshot and durable seed queue.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,6 +45,9 @@ attestation, selected feeder, and rotating refresh token; the email, password,
 and short-lived access token are never stored. `birdbuddy-detections.json`
 deduplicates postcard species for 366 days, retains older all-time totals, and
 keeps the newest confirmed metadata evidence for each species and provenance.
+Private media identifiers link complete confirmed records back to cached
+postcards so corrections replace preview classifications without downloading
+media.
 Confirmed evidence closes the transient-feed gap without counting several
 media files as several visits. Account-level manual evidence affects discovery
 only when `birdbuddy_include_manual_sightings` is enabled. Both files use atomic

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,9 @@ deduplicates postcard species for 366 days, retains older all-time totals, and
 keeps the newest confirmed metadata evidence for each species and provenance.
 Private media identifiers link complete confirmed records back to cached
 postcards so corrections replace preview classifications without downloading
-media.
+media. After the 366-day detail window, a compact correction ledger remains
+only while the corresponding confirmed media remains visible; it can update
+archived totals without retaining the postcard ID.
 Confirmed evidence closes the transient-feed gap without counting several
 media files as several visits. Account-level manual evidence affects discovery
 only when `birdbuddy_include_manual_sightings` is enabled. Both files use atomic

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -229,13 +229,22 @@ the option is disabled. Livestream `WATCHING` records and postcard history from
 other feeders are always excluded.
 
 Exact postcard events remain in private history for 366 days, with older
-all-time totals retained separately. Confirmed history keeps the newest
-evidence per species and provenance. The first sync can import only metadata
-Bird Buddy still exposes. `all-time` combines exact history accumulated since
-the integration began with conservative presence evidence from the current
-confirmed collection; it is not a claim about Bird Buddy's total visit count.
-Repeated polls are idempotent, and changed classifications replace prior
-species while Bird Buddy still exposes the underlying record.
+all-time totals retained separately. A compact correction ledger keeps media
+linkage for an archived postcard only while Bird Buddy still exposes every
+linked media record; it can adjust the totals without retaining the postcard
+ID. Confirmed history keeps the newest evidence per species and provenance.
+The first sync can import only metadata Bird Buddy still exposes. `all-time`
+combines exact history accumulated since the integration began with
+conservative presence evidence from the current confirmed collection; it is
+not a claim about Bird Buddy's total visit count. Repeated polls are idempotent,
+and changed or removed classifications replace prior species while Bird Buddy
+still exposes the underlying record.
+
+History written before media linkage cannot prove which confirmed record
+belongs to a cached postcard. The first successful sync after this upgrade
+drops those unlinked, short-lived postcard rows instead of risking a stale
+classification. Current confirmed metadata can still restore conservative
+species presence.
 
 ## How eBird enrichment works
 

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -188,10 +188,12 @@ Bird Buddy rotates its refresh token during every authenticated request, so
 even `discover` and seed previews must atomically update authentication state.
 Preview commands do not commit detection history or taxonomy cache changes.
 
-The provider reads high-confidence species metadata from new postcards. It
-also reads the species, capture time, origin, and feeder ID from confirmed
-history so a postcard is not missed when someone confirms it before Inky's
-next poll. It never requests media URLs or downloads photos, video, or audio.
+The provider reads high-confidence species metadata and media identifiers from
+new postcards. It also reads the species, capture time, origin, feeder ID, and
+media identifier from confirmed history so a postcard is not missed when
+someone confirms it before Inky's next poll. The identifiers link a confirmed
+correction back to its cached postcard; they never enter the public catalog.
+Inky never requests media URLs or downloads photos, video, or audio.
 It does not convert, reanalyze, collect, edit, discard, or share a postcard or
 control a feeder. The independent
 [pybirdbuddy project](https://github.com/jhansche/pybirdbuddy) demonstrates the
@@ -201,6 +203,9 @@ authoritative Bird Buddy API contract and is not a runtime dependency here.
 Bird Buddy removes a postcard from the new-postcard feed after it is confirmed.
 The controller therefore combines exact postcard history with confirmed
 metadata. Exact postcards are deduplicated and counted once per species.
+When confirmed history covers every media item on a cached postcard, its
+species replace the earlier preview classification. An incomplete match leaves
+the cached postcard unchanged rather than guessing.
 Confirmed records fill gaps in species presence and supply the newest capture
 time, but they do not increase an existing postcard count: one postcard can
 contain several media records, and treating each as a visit would inflate the

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -15,7 +15,7 @@ automate Merlin.
 | `inaturalist` | None | All | Default setup, historical seeds, and licensed references |
 | `ebird` | Personal eBird key | 1, 7, or 30 days | Bird-specific recent public sightings |
 | `birdweather` | BirdWeather station token | All | Species acoustically detected by one station |
-| `birdbuddy` | Authorized Bird Buddy account | All after setup | High-confidence postcard species from one feeder |
+| `birdbuddy` | Authorized Bird Buddy account | All after setup | Postcard species from one feeder, plus optional manual sightings |
 
 Select any combination with a TOML array. Each configured provider runs
 independently.
@@ -156,6 +156,7 @@ Add the provider without putting credentials in TOML:
 ```toml
 [discovery]
 sources = ["inaturalist", "birdbuddy"]
+birdbuddy_include_manual_sightings = false
 zip_code = "12345"
 radius_km = 8
 species_limit = 50
@@ -187,20 +188,49 @@ Bird Buddy rotates its refresh token during every authenticated request, so
 even `discover` and seed previews must atomically update authentication state.
 Preview commands do not commit detection history or taxonomy cache changes.
 
-The provider reads only high-confidence recognized-bird metadata from new
-postcards. It does not convert, reanalyze, collect, edit, discard, or share a
-postcard; control a feeder; or download photos, video, or audio. The independent
+The provider reads high-confidence species metadata from new postcards. It
+also reads the species, capture time, origin, and feeder ID from confirmed
+history so a postcard is not missed when someone confirms it before Inky's
+next poll. It never requests media URLs or downloads photos, video, or audio.
+It does not convert, reanalyze, collect, edit, discard, or share a postcard or
+control a feeder. The independent
 [pybirdbuddy project](https://github.com/jhansche/pybirdbuddy) demonstrates the
 private API's current password and guest-account behavior but is not an
 authoritative Bird Buddy API contract and is not a runtime dependency here.
 
-Bird Buddy removes postcards from the main feed after seven days. The
-controller therefore keeps a private, feeder-scoped history: exact postcard
-events for 366 days and separate older all-time totals. Standard windows are
-accurate from setup forward. The first sync can import only what Bird Buddy
-still exposes, and `all-time` means since the integration began. Repeated polls
-are deduplicated, and a changed classification replaces the prior species while
-the postcard remains available.
+Bird Buddy removes a postcard from the new-postcard feed after it is confirmed.
+The controller therefore combines exact postcard history with confirmed
+metadata. Exact postcards are deduplicated and counted once per species.
+Confirmed records fill gaps in species presence and supply the newest capture
+time, but they do not increase an existing postcard count: one postcard can
+contain several media records, and treating each as a visit would inflate the
+result. Counts that rely only on confirmed history are conservative lower
+bounds.
+
+Manually added app sightings use Bird Buddy's account-level `CUSTOM_ID` origin.
+They are not tied to the selected feeder and may have been recorded somewhere
+else, so Inky excludes them by default. Include them only when that matches how
+you use the account:
+
+```toml
+[discovery]
+sources = ["birdbuddy"]
+birdbuddy_include_manual_sightings = true
+```
+
+The choice is reversible. Manual evidence remains in the private history so it
+does not need to be fetched again, but it stops affecting discovery as soon as
+the option is disabled. Livestream `WATCHING` records and postcard history from
+other feeders are always excluded.
+
+Exact postcard events remain in private history for 366 days, with older
+all-time totals retained separately. Confirmed history keeps the newest
+evidence per species and provenance. The first sync can import only metadata
+Bird Buddy still exposes. `all-time` combines exact history accumulated since
+the integration began with conservative presence evidence from the current
+confirmed collection; it is not a claim about Bird Buddy's total visit count.
+Repeated polls are idempotent, and changed classifications replace prior
+species while Bird Buddy still exposes the underlying record.
 
 ## How eBird enrichment works
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -116,8 +116,13 @@ Do not quote a value unless the quote characters are part of the secret.
 Bird Buddy is different: its email and password are used once and must not be
 kept in `config.toml` or `controller.env`. After obtaining Bird Buddy's
 permission, add `"birdbuddy"` to `discovery.sources`, import the configuration,
-and perform the one-time login. The `-e` options pass existing shell variables
-without putting their values in the command line:
+and perform the one-time login.
+
+Manually added app sightings are excluded by default because they are not tied
+to the selected feeder. Set `birdbuddy_include_manual_sightings = true` in
+`[discovery]` before importing the configuration when they should count for
+this installation. The `-e` options below pass existing shell variables without
+putting their values in the command line:
 
 ```bash
 read -r -p "Bird Buddy email: " INKY_BIRDBUDDY_EMAIL

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -49,6 +49,11 @@ sightings are separate. Set
 should influence this frame; disable it to exclude them again without deleting
 private history.
 
+The first successful sync after upgrading from pre-linkage Bird Buddy history
+removes cached postcard rows that lack media identifiers. This avoids keeping
+an unprovable preview classification; confirmed metadata still supplies
+conservative presence for records Bird Buddy continues to expose.
+
 Schedules are configured in `[schedule]`. Conservative starting values are:
 
 - controller HTTP service: always running;

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -40,6 +40,13 @@ if the session is revoked. Removing `birdbuddy` from `discovery.sources` is the
 non-destructive rollback; `birdbuddy logout --yes` additionally removes local
 authentication without deleting accumulated history.
 
+The selected feeder's confirmed metadata is always used as a safety net when a
+postcard leaves the new-postcard feed before a poll. Account-level manually
+added sightings are separate. Set
+`discovery.birdbuddy_include_manual_sightings = true` only when those sightings
+should influence this frame; disable it to exclude them again without deleting
+private history.
+
 Schedules are configured in `[schedule]`. Conservative starting values are:
 
 - controller HTTP service: always running;

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -49,10 +49,12 @@ sightings are separate. Set
 should influence this frame; disable it to exclude them again without deleting
 private history.
 
-The first successful sync after upgrading from pre-linkage Bird Buddy history
-removes cached postcard rows that lack media identifiers. This avoids keeping
-an unprovable preview classification; confirmed metadata still supplies
-conservative presence for records Bird Buddy continues to expose.
+The first successful sync for the selected feeder after upgrading from
+pre-linkage Bird Buddy history removes its cached postcard rows that lack media
+identifiers. Inactive feeder histories remain untouched until that feeder is
+selected and synced. This avoids keeping an unprovable preview classification;
+confirmed metadata still supplies conservative presence for records Bird Buddy
+continues to expose.
 
 Schedules are configured in `[schedule]`. Conservative starting values are:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -41,8 +41,10 @@ non-destructive rollback; `birdbuddy logout --yes` additionally removes local
 authentication without deleting accumulated history.
 
 The selected feeder's confirmed metadata is always used as a safety net when a
-postcard leaves the new-postcard feed before a poll. Account-level manually
-added sightings are separate. Set
+postcard leaves the new-postcard feed before a poll. When all of a cached
+postcard's media identifiers are present in confirmed history, the confirmed
+species replace its preview classification. Account-level manually added
+sightings are separate. Set
 `discovery.birdbuddy_include_manual_sightings = true` only when those sightings
 should influence this frame; disable it to exclude them again without deleting
 private history.

--- a/src/inky_bird_frame/birdbuddy.py
+++ b/src/inky_bird_frame/birdbuddy.py
@@ -693,7 +693,12 @@ def _parse_postcard(
         if species_id is None or common_name is None or scientific_name is None:
             incomplete_recognized_sighting = True
             continue
-        species[species_id] = PostcardSpecies(species_id, common_name, scientific_name)
+        parsed_species = PostcardSpecies(species_id, common_name, scientific_name)
+        existing_species = species.get(species_id)
+        if existing_species is not None and existing_species != parsed_species:
+            incomplete_recognized_sighting = True
+            continue
+        species[species_id] = parsed_species
     if not species:
         return BirdBuddyPostcard(
             postcard_id,
@@ -749,6 +754,11 @@ def _fetch_postcard_variant(
             if postcard is None:
                 ignored += 1
             else:
+                existing = postcards.get(postcard.postcard_id)
+                if existing is not None and existing != postcard:
+                    raise DataSourceError(
+                        "Bird Buddy feed returned conflicting duplicate postcards"
+                    )
                 postcards[postcard.postcard_id] = postcard
                 if not postcard.complete or not postcard.species:
                     ignored += 1
@@ -775,7 +785,11 @@ def _merge_postcard_variants(
     if existing.observed_at != incoming.observed_at:
         raise DataSourceError("Bird Buddy returned inconsistent postcard timestamps")
     species = {item.species_id: item for item in existing.species}
-    species.update({item.species_id: item for item in incoming.species})
+    for item in incoming.species:
+        existing_species = species.get(item.species_id)
+        if existing_species is not None and existing_species != item:
+            raise DataSourceError("Bird Buddy returned conflicting species identities")
+        species[item.species_id] = item
     media_ids_match = existing.media_ids == incoming.media_ids
     postcards[incoming.postcard_id] = BirdBuddyPostcard(
         existing.postcard_id,
@@ -871,7 +885,13 @@ def _parse_confirmed_evidence(
         scientific_name = _nonempty_string(item.get("scientificName"))
         if species_id is None or common_name is None or scientific_name is None:
             raise DataSourceError("Bird Buddy confirmed history record was incomplete")
-        species[species_id] = PostcardSpecies(species_id, common_name, scientific_name)
+        parsed_species = PostcardSpecies(species_id, common_name, scientific_name)
+        existing_species = species.get(species_id)
+        if existing_species is not None and existing_species != parsed_species:
+            raise DataSourceError(
+                "Bird Buddy confirmed history returned conflicting species identities"
+            )
+        species[species_id] = parsed_species
     return _ConfirmedMediaRecord(
         media_id,
         media_type,
@@ -927,13 +947,12 @@ def _fetch_confirmed_history(
             accepted_records += 1
             if parsed.source == _CONFIRMED_MANUAL_SOURCE:
                 accepted_manual_records += 1
-            if parsed.source == _CONFIRMED_FEEDER_SOURCE:
-                existing_record = records_by_media.get(parsed.media_id)
-                if existing_record is not None and existing_record != parsed:
-                    raise DataSourceError(
-                        "Bird Buddy confirmed history returned conflicting media records"
-                    )
-                records_by_media[parsed.media_id] = parsed
+            existing_record = records_by_media.get(parsed.media_id)
+            if existing_record is not None and existing_record != parsed:
+                raise DataSourceError(
+                    "Bird Buddy confirmed history returned conflicting media records"
+                )
+            records_by_media[parsed.media_id] = parsed
             for species in parsed.species:
                 item = ConfirmedSpeciesEvidence(
                     species,
@@ -968,7 +987,11 @@ def _fetch_confirmed_history(
         accepted_records,
         accepted_manual_records,
         processed - accepted_records,
-        {media_id: record.species for media_id, record in records_by_media.items()},
+        {
+            media_id: record.species
+            for media_id, record in records_by_media.items()
+            if record.source == _CONFIRMED_FEEDER_SOURCE
+        },
     )
 
 
@@ -1459,7 +1482,17 @@ def _reconcile_archived_postcards(
         confirmed_by_id = {item.species_id: item for item in confirmed_species}
         old_ids = set(archived_postcard.species_ids)
         new_ids = set(confirmed_by_id)
-        if old_ids == new_ids:
+        identity_changed = False
+        for species_id in old_ids & new_ids:
+            archived = history.archived_species.get(species_id)
+            if archived is None:
+                raise DataSourceError("Invalid Bird Buddy archived correction history")
+            confirmed_identity = confirmed_by_id[species_id]
+            identity_changed = identity_changed or (
+                archived.common_name != confirmed_identity.common_name
+                or archived.scientific_name != confirmed_identity.scientific_name
+            )
+        if old_ids == new_ids and not identity_changed:
             continue
         history.archived_postcards[media_ids] = ArchivedPostcardLink(
             archived_postcard.observed_at,

--- a/src/inky_bird_frame/birdbuddy.py
+++ b/src/inky_bird_frame/birdbuddy.py
@@ -21,6 +21,10 @@ BIRDBUDDY_GRAPHQL_URL: Final = "https://graphql.app-api.prod.aws.mybirdbuddy.com
 BIRDBUDDY_PAGE_SIZE: Final = 50
 # A seven-day feed would need more than 700 visits per day to reach this guard.
 BIRDBUDDY_MAX_FEED_PAGES: Final = 100
+# Confirmed history is normally far smaller than this 5,000-record bound. The
+# cap prevents an undocumented pagination change from creating an unbounded
+# controller cycle while still failing visibly instead of truncating history.
+BIRDBUDDY_MAX_CONFIRMED_PAGES: Final = 100
 BIRDBUDDY_HISTORY_DAYS: Final = 366
 AUTH_SCHEMA_VERSION: Final = 1
 HISTORY_SCHEMA_VERSION: Final = 1
@@ -140,6 +144,34 @@ _FEED_SIGHTING_TYPES: Final = (
     "SightingRecognizedBirdUnlocked",
 )
 
+_CONFIRMED_HISTORY = """
+query InkyBirdBuddyConfirmedHistory($first: Int!, $after: String) {
+  me {
+    mediasOwned(first: $first, after: $after) {
+      edges {
+        node {
+          origin
+          feeder { id }
+          media { createdAt }
+          species {
+            __typename
+            ... on SpeciesBird { id name scientificName }
+          }
+        }
+      }
+      pageInfo { endCursor hasNextPage }
+    }
+  }
+}
+""".strip()
+
+_CONFIRMED_FEEDER_SOURCE: Final = "selected_feeder"
+_CONFIRMED_MANUAL_SOURCE: Final = "manual"
+_CONFIRMED_SOURCES: Final = {
+    _CONFIRMED_FEEDER_SOURCE,
+    _CONFIRMED_MANUAL_SOURCE,
+}
+
 
 @dataclass(frozen=True)
 class BirdBuddyFeeder:
@@ -171,6 +203,13 @@ class BirdBuddyPostcard:
 
 
 @dataclass(frozen=True)
+class ConfirmedSpeciesEvidence:
+    species: PostcardSpecies
+    observed_at: str
+    source: str
+
+
+@dataclass(frozen=True)
 class ArchivedSpecies:
     species_id: str
     common_name: str
@@ -186,6 +225,7 @@ class FeederHistory:
     last_successful_sync_at: str | None
     postcards: dict[str, BirdBuddyPostcard]
     archived_species: dict[str, ArchivedSpecies]
+    confirmed_species: dict[tuple[str, str], ConfirmedSpeciesEvidence]
 
 
 @dataclass(frozen=True)
@@ -199,6 +239,11 @@ class BirdBuddySyncStats:
     history_started_at: str
     earliest_initial_feed_at: str | None
     last_successful_sync_at: str
+    confirmed_pages: int = 0
+    confirmed_records_processed: int = 0
+    confirmed_records_accepted: int = 0
+    manual_records_accepted: int = 0
+    confirmed_records_ignored: int = 0
 
     def as_dict(self) -> dict[str, object]:
         return {
@@ -211,6 +256,11 @@ class BirdBuddySyncStats:
             "history_started_at": self.history_started_at,
             "earliest_initial_feed_at": self.earliest_initial_feed_at,
             "last_successful_sync_at": self.last_successful_sync_at,
+            "confirmed_pages": self.confirmed_pages,
+            "confirmed_records_processed": self.confirmed_records_processed,
+            "confirmed_records_accepted": self.confirmed_records_accepted,
+            "manual_records_accepted": self.manual_records_accepted,
+            "confirmed_records_ignored": self.confirmed_records_ignored,
         }
 
 
@@ -225,6 +275,16 @@ class _HistoryUpdate:
     history: FeederHistory
     duplicate_postcards: int
     reclassified_postcards: int
+
+
+@dataclass(frozen=True)
+class _ConfirmedHistoryFetch:
+    evidence: list[ConfirmedSpeciesEvidence]
+    pages: int
+    records_processed: int
+    records_accepted: int
+    manual_records_accepted: int
+    records_ignored: int
 
 
 def _auth_path(state_dir: Path) -> Path:
@@ -690,6 +750,122 @@ def _fetch_postcards(
     return complete_postcards, total_pages, processed, ignored
 
 
+def _parse_confirmed_evidence(
+    value: object,
+    selected_feeder_id: str,
+    *,
+    include_manual_sightings: bool,
+) -> tuple[ConfirmedSpeciesEvidence, ...]:
+    if not isinstance(value, dict):
+        return ()
+    origin = value.get("origin")
+    feeder_id = _feeder_id(value.get("feeder"))
+    if origin == "POSTCARD" and feeder_id == selected_feeder_id:
+        source = _CONFIRMED_FEEDER_SOURCE
+    elif origin == "CUSTOM_ID" and include_manual_sightings:
+        source = _CONFIRMED_MANUAL_SOURCE
+    else:
+        return ()
+    media = value.get("media")
+    created_at = media.get("createdAt") if isinstance(media, dict) else None
+    observed = parse_utc_timestamp(created_at)
+    species_values = value.get("species")
+    if observed is None or not isinstance(species_values, list):
+        return ()
+    observed_at = observed.astimezone(UTC).replace(microsecond=0).isoformat()
+    species: dict[str, PostcardSpecies] = {}
+    for item in species_values:
+        if not isinstance(item, dict) or item.get("__typename") != "SpeciesBird":
+            continue
+        species_id = _nonempty_string(item.get("id"))
+        common_name = _nonempty_string(item.get("name"))
+        scientific_name = _nonempty_string(item.get("scientificName"))
+        if species_id is None or common_name is None or scientific_name is None:
+            continue
+        species[species_id] = PostcardSpecies(species_id, common_name, scientific_name)
+    return tuple(
+        ConfirmedSpeciesEvidence(item, observed_at, source)
+        for item in sorted(species.values(), key=lambda candidate: candidate.species_id)
+    )
+
+
+def _fetch_confirmed_history(
+    access_token: str,
+    feeder_id: str,
+    *,
+    include_manual_sightings: bool,
+) -> _ConfirmedHistoryFetch:
+    evidence: dict[tuple[str, str], ConfirmedSpeciesEvidence] = {}
+    after: str | None = None
+    seen_cursors: set[str] = set()
+    pages = 0
+    processed = 0
+    accepted_records = 0
+    accepted_manual_records = 0
+    while True:
+        if pages >= BIRDBUDDY_MAX_CONFIRMED_PAGES:
+            raise DataSourceError("Bird Buddy confirmed history exceeded the safe pagination limit")
+        variables: dict[str, object] = {"first": BIRDBUDDY_PAGE_SIZE}
+        if after is not None:
+            variables["after"] = after
+        data = _graphql_request(
+            _CONFIRMED_HISTORY,
+            variables,
+            "confirmed history query",
+            access_token=access_token,
+        )
+        me = data.get("me")
+        connection = me.get("mediasOwned") if isinstance(me, dict) else None
+        edges = connection.get("edges") if isinstance(connection, dict) else None
+        page_info = connection.get("pageInfo") if isinstance(connection, dict) else None
+        if not isinstance(edges, list) or not isinstance(page_info, dict):
+            raise DataSourceError("Bird Buddy confirmed history response was incomplete")
+        pages += 1
+        for edge in edges:
+            processed += 1
+            node = edge.get("node") if isinstance(edge, dict) else None
+            parsed = _parse_confirmed_evidence(
+                node,
+                feeder_id,
+                include_manual_sightings=include_manual_sightings,
+            )
+            if not parsed:
+                continue
+            accepted_records += 1
+            if any(item.source == _CONFIRMED_MANUAL_SOURCE for item in parsed):
+                accepted_manual_records += 1
+            for item in parsed:
+                key = (item.source, item.species.species_id)
+                existing = evidence.get(key)
+                if (
+                    existing is None
+                    or _newest_timestamp(existing.observed_at, item.observed_at) == item.observed_at
+                ):
+                    evidence[key] = item
+        has_next = page_info.get("hasNextPage")
+        if has_next is False:
+            break
+        if has_next is not True:
+            raise DataSourceError(
+                "Bird Buddy confirmed history response had invalid pagination state"
+            )
+        cursor = _nonempty_string(page_info.get("endCursor"))
+        if cursor is None or cursor in seen_cursors:
+            raise DataSourceError(
+                "Bird Buddy confirmed history returned a repeated pagination cursor"
+            )
+        seen_cursors.add(cursor)
+        after = cursor
+    return _ConfirmedHistoryFetch(
+        list(evidence.values()),
+        pages,
+        processed,
+        accepted_records,
+        accepted_manual_records,
+        processed - accepted_records,
+    )
+
+
 def _parse_postcard_state(value: object) -> BirdBuddyPostcard:
     if not isinstance(value, dict):
         raise DataSourceError("Invalid Bird Buddy detection history")
@@ -736,6 +912,30 @@ def _parse_archived_species(value: object, species_id: str) -> ArchivedSpecies:
     return ArchivedSpecies(species_id, common_name, scientific_name, count, latest)
 
 
+def _parse_confirmed_species(value: object) -> ConfirmedSpeciesEvidence:
+    if not isinstance(value, dict):
+        raise DataSourceError("Invalid Bird Buddy detection history")
+    species_id = _nonempty_string(value.get("id"))
+    common_name = _nonempty_string(value.get("common_name"))
+    scientific_name = _nonempty_string(value.get("scientific_name"))
+    observed_at = _nonempty_string(value.get("observed_at"))
+    source = _nonempty_string(value.get("source"))
+    if (
+        species_id is None
+        or common_name is None
+        or scientific_name is None
+        or observed_at is None
+        or parse_utc_timestamp(observed_at) is None
+        or source not in _CONFIRMED_SOURCES
+    ):
+        raise DataSourceError("Invalid Bird Buddy detection history")
+    return ConfirmedSpeciesEvidence(
+        PostcardSpecies(species_id, common_name, scientific_name),
+        observed_at,
+        source,
+    )
+
+
 def _parse_feeder_history(value: object) -> FeederHistory:
     if not isinstance(value, dict):
         raise DataSourceError("Invalid Bird Buddy detection history")
@@ -744,6 +944,7 @@ def _parse_feeder_history(value: object) -> FeederHistory:
     last_sync = value.get("last_successful_sync_at")
     postcard_values = value.get("postcards")
     archived_values = value.get("archived_species")
+    confirmed_values = value.get("confirmed_species", [])
     if (
         history_started_at is None
         or parse_utc_timestamp(history_started_at) is None
@@ -751,6 +952,7 @@ def _parse_feeder_history(value: object) -> FeederHistory:
         or (last_sync is not None and parse_utc_timestamp(last_sync) is None)
         or not isinstance(postcard_values, list)
         or not isinstance(archived_values, dict)
+        or not isinstance(confirmed_values, list)
     ):
         raise DataSourceError("Invalid Bird Buddy detection history")
     postcards = {
@@ -765,12 +967,17 @@ def _parse_feeder_history(value: object) -> FeederHistory:
     }
     if len(archived) != len(archived_values):
         raise DataSourceError("Invalid Bird Buddy detection history")
+    confirmed_items = [_parse_confirmed_species(item) for item in confirmed_values]
+    confirmed = {(item.source, item.species.species_id): item for item in confirmed_items}
+    if len(confirmed) != len(confirmed_items):
+        raise DataSourceError("Invalid Bird Buddy detection history")
     return FeederHistory(
         history_started_at,
         earliest if isinstance(earliest, str) else None,
         last_sync if isinstance(last_sync, str) else None,
         postcards,
         archived,
+        confirmed,
     )
 
 
@@ -835,6 +1042,16 @@ def _history_payload(histories: dict[str, FeederHistory]) -> dict[str, object]:
                     }
                     for species_id, species in sorted(history.archived_species.items())
                 },
+                "confirmed_species": [
+                    {
+                        "id": item.species.species_id,
+                        "common_name": item.species.common_name,
+                        "scientific_name": item.species.scientific_name,
+                        "observed_at": item.observed_at,
+                        "source": item.source,
+                    }
+                    for _, item in sorted(history.confirmed_species.items())
+                ],
             }
             for feeder_id, history in sorted(histories.items())
         },
@@ -880,18 +1097,20 @@ def _aggregate_species(
     window: ObservationWindow,
     now: datetime,
     limit: int,
+    *,
+    include_manual_sightings: bool,
 ) -> list[BirdBuddySpecies]:
     counts: dict[str, int] = {}
     identities: dict[str, PostcardSpecies] = {}
     latest: dict[str, str] = {}
     cutoff = _window_cutoff(window, now)
     if cutoff is None:
-        for item in history.archived_species.values():
-            counts[item.species_id] = item.detection_count
-            identities[item.species_id] = PostcardSpecies(
-                item.species_id, item.common_name, item.scientific_name
+        for archived in history.archived_species.values():
+            counts[archived.species_id] = archived.detection_count
+            identities[archived.species_id] = PostcardSpecies(
+                archived.species_id, archived.common_name, archived.scientific_name
             )
-            latest[item.species_id] = item.latest_detection_at
+            latest[archived.species_id] = archived.latest_detection_at
     for postcard in history.postcards.values():
         observed = parse_utc_timestamp(postcard.observed_at)
         if observed is None:
@@ -907,6 +1126,27 @@ def _aggregate_species(
                 if current_latest is None
                 else _newest_timestamp(current_latest, postcard.observed_at)
             )
+    for evidence in history.confirmed_species.values():
+        if evidence.source == _CONFIRMED_MANUAL_SOURCE and not include_manual_sightings:
+            continue
+        observed = parse_utc_timestamp(evidence.observed_at)
+        if observed is None:
+            raise DataSourceError("Invalid Bird Buddy confirmed-history timestamp")
+        if cutoff is not None and observed < cutoff:
+            continue
+        species_id = evidence.species.species_id
+        # Confirmed media closes the transient-feed gap, but one postcard can
+        # contain several media records. It therefore supplies conservative
+        # presence evidence and a newest timestamp, never a fabricated visit
+        # count. Exact postcard history remains authoritative when available.
+        counts.setdefault(species_id, 1)
+        identities[species_id] = evidence.species
+        current_latest = latest.get(species_id)
+        latest[species_id] = (
+            evidence.observed_at
+            if current_latest is None
+            else _newest_timestamp(current_latest, evidence.observed_at)
+        )
     result = [
         BirdBuddySpecies(
             species_id,
@@ -923,10 +1163,17 @@ def _aggregate_species(
     return result[:limit]
 
 
-def _latest_history_detection(history: FeederHistory) -> str | None:
+def _latest_history_detection(
+    history: FeederHistory, *, include_manual_sightings: bool
+) -> str | None:
     latest: str | None = None
     timestamps = [postcard.observed_at for postcard in history.postcards.values()]
     timestamps.extend(species.latest_detection_at for species in history.archived_species.values())
+    timestamps.extend(
+        item.observed_at
+        for item in history.confirmed_species.values()
+        if item.source != _CONFIRMED_MANUAL_SOURCE or include_manual_sightings
+    )
     for timestamp in timestamps:
         latest = timestamp if latest is None else _newest_timestamp(latest, timestamp)
     return latest
@@ -936,9 +1183,11 @@ def _update_history(
     state_dir: Path,
     feeder_id: str,
     incoming: list[BirdBuddyPostcard],
+    confirmed: list[ConfirmedSpeciesEvidence],
     current: datetime,
     *,
     persist: bool,
+    replace_manual_evidence: bool,
 ) -> _HistoryUpdate:
     current_iso = current.isoformat()
     lock = _history_lock(state_dir) if persist else nullcontext()
@@ -946,7 +1195,7 @@ def _update_history(
         histories = _read_history(state_dir)
         history = histories.get(
             feeder_id,
-            FeederHistory(current_iso, None, None, {}, {}),
+            FeederHistory(current_iso, None, None, {}, {}, {}),
         )
         duplicates = 0
         reclassified = 0
@@ -962,6 +1211,21 @@ def _update_history(
             elif existing is not None:
                 reclassified += 1
             history.postcards[postcard.postcard_id] = postcard
+        replaced_sources = {_CONFIRMED_FEEDER_SOURCE}
+        if replace_manual_evidence:
+            replaced_sources.add(_CONFIRMED_MANUAL_SOURCE)
+        for key in list(history.confirmed_species):
+            if key[0] in replaced_sources:
+                del history.confirmed_species[key]
+        for evidence in confirmed:
+            key = (evidence.source, evidence.species.species_id)
+            existing_evidence = history.confirmed_species.get(key)
+            if (
+                existing_evidence is None
+                or _newest_timestamp(existing_evidence.observed_at, evidence.observed_at)
+                == evidence.observed_at
+            ):
+                history.confirmed_species[key] = evidence
         if history.earliest_initial_feed_at is None and incoming:
             history.earliest_initial_feed_at = min(item.observed_at for item in incoming)
         prune_before = current - timedelta(days=BIRDBUDDY_HISTORY_DAYS)
@@ -986,21 +1250,35 @@ def sync_birdbuddy_detections(
     limit: int,
     now: datetime | None = None,
     persist_history: bool = True,
+    include_manual_sightings: bool = False,
 ) -> BirdBuddySyncResult:
     if limit <= 0:
         raise ValueError("Bird Buddy species limit must be greater than zero")
     current = (now or datetime.now(UTC)).astimezone(UTC).replace(microsecond=0)
     access_token, feeder = _refreshed_access_token(state_dir)
     incoming, pages, processed, ignored = _fetch_postcards(access_token, feeder.feeder_id)
+    confirmed = _fetch_confirmed_history(
+        access_token,
+        feeder.feeder_id,
+        include_manual_sightings=include_manual_sightings,
+    )
     current_iso = current.isoformat()
     update = _update_history(
         state_dir,
         feeder.feeder_id,
         incoming,
+        confirmed.evidence,
         current,
         persist=persist_history,
+        replace_manual_evidence=include_manual_sightings,
     )
-    species = _aggregate_species(update.history, window, current, limit)
+    species = _aggregate_species(
+        update.history,
+        window,
+        current,
+        limit,
+        include_manual_sightings=include_manual_sightings,
+    )
     stats = BirdBuddySyncStats(
         pages=pages,
         postcards_processed=processed,
@@ -1011,11 +1289,18 @@ def sync_birdbuddy_detections(
         history_started_at=update.history.history_started_at,
         earliest_initial_feed_at=update.history.earliest_initial_feed_at,
         last_successful_sync_at=current_iso,
+        confirmed_pages=confirmed.pages,
+        confirmed_records_processed=confirmed.records_processed,
+        confirmed_records_accepted=confirmed.records_accepted,
+        manual_records_accepted=confirmed.manual_records_accepted,
+        confirmed_records_ignored=confirmed.records_ignored,
     )
     return BirdBuddySyncResult(species, stats)
 
 
-def birdbuddy_status(state_dir: Path) -> dict[str, object]:
+def birdbuddy_status(
+    state_dir: Path, *, include_manual_sightings: bool = False
+) -> dict[str, object]:
     path = _auth_path(state_dir)
     if path.is_symlink():
         raise DataSourceError(f"Refusing symlinked Bird Buddy authentication state: {path}")
@@ -1046,9 +1331,21 @@ def birdbuddy_status(state_dir: Path) -> dict[str, object]:
                 "history_started_at": history.history_started_at,
                 "earliest_initial_feed_at": history.earliest_initial_feed_at,
                 "last_successful_sync_at": history.last_successful_sync_at,
-                "latest_detection_at": _latest_history_detection(history),
+                "latest_detection_at": _latest_history_detection(
+                    history,
+                    include_manual_sightings=include_manual_sightings,
+                ),
                 "retained_postcards": len(history.postcards),
                 "archived_species": len(history.archived_species),
+                "confirmed_feeder_species": sum(
+                    item.source == _CONFIRMED_FEEDER_SOURCE
+                    for item in history.confirmed_species.values()
+                ),
+                "confirmed_manual_species": sum(
+                    item.source == _CONFIRMED_MANUAL_SOURCE
+                    for item in history.confirmed_species.values()
+                ),
+                "manual_sightings_included": include_manual_sightings,
             }
             if history is not None
             else None

--- a/src/inky_bird_frame/birdbuddy.py
+++ b/src/inky_bird_frame/birdbuddy.py
@@ -251,6 +251,7 @@ class FeederHistory:
     archived_species: dict[str, ArchivedSpecies]
     confirmed_species: dict[tuple[str, str], ConfirmedSpeciesEvidence]
     archived_postcards: dict[tuple[str, ...], ArchivedPostcardLink] = field(default_factory=dict)
+    archived_unlinked_latest: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -812,34 +813,40 @@ def _parse_confirmed_evidence(
     include_manual_sightings: bool,
 ) -> _ConfirmedMediaRecord | None:
     if not isinstance(value, dict):
-        return None
-    origin = value.get("origin")
+        raise DataSourceError("Bird Buddy confirmed history record was incomplete")
+    origin = _nonempty_string(value.get("origin"))
     feeder_id = _feeder_id(value.get("feeder"))
-    if origin == "POSTCARD" and feeder_id == selected_feeder_id:
+    if origin == "POSTCARD":
+        if feeder_id is None:
+            raise DataSourceError("Bird Buddy confirmed history record was incomplete")
+        if feeder_id != selected_feeder_id:
+            return None
         source = _CONFIRMED_FEEDER_SOURCE
     elif origin == "CUSTOM_ID" and include_manual_sightings:
         source = _CONFIRMED_MANUAL_SOURCE
-    else:
+    elif origin in {"CUSTOM_ID", "WATCHING"}:
         return None
+    else:
+        raise DataSourceError("Bird Buddy confirmed history record had an unsupported origin")
     media = value.get("media")
     created_at = media.get("createdAt") if isinstance(media, dict) else None
     media_id = _nonempty_string(media.get("id")) if isinstance(media, dict) else None
     observed = parse_utc_timestamp(created_at)
     species_values = value.get("species")
     if media_id is None or observed is None or not isinstance(species_values, list):
-        return None
+        raise DataSourceError("Bird Buddy confirmed history record was incomplete")
     observed_at = observed.astimezone(UTC).replace(microsecond=0).isoformat()
     species: dict[str, PostcardSpecies] = {}
     for item in species_values:
         if not isinstance(item, dict):
-            return None
+            raise DataSourceError("Bird Buddy confirmed history record was incomplete")
         if item.get("__typename") != "SpeciesBird":
             continue
         species_id = _nonempty_string(item.get("id"))
         common_name = _nonempty_string(item.get("name"))
         scientific_name = _nonempty_string(item.get("scientificName"))
         if species_id is None or common_name is None or scientific_name is None:
-            return None
+            raise DataSourceError("Bird Buddy confirmed history record was incomplete")
         species[species_id] = PostcardSpecies(species_id, common_name, scientific_name)
     return _ConfirmedMediaRecord(
         media_id,
@@ -1078,6 +1085,7 @@ def _parse_feeder_history(value: object) -> FeederHistory:
     postcard_values = value.get("postcards")
     archived_values = value.get("archived_species")
     archived_postcard_values = value.get("archived_postcards", [])
+    archived_unlinked_values = value.get("archived_unlinked_latest")
     confirmed_values = value.get("confirmed_species", [])
     if (
         history_started_at is None
@@ -1087,17 +1095,12 @@ def _parse_feeder_history(value: object) -> FeederHistory:
         or not isinstance(postcard_values, list)
         or not isinstance(archived_values, dict)
         or not isinstance(archived_postcard_values, list)
+        or (archived_unlinked_values is not None and not isinstance(archived_unlinked_values, dict))
         or not isinstance(confirmed_values, list)
     ):
         raise DataSourceError("Invalid Bird Buddy detection history")
     parsed_postcards = [_parse_postcard_state(item) for item in postcard_values]
-    # Version-one history written before media linkage cannot safely reconcile
-    # a later confirmation. Drop those short-lived rows instead of retaining a
-    # stale preview classification; confirmed history can still restore
-    # conservative species presence on this successful sync.
-    postcards = {
-        postcard.postcard_id: postcard for postcard in parsed_postcards if postcard.media_ids
-    }
+    postcards = {postcard.postcard_id: postcard for postcard in parsed_postcards}
     archived = {
         species_id: _parse_archived_species(item, species_id)
         for species_id, item in archived_values.items()
@@ -1109,6 +1112,39 @@ def _parse_feeder_history(value: object) -> FeederHistory:
     archived_postcards = {item.media_ids: item for item in archived_postcard_items}
     if len(archived_postcards) != len(archived_postcard_items):
         raise DataSourceError("Invalid Bird Buddy detection history")
+    linked_counts: dict[str, int] = {}
+    for item in archived_postcards.values():
+        for species_id in item.species_ids:
+            linked_counts[species_id] = linked_counts.get(species_id, 0) + 1
+    if any(
+        species_id not in archived or count > archived[species_id].detection_count
+        for species_id, count in linked_counts.items()
+    ):
+        raise DataSourceError("Invalid Bird Buddy detection history")
+    if archived_unlinked_values is None:
+        archived_unlinked_latest = {
+            species_id: item.latest_detection_at
+            for species_id, item in archived.items()
+            if linked_counts.get(species_id, 0) < item.detection_count
+        }
+    else:
+        archived_unlinked_latest = {
+            species_id: timestamp
+            for species_id, value in archived_unlinked_values.items()
+            if isinstance(species_id, str)
+            for timestamp in [_nonempty_string(value)]
+            if timestamp is not None and parse_utc_timestamp(timestamp) is not None
+        }
+        expected_unlinked = {
+            species_id
+            for species_id, item in archived.items()
+            if linked_counts.get(species_id, 0) < item.detection_count
+        }
+        if (
+            len(archived_unlinked_latest) != len(archived_unlinked_values)
+            or set(archived_unlinked_latest) != expected_unlinked
+        ):
+            raise DataSourceError("Invalid Bird Buddy detection history")
     confirmed_items = [_parse_confirmed_species(item) for item in confirmed_values]
     confirmed = {(item.source, item.species.species_id): item for item in confirmed_items}
     if len(confirmed) != len(confirmed_items):
@@ -1121,6 +1157,7 @@ def _parse_feeder_history(value: object) -> FeederHistory:
         archived,
         confirmed,
         archived_postcards,
+        archived_unlinked_latest,
     )
 
 
@@ -1200,6 +1237,7 @@ def _history_payload(histories: dict[str, FeederHistory]) -> dict[str, object]:
                         ),
                     )
                 ],
+                "archived_unlinked_latest": dict(sorted(history.archived_unlinked_latest.items())),
                 "confirmed_species": [
                     {
                         "id": item.species.species_id,
@@ -1224,7 +1262,12 @@ def _newest_timestamp(first: str, second: str) -> str:
     return first if first_at >= second_at else second
 
 
-def _archive_postcard(history: FeederHistory, postcard: BirdBuddyPostcard) -> None:
+def _archive_postcard(
+    history: FeederHistory,
+    postcard: BirdBuddyPostcard,
+    *,
+    linked: bool,
+) -> None:
     for species in postcard.species:
         existing = history.archived_species.get(species.species_id)
         history.archived_species[species.species_id] = ArchivedSpecies(
@@ -1238,6 +1281,13 @@ def _archive_postcard(history: FeederHistory, postcard: BirdBuddyPostcard) -> No
                 else postcard.observed_at
             ),
         )
+        if not linked:
+            unlinked_latest = history.archived_unlinked_latest.get(species.species_id)
+            history.archived_unlinked_latest[species.species_id] = (
+                postcard.observed_at
+                if unlinked_latest is None
+                else _newest_timestamp(unlinked_latest, postcard.observed_at)
+            )
 
 
 def _window_cutoff(window: ObservationWindow, now: datetime) -> datetime | None:
@@ -1349,6 +1399,23 @@ def _confirmed_species_for_media(
     return tuple(sorted(species.values(), key=lambda item: item.species_id))
 
 
+def _archived_latest_timestamp(history: FeederHistory, species_id: str) -> str:
+    candidates = [
+        item.observed_at
+        for item in history.archived_postcards.values()
+        if species_id in item.species_ids
+    ]
+    unlinked_latest = history.archived_unlinked_latest.get(species_id)
+    if unlinked_latest is not None:
+        candidates.append(unlinked_latest)
+    if not candidates:
+        raise DataSourceError("Invalid Bird Buddy archived correction history")
+    latest = candidates[0]
+    for candidate in candidates[1:]:
+        latest = _newest_timestamp(latest, candidate)
+    return latest
+
+
 def _reconcile_archived_postcards(
     history: FeederHistory,
     species_by_media: dict[str, tuple[PostcardSpecies, ...]],
@@ -1357,6 +1424,13 @@ def _reconcile_archived_postcards(
     for media_ids, archived_postcard in list(history.archived_postcards.items()):
         confirmed_species = _confirmed_species_for_media(media_ids, species_by_media)
         if confirmed_species is None:
+            for species_id in archived_postcard.species_ids:
+                current = history.archived_unlinked_latest.get(species_id)
+                history.archived_unlinked_latest[species_id] = (
+                    archived_postcard.observed_at
+                    if current is None
+                    else _newest_timestamp(current, archived_postcard.observed_at)
+                )
             del history.archived_postcards[media_ids]
             continue
         confirmed_by_id = {item.species_id: item for item in confirmed_species}
@@ -1364,19 +1438,25 @@ def _reconcile_archived_postcards(
         new_ids = set(confirmed_by_id)
         if old_ids == new_ids:
             continue
+        history.archived_postcards[media_ids] = ArchivedPostcardLink(
+            archived_postcard.observed_at,
+            media_ids,
+            tuple(sorted(new_ids)),
+        )
         for species_id in old_ids - new_ids:
             archived = history.archived_species.get(species_id)
             if archived is None:
                 raise DataSourceError("Invalid Bird Buddy archived correction history")
             if archived.detection_count == 1:
                 del history.archived_species[species_id]
+                history.archived_unlinked_latest.pop(species_id, None)
             else:
                 history.archived_species[species_id] = ArchivedSpecies(
                     archived.species_id,
                     archived.common_name,
                     archived.scientific_name,
                     archived.detection_count - 1,
-                    archived.latest_detection_at,
+                    _archived_latest_timestamp(history, species_id),
                 )
         for species_id in new_ids:
             species = confirmed_by_id[species_id]
@@ -1398,11 +1478,6 @@ def _reconcile_archived_postcards(
                     else archived_postcard.observed_at
                 ),
             )
-        history.archived_postcards[media_ids] = ArchivedPostcardLink(
-            archived_postcard.observed_at,
-            media_ids,
-            tuple(sorted(new_ids)),
-        )
         reclassified += 1
     return reclassified
 
@@ -1426,6 +1501,12 @@ def _update_history(
             feeder_id,
             FeederHistory(current_iso, None, None, {}, {}, {}),
         )
+        # History written before media linkage cannot safely reconcile a later
+        # confirmation. Migrate only the selected feeder after both remote
+        # snapshots succeeded; inactive feeder history must remain untouched.
+        for postcard_id, postcard in list(history.postcards.items()):
+            if not postcard.media_ids:
+                del history.postcards[postcard_id]
         duplicates = 0
         reclassified_postcard_ids: set[str] = set()
         for postcard in incoming:
@@ -1485,15 +1566,13 @@ def _update_history(
             if observed is None:
                 raise DataSourceError("Invalid Bird Buddy detection timestamp")
             if observed < prune_before:
-                _archive_postcard(history, postcard)
-                if (
-                    postcard.media_ids
-                    and _confirmed_species_for_media(
-                        postcard.media_ids,
-                        confirmed_species_by_media,
-                    )
-                    is not None
-                ):
+                confirmed_species = _confirmed_species_for_media(
+                    postcard.media_ids,
+                    confirmed_species_by_media,
+                )
+                linked = bool(postcard.media_ids) and confirmed_species is not None
+                _archive_postcard(history, postcard, linked=linked)
+                if linked:
                     history.archived_postcards[postcard.media_ids] = ArchivedPostcardLink(
                         postcard.observed_at,
                         postcard.media_ids,

--- a/src/inky_bird_frame/birdbuddy.py
+++ b/src/inky_bird_frame/birdbuddy.py
@@ -840,7 +840,10 @@ def _parse_confirmed_evidence(
     for item in species_values:
         if not isinstance(item, dict):
             raise DataSourceError("Bird Buddy confirmed history record was incomplete")
-        if item.get("__typename") != "SpeciesBird":
+        species_type = _nonempty_string(item.get("__typename"))
+        if species_type is None:
+            raise DataSourceError("Bird Buddy confirmed history record was incomplete")
+        if species_type != "SpeciesBird":
             continue
         species_id = _nonempty_string(item.get("id"))
         common_name = _nonempty_string(item.get("name"))
@@ -1375,7 +1378,9 @@ def _latest_history_detection(
     history: FeederHistory, *, include_manual_sightings: bool
 ) -> str | None:
     latest: str | None = None
-    timestamps = [postcard.observed_at for postcard in history.postcards.values()]
+    timestamps = [
+        postcard.observed_at for postcard in history.postcards.values() if postcard.species
+    ]
     timestamps.extend(species.latest_detection_at for species in history.archived_species.values())
     timestamps.extend(
         item.observed_at

--- a/src/inky_bird_frame/birdbuddy.py
+++ b/src/inky_bird_frame/birdbuddy.py
@@ -351,6 +351,20 @@ def _history_lock(state_dir: Path) -> Iterator[None]:
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
+@contextmanager
+def _sync_lock(state_dir: Path) -> Iterator[None]:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    with (state_dir / "birdbuddy-sync.lock").open("a+") as handle:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise DataSourceError("Another Bird Buddy detection sync is already running") from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
 def _require_private_file(path: Path, label: str) -> None:
     if path.is_symlink():
         raise DataSourceError(f"Refusing symlinked {label} state: {path}")
@@ -652,10 +666,19 @@ def _parse_postcard(
             media_ids=sorted_media_ids,
             complete=False,
         )
+    confidence_level = _nonempty_string(value.get("inferenceConfidenceLevel"))
+    if confidence_level is None:
+        return BirdBuddyPostcard(
+            postcard_id,
+            observed_at,
+            (),
+            media_ids=sorted_media_ids,
+            complete=False,
+        )
     # An empty species tuple is a reconciliation tombstone. It lets a complete
     # feed refresh remove a previously accepted classification without storing
     # low-confidence or non-bird results in detection history.
-    if value.get("inferenceConfidenceLevel") != "HIGH_CONFIDENCE":
+    if confidence_level != "HIGH_CONFIDENCE":
         return BirdBuddyPostcard(
             postcard_id,
             observed_at,
@@ -721,8 +744,11 @@ def _fetch_postcard_variant(
     feeder_id: str,
     query: str,
     sighting_type: str | None = None,
+    *,
+    raw_postcards: dict[str, tuple[str | None, BirdBuddyPostcard | None, str | None]] | None = None,
 ) -> tuple[list[BirdBuddyPostcard], int, int, int]:
     postcards: dict[str, BirdBuddyPostcard] = {}
+    raw_records = raw_postcards if raw_postcards is not None else {}
     after: str | None = None
     seen_cursors: set[str] = set()
     pages = 0
@@ -751,6 +777,28 @@ def _fetch_postcard_variant(
             processed += 1
             node = edge.get("node") if isinstance(edge, dict) else None
             postcard = _parse_postcard(node, feeder_id, sighting_type)
+            raw_id = _nonempty_string(node.get("id")) if isinstance(node, dict) else None
+            confidence = (
+                _nonempty_string(node.get("inferenceConfidenceLevel"))
+                if isinstance(node, dict)
+                else None
+            )
+            if raw_id is not None:
+                if raw_id in raw_records:
+                    previous_variant, previous_postcard, previous_confidence = raw_records[raw_id]
+                    if postcard is None or previous_postcard is None:
+                        raise DataSourceError(
+                            "Bird Buddy feed returned an invalid duplicate postcard"
+                        )
+                    if previous_confidence != confidence:
+                        raise DataSourceError(
+                            "Bird Buddy returned inconsistent postcard confidence levels"
+                        )
+                    if previous_variant == sighting_type and previous_postcard != postcard:
+                        raise DataSourceError(
+                            "Bird Buddy feed returned conflicting duplicate postcards"
+                        )
+                raw_records[raw_id] = (sighting_type, postcard, confidence)
             if postcard is None:
                 ignored += 1
             else:
@@ -805,6 +853,7 @@ def _fetch_postcards(
     feeder_id: str,
 ) -> tuple[list[BirdBuddyPostcard], int, int, int]:
     postcards: dict[str, BirdBuddyPostcard] = {}
+    raw_postcards: dict[str, tuple[str | None, BirdBuddyPostcard | None, str | None]] = {}
     variant_counts: dict[str, int] = {}
     total_pages = 0
     processed_per_variant: list[int] = []
@@ -818,6 +867,7 @@ def _fetch_postcards(
             feeder_id,
             query,
             sighting_type,
+            raw_postcards=raw_postcards,
         )
         total_pages += pages
         processed_per_variant.append(processed)
@@ -909,6 +959,7 @@ def _fetch_confirmed_history(
 ) -> _ConfirmedHistoryFetch:
     evidence: dict[tuple[str, str], ConfirmedSpeciesEvidence] = {}
     records_by_media: dict[str, _ConfirmedMediaRecord] = {}
+    species_identities: dict[str, PostcardSpecies] = {}
     after: str | None = None
     seen_cursors: set[str] = set()
     pages = 0
@@ -954,6 +1005,12 @@ def _fetch_confirmed_history(
                 )
             records_by_media[parsed.media_id] = parsed
             for species in parsed.species:
+                existing_identity = species_identities.get(species.species_id)
+                if existing_identity is not None and existing_identity != species:
+                    raise DataSourceError(
+                        "Bird Buddy confirmed history returned conflicting species identities"
+                    )
+                species_identities[species.species_id] = species
                 item = ConfirmedSpeciesEvidence(
                     species,
                     parsed.observed_at,
@@ -1658,24 +1715,26 @@ def sync_birdbuddy_detections(
     if limit <= 0:
         raise ValueError("Bird Buddy species limit must be greater than zero")
     current = (now or datetime.now(UTC)).astimezone(UTC).replace(microsecond=0)
-    access_token, feeder = _refreshed_access_token(state_dir)
-    incoming, pages, processed, ignored = _fetch_postcards(access_token, feeder.feeder_id)
-    confirmed = _fetch_confirmed_history(
-        access_token,
-        feeder.feeder_id,
-        include_manual_sightings=include_manual_sightings,
-    )
-    current_iso = current.isoformat()
-    update = _update_history(
-        state_dir,
-        feeder.feeder_id,
-        incoming,
-        confirmed.evidence,
-        current,
-        persist=persist_history,
-        replace_manual_evidence=include_manual_sightings,
-        confirmed_species_by_media=confirmed.species_by_media,
-    )
+    sync_lock = _sync_lock(state_dir) if persist_history else nullcontext()
+    with sync_lock:
+        access_token, feeder = _refreshed_access_token(state_dir)
+        incoming, pages, processed, ignored = _fetch_postcards(access_token, feeder.feeder_id)
+        confirmed = _fetch_confirmed_history(
+            access_token,
+            feeder.feeder_id,
+            include_manual_sightings=include_manual_sightings,
+        )
+        current_iso = current.isoformat()
+        update = _update_history(
+            state_dir,
+            feeder.feeder_id,
+            incoming,
+            confirmed.evidence,
+            current,
+            persist=persist_history,
+            replace_manual_evidence=include_manual_sightings,
+            confirmed_species_by_media=confirmed.species_by_media,
+        )
     species = _aggregate_species(
         update.history,
         window,

--- a/src/inky_bird_frame/birdbuddy.py
+++ b/src/inky_bird_frame/birdbuddy.py
@@ -829,11 +829,17 @@ def _parse_confirmed_evidence(
     else:
         raise DataSourceError("Bird Buddy confirmed history record had an unsupported origin")
     media = value.get("media")
+    media_type = _nonempty_string(media.get("__typename")) if isinstance(media, dict) else None
     created_at = media.get("createdAt") if isinstance(media, dict) else None
     media_id = _nonempty_string(media.get("id")) if isinstance(media, dict) else None
     observed = parse_utc_timestamp(created_at)
     species_values = value.get("species")
-    if media_id is None or observed is None or not isinstance(species_values, list):
+    if (
+        media_type is None
+        or media_id is None
+        or observed is None
+        or not isinstance(species_values, list)
+    ):
         raise DataSourceError("Bird Buddy confirmed history record was incomplete")
     observed_at = observed.astimezone(UTC).replace(microsecond=0).isoformat()
     species: dict[str, PostcardSpecies] = {}

--- a/src/inky_bird_frame/birdbuddy.py
+++ b/src/inky_bird_frame/birdbuddy.py
@@ -216,7 +216,14 @@ class ConfirmedSpeciesEvidence:
     species: PostcardSpecies
     observed_at: str
     source: str
-    media_id: str | None = None
+
+
+@dataclass(frozen=True)
+class _ConfirmedMediaRecord:
+    media_id: str
+    observed_at: str
+    source: str
+    species: tuple[PostcardSpecies, ...]
 
 
 @dataclass(frozen=True)
@@ -228,6 +235,13 @@ class ArchivedSpecies:
     latest_detection_at: str
 
 
+@dataclass(frozen=True)
+class ArchivedPostcardLink:
+    observed_at: str
+    media_ids: tuple[str, ...]
+    species_ids: tuple[str, ...]
+
+
 @dataclass
 class FeederHistory:
     history_started_at: str
@@ -236,6 +250,7 @@ class FeederHistory:
     postcards: dict[str, BirdBuddyPostcard]
     archived_species: dict[str, ArchivedSpecies]
     confirmed_species: dict[tuple[str, str], ConfirmedSpeciesEvidence]
+    archived_postcards: dict[tuple[str, ...], ArchivedPostcardLink] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -795,9 +810,9 @@ def _parse_confirmed_evidence(
     selected_feeder_id: str,
     *,
     include_manual_sightings: bool,
-) -> tuple[ConfirmedSpeciesEvidence, ...]:
+) -> _ConfirmedMediaRecord | None:
     if not isinstance(value, dict):
-        return ()
+        return None
     origin = value.get("origin")
     feeder_id = _feeder_id(value.get("feeder"))
     if origin == "POSTCARD" and feeder_id == selected_feeder_id:
@@ -805,28 +820,32 @@ def _parse_confirmed_evidence(
     elif origin == "CUSTOM_ID" and include_manual_sightings:
         source = _CONFIRMED_MANUAL_SOURCE
     else:
-        return ()
+        return None
     media = value.get("media")
     created_at = media.get("createdAt") if isinstance(media, dict) else None
     media_id = _nonempty_string(media.get("id")) if isinstance(media, dict) else None
     observed = parse_utc_timestamp(created_at)
     species_values = value.get("species")
     if media_id is None or observed is None or not isinstance(species_values, list):
-        return ()
+        return None
     observed_at = observed.astimezone(UTC).replace(microsecond=0).isoformat()
     species: dict[str, PostcardSpecies] = {}
     for item in species_values:
-        if not isinstance(item, dict) or item.get("__typename") != "SpeciesBird":
+        if not isinstance(item, dict):
+            return None
+        if item.get("__typename") != "SpeciesBird":
             continue
         species_id = _nonempty_string(item.get("id"))
         common_name = _nonempty_string(item.get("name"))
         scientific_name = _nonempty_string(item.get("scientificName"))
         if species_id is None or common_name is None or scientific_name is None:
-            continue
+            return None
         species[species_id] = PostcardSpecies(species_id, common_name, scientific_name)
-    return tuple(
-        ConfirmedSpeciesEvidence(item, observed_at, source, media_id)
-        for item in sorted(species.values(), key=lambda candidate: candidate.species_id)
+    return _ConfirmedMediaRecord(
+        media_id,
+        observed_at,
+        source,
+        tuple(sorted(species.values(), key=lambda candidate: candidate.species_id)),
     )
 
 
@@ -871,15 +890,25 @@ def _fetch_confirmed_history(
                 feeder_id,
                 include_manual_sightings=include_manual_sightings,
             )
-            if not parsed:
+            if parsed is None:
                 continue
             accepted_records += 1
-            if any(item.source == _CONFIRMED_MANUAL_SOURCE for item in parsed):
+            if parsed.source == _CONFIRMED_MANUAL_SOURCE:
                 accepted_manual_records += 1
-            for item in parsed:
-                if item.source == _CONFIRMED_FEEDER_SOURCE and item.media_id is not None:
-                    media_species = species_by_media.setdefault(item.media_id, {})
-                    media_species[item.species.species_id] = item.species
+            if parsed.source == _CONFIRMED_FEEDER_SOURCE:
+                parsed_species = {item.species_id: item for item in parsed.species}
+                existing_species = species_by_media.get(parsed.media_id)
+                if existing_species is not None and existing_species != parsed_species:
+                    raise DataSourceError(
+                        "Bird Buddy confirmed history returned conflicting media records"
+                    )
+                species_by_media[parsed.media_id] = parsed_species
+            for species in parsed.species:
+                item = ConfirmedSpeciesEvidence(
+                    species,
+                    parsed.observed_at,
+                    parsed.source,
+                )
                 key = (item.source, item.species.species_id)
                 existing = evidence.get(key)
                 if (
@@ -976,6 +1005,46 @@ def _parse_archived_species(value: object, species_id: str) -> ArchivedSpecies:
     return ArchivedSpecies(species_id, common_name, scientific_name, count, latest)
 
 
+def _parse_archived_postcard(value: object) -> ArchivedPostcardLink:
+    if not isinstance(value, dict):
+        raise DataSourceError("Invalid Bird Buddy detection history")
+    observed_at = _nonempty_string(value.get("observed_at"))
+    media_values = value.get("media_ids")
+    species_values = value.get("species_ids")
+    if (
+        observed_at is None
+        or parse_utc_timestamp(observed_at) is None
+        or not isinstance(media_values, list)
+        or not isinstance(species_values, list)
+    ):
+        raise DataSourceError("Invalid Bird Buddy detection history")
+    media_ids = tuple(
+        media_id
+        for item in media_values
+        for media_id in [_nonempty_string(item)]
+        if media_id is not None
+    )
+    species_ids = tuple(
+        species_id
+        for item in species_values
+        for species_id in [_nonempty_string(item)]
+        if species_id is not None
+    )
+    if (
+        not media_ids
+        or len(media_ids) != len(media_values)
+        or len(set(media_ids)) != len(media_ids)
+        or len(species_ids) != len(species_values)
+        or len(set(species_ids)) != len(species_ids)
+    ):
+        raise DataSourceError("Invalid Bird Buddy detection history")
+    return ArchivedPostcardLink(
+        observed_at,
+        tuple(sorted(media_ids)),
+        tuple(sorted(species_ids)),
+    )
+
+
 def _parse_confirmed_species(value: object) -> ConfirmedSpeciesEvidence:
     if not isinstance(value, dict):
         raise DataSourceError("Invalid Bird Buddy detection history")
@@ -1008,6 +1077,7 @@ def _parse_feeder_history(value: object) -> FeederHistory:
     last_sync = value.get("last_successful_sync_at")
     postcard_values = value.get("postcards")
     archived_values = value.get("archived_species")
+    archived_postcard_values = value.get("archived_postcards", [])
     confirmed_values = value.get("confirmed_species", [])
     if (
         history_started_at is None
@@ -1016,13 +1086,17 @@ def _parse_feeder_history(value: object) -> FeederHistory:
         or (last_sync is not None and parse_utc_timestamp(last_sync) is None)
         or not isinstance(postcard_values, list)
         or not isinstance(archived_values, dict)
+        or not isinstance(archived_postcard_values, list)
         or not isinstance(confirmed_values, list)
     ):
         raise DataSourceError("Invalid Bird Buddy detection history")
+    parsed_postcards = [_parse_postcard_state(item) for item in postcard_values]
+    # Version-one history written before media linkage cannot safely reconcile
+    # a later confirmation. Drop those short-lived rows instead of retaining a
+    # stale preview classification; confirmed history can still restore
+    # conservative species presence on this successful sync.
     postcards = {
-        postcard.postcard_id: postcard
-        for item in postcard_values
-        for postcard in [_parse_postcard_state(item)]
+        postcard.postcard_id: postcard for postcard in parsed_postcards if postcard.media_ids
     }
     archived = {
         species_id: _parse_archived_species(item, species_id)
@@ -1030,6 +1104,10 @@ def _parse_feeder_history(value: object) -> FeederHistory:
         if isinstance(species_id, str)
     }
     if len(archived) != len(archived_values):
+        raise DataSourceError("Invalid Bird Buddy detection history")
+    archived_postcard_items = [_parse_archived_postcard(item) for item in archived_postcard_values]
+    archived_postcards = {item.media_ids: item for item in archived_postcard_items}
+    if len(archived_postcards) != len(archived_postcard_items):
         raise DataSourceError("Invalid Bird Buddy detection history")
     confirmed_items = [_parse_confirmed_species(item) for item in confirmed_values]
     confirmed = {(item.source, item.species.species_id): item for item in confirmed_items}
@@ -1042,6 +1120,7 @@ def _parse_feeder_history(value: object) -> FeederHistory:
         postcards,
         archived,
         confirmed,
+        archived_postcards,
     )
 
 
@@ -1107,6 +1186,20 @@ def _history_payload(histories: dict[str, FeederHistory]) -> dict[str, object]:
                     }
                     for species_id, species in sorted(history.archived_species.items())
                 },
+                "archived_postcards": [
+                    {
+                        "observed_at": item.observed_at,
+                        "media_ids": list(item.media_ids),
+                        "species_ids": list(item.species_ids),
+                    }
+                    for item in sorted(
+                        history.archived_postcards.values(),
+                        key=lambda candidate: (
+                            candidate.observed_at,
+                            candidate.media_ids,
+                        ),
+                    )
+                ],
                 "confirmed_species": [
                     {
                         "id": item.species.species_id,
@@ -1244,20 +1337,74 @@ def _latest_history_detection(
     return latest
 
 
-def _confirmed_postcard_species(
-    postcard: BirdBuddyPostcard,
+def _confirmed_species_for_media(
+    media_ids: tuple[str, ...],
     species_by_media: dict[str, tuple[PostcardSpecies, ...]],
 ) -> tuple[PostcardSpecies, ...] | None:
-    if not postcard.media_ids or any(
-        media_id not in species_by_media for media_id in postcard.media_ids
-    ):
+    if not media_ids or any(media_id not in species_by_media for media_id in media_ids):
         return None
     species = {
-        item.species_id: item
-        for media_id in postcard.media_ids
-        for item in species_by_media[media_id]
+        item.species_id: item for media_id in media_ids for item in species_by_media[media_id]
     }
     return tuple(sorted(species.values(), key=lambda item: item.species_id))
+
+
+def _reconcile_archived_postcards(
+    history: FeederHistory,
+    species_by_media: dict[str, tuple[PostcardSpecies, ...]],
+) -> int:
+    reclassified = 0
+    for media_ids, archived_postcard in list(history.archived_postcards.items()):
+        confirmed_species = _confirmed_species_for_media(media_ids, species_by_media)
+        if confirmed_species is None:
+            del history.archived_postcards[media_ids]
+            continue
+        confirmed_by_id = {item.species_id: item for item in confirmed_species}
+        old_ids = set(archived_postcard.species_ids)
+        new_ids = set(confirmed_by_id)
+        if old_ids == new_ids:
+            continue
+        for species_id in old_ids - new_ids:
+            archived = history.archived_species.get(species_id)
+            if archived is None:
+                raise DataSourceError("Invalid Bird Buddy archived correction history")
+            if archived.detection_count == 1:
+                del history.archived_species[species_id]
+            else:
+                history.archived_species[species_id] = ArchivedSpecies(
+                    archived.species_id,
+                    archived.common_name,
+                    archived.scientific_name,
+                    archived.detection_count - 1,
+                    archived.latest_detection_at,
+                )
+        for species_id in new_ids:
+            species = confirmed_by_id[species_id]
+            archived = history.archived_species.get(species_id)
+            added = species_id not in old_ids
+            if not added and archived is None:
+                raise DataSourceError("Invalid Bird Buddy archived correction history")
+            history.archived_species[species_id] = ArchivedSpecies(
+                species_id,
+                species.common_name,
+                species.scientific_name,
+                (archived.detection_count if archived is not None else 0) + (1 if added else 0),
+                (
+                    _newest_timestamp(
+                        archived.latest_detection_at,
+                        archived_postcard.observed_at,
+                    )
+                    if archived is not None
+                    else archived_postcard.observed_at
+                ),
+            )
+        history.archived_postcards[media_ids] = ArchivedPostcardLink(
+            archived_postcard.observed_at,
+            media_ids,
+            tuple(sorted(new_ids)),
+        )
+        reclassified += 1
+    return reclassified
 
 
 def _update_history(
@@ -1298,8 +1445,8 @@ def _update_history(
                 reclassified_postcard_ids.add(postcard.postcard_id)
             history.postcards[postcard.postcard_id] = postcard
         for postcard_id, postcard in list(history.postcards.items()):
-            confirmed_species = _confirmed_postcard_species(
-                postcard,
+            confirmed_species = _confirmed_species_for_media(
+                postcard.media_ids,
                 confirmed_species_by_media,
             )
             if confirmed_species is None or confirmed_species == postcard.species:
@@ -1311,6 +1458,10 @@ def _update_history(
                 media_ids=postcard.media_ids,
             )
             reclassified_postcard_ids.add(postcard_id)
+        archived_reclassifications = _reconcile_archived_postcards(
+            history,
+            confirmed_species_by_media,
+        )
         replaced_sources = {_CONFIRMED_FEEDER_SOURCE}
         if replace_manual_evidence:
             replaced_sources.add(_CONFIRMED_MANUAL_SOURCE)
@@ -1335,12 +1486,29 @@ def _update_history(
                 raise DataSourceError("Invalid Bird Buddy detection timestamp")
             if observed < prune_before:
                 _archive_postcard(history, postcard)
+                if (
+                    postcard.media_ids
+                    and _confirmed_species_for_media(
+                        postcard.media_ids,
+                        confirmed_species_by_media,
+                    )
+                    is not None
+                ):
+                    history.archived_postcards[postcard.media_ids] = ArchivedPostcardLink(
+                        postcard.observed_at,
+                        postcard.media_ids,
+                        tuple(item.species_id for item in postcard.species),
+                    )
                 del history.postcards[postcard_id]
         history.last_successful_sync_at = current_iso
         histories[feeder_id] = history
         if persist:
             write_json_atomic(_history_path(state_dir), _history_payload(histories), mode=0o600)
-    return _HistoryUpdate(history, duplicates, len(reclassified_postcard_ids))
+    return _HistoryUpdate(
+        history,
+        duplicates,
+        len(reclassified_postcard_ids) + archived_reclassifications,
+    )
 
 
 def sync_birdbuddy_detections(

--- a/src/inky_bird_frame/birdbuddy.py
+++ b/src/inky_bird_frame/birdbuddy.py
@@ -227,6 +227,7 @@ class ConfirmedSpeciesEvidence:
 @dataclass(frozen=True)
 class _ConfirmedMediaRecord:
     media_id: str
+    media_type: str
     observed_at: str
     source: str
     species: tuple[PostcardSpecies, ...]
@@ -668,7 +669,10 @@ def _parse_postcard(
         if not isinstance(sighting, dict):
             incomplete_recognized_sighting = True
             continue
-        typename = sighting.get("__typename")
+        typename = _nonempty_string(sighting.get("__typename"))
+        if typename is None:
+            incomplete_recognized_sighting = True
+            continue
         if typename not in {
             "SightingRecognizedBird",
             "SightingRecognizedBirdUnlocked",
@@ -870,6 +874,7 @@ def _parse_confirmed_evidence(
         species[species_id] = PostcardSpecies(species_id, common_name, scientific_name)
     return _ConfirmedMediaRecord(
         media_id,
+        media_type,
         observed_at,
         source,
         tuple(sorted(species.values(), key=lambda candidate: candidate.species_id)),
@@ -924,10 +929,7 @@ def _fetch_confirmed_history(
                 accepted_manual_records += 1
             if parsed.source == _CONFIRMED_FEEDER_SOURCE:
                 existing_record = records_by_media.get(parsed.media_id)
-                if existing_record is not None and (
-                    existing_record.observed_at != parsed.observed_at
-                    or existing_record.species != parsed.species
-                ):
+                if existing_record is not None and existing_record != parsed:
                     raise DataSourceError(
                         "Bird Buddy confirmed history returned conflicting media records"
                     )

--- a/src/inky_bird_frame/birdbuddy.py
+++ b/src/inky_bird_frame/birdbuddy.py
@@ -7,7 +7,7 @@ import json
 import stat
 from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Final
@@ -79,6 +79,7 @@ query InkyBirdBuddyFeed($first: Int!, $after: String) {
               ... on FeederForPublic { id }
               ... on FeederForRemoteGuest { id }
             }
+            medias { __typename id }
             sightingReportPreview {
               sightings {
                 __typename
@@ -118,6 +119,7 @@ query InkyBirdBuddyFeed($first: Int!, $after: String) {
               ... on FeederForPublic { id }
               ... on FeederForRemoteGuest { id }
             }
+            medias { __typename id }
             sightingReportPreview {
               sightings {
                 __typename
@@ -151,8 +153,14 @@ query InkyBirdBuddyConfirmedHistory($first: Int!, $after: String) {
       edges {
         node {
           origin
-          feeder { id }
-          media { createdAt }
+          feeder {
+            __typename
+            ... on FeederForMember { id }
+            ... on FeederForOwner { id }
+            ... on FeederForPublic { id }
+            ... on FeederForRemoteGuest { id }
+          }
+          media { __typename id createdAt }
           species {
             __typename
             ... on SpeciesBird { id name scientificName }
@@ -199,6 +207,7 @@ class BirdBuddyPostcard:
     postcard_id: str
     observed_at: str
     species: tuple[PostcardSpecies, ...]
+    media_ids: tuple[str, ...] = ()
     complete: bool = True
 
 
@@ -207,6 +216,7 @@ class ConfirmedSpeciesEvidence:
     species: PostcardSpecies
     observed_at: str
     source: str
+    media_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -285,6 +295,7 @@ class _ConfirmedHistoryFetch:
     records_accepted: int
     manual_records_accepted: int
     records_ignored: int
+    species_by_media: dict[str, tuple[PostcardSpecies, ...]] = field(default_factory=dict)
 
 
 def _auth_path(state_dir: Path) -> Path:
@@ -587,18 +598,43 @@ def _parse_postcard(
     ):
         return None
     observed_at = observed.replace(microsecond=0).isoformat()
+    media_values = value.get("medias")
+    media_ids: set[str] = set()
+    media_complete = isinstance(media_values, list)
+    if isinstance(media_values, list):
+        for media in media_values:
+            media_id = _nonempty_string(media.get("id")) if isinstance(media, dict) else None
+            if media_id is None:
+                media_complete = False
+                continue
+            media_ids.add(media_id)
+        if not media_ids:
+            media_complete = False
+    sorted_media_ids = tuple(sorted(media_ids))
     preview = value.get("sightingReportPreview")
     sightings = preview.get("sightings") if isinstance(preview, dict) else None
     if not isinstance(sightings, list):
         # A missing preview is an incomplete response, not an explicit
         # withdrawal. Ignore it so a transient schema/backend response cannot
         # delete a previously retained classification during reconciliation.
-        return BirdBuddyPostcard(postcard_id, observed_at, (), complete=False)
+        return BirdBuddyPostcard(
+            postcard_id,
+            observed_at,
+            (),
+            media_ids=sorted_media_ids,
+            complete=False,
+        )
     # An empty species tuple is a reconciliation tombstone. It lets a complete
     # feed refresh remove a previously accepted classification without storing
     # low-confidence or non-bird results in detection history.
     if value.get("inferenceConfidenceLevel") != "HIGH_CONFIDENCE":
-        return BirdBuddyPostcard(postcard_id, observed_at, ())
+        return BirdBuddyPostcard(
+            postcard_id,
+            observed_at,
+            (),
+            media_ids=sorted_media_ids,
+            complete=media_complete,
+        )
     species: dict[str, PostcardSpecies] = {}
     incomplete_recognized_sighting = False
     for sighting in sightings:
@@ -632,13 +668,15 @@ def _parse_postcard(
             postcard_id,
             observed_at,
             (),
-            complete=not incomplete_recognized_sighting,
+            media_ids=sorted_media_ids,
+            complete=media_complete and not incomplete_recognized_sighting,
         )
     return BirdBuddyPostcard(
         postcard_id,
         observed_at,
         tuple(sorted(species.values(), key=lambda item: item.species_id)),
-        complete=not incomplete_recognized_sighting,
+        media_ids=sorted_media_ids,
+        complete=media_complete and not incomplete_recognized_sighting,
     )
 
 
@@ -707,11 +745,13 @@ def _merge_postcard_variants(
         raise DataSourceError("Bird Buddy returned inconsistent postcard timestamps")
     species = {item.species_id: item for item in existing.species}
     species.update({item.species_id: item for item in incoming.species})
+    media_ids_match = existing.media_ids == incoming.media_ids
     postcards[incoming.postcard_id] = BirdBuddyPostcard(
         existing.postcard_id,
         existing.observed_at,
         tuple(sorted(species.values(), key=lambda item: item.species_id)),
-        complete=existing.complete and incoming.complete,
+        media_ids=tuple(sorted(set(existing.media_ids) | set(incoming.media_ids))),
+        complete=existing.complete and incoming.complete and media_ids_match,
     )
 
 
@@ -768,9 +808,10 @@ def _parse_confirmed_evidence(
         return ()
     media = value.get("media")
     created_at = media.get("createdAt") if isinstance(media, dict) else None
+    media_id = _nonempty_string(media.get("id")) if isinstance(media, dict) else None
     observed = parse_utc_timestamp(created_at)
     species_values = value.get("species")
-    if observed is None or not isinstance(species_values, list):
+    if media_id is None or observed is None or not isinstance(species_values, list):
         return ()
     observed_at = observed.astimezone(UTC).replace(microsecond=0).isoformat()
     species: dict[str, PostcardSpecies] = {}
@@ -784,7 +825,7 @@ def _parse_confirmed_evidence(
             continue
         species[species_id] = PostcardSpecies(species_id, common_name, scientific_name)
     return tuple(
-        ConfirmedSpeciesEvidence(item, observed_at, source)
+        ConfirmedSpeciesEvidence(item, observed_at, source, media_id)
         for item in sorted(species.values(), key=lambda candidate: candidate.species_id)
     )
 
@@ -796,6 +837,7 @@ def _fetch_confirmed_history(
     include_manual_sightings: bool,
 ) -> _ConfirmedHistoryFetch:
     evidence: dict[tuple[str, str], ConfirmedSpeciesEvidence] = {}
+    species_by_media: dict[str, dict[str, PostcardSpecies]] = {}
     after: str | None = None
     seen_cursors: set[str] = set()
     pages = 0
@@ -835,6 +877,9 @@ def _fetch_confirmed_history(
             if any(item.source == _CONFIRMED_MANUAL_SOURCE for item in parsed):
                 accepted_manual_records += 1
             for item in parsed:
+                if item.source == _CONFIRMED_FEEDER_SOURCE and item.media_id is not None:
+                    media_species = species_by_media.setdefault(item.media_id, {})
+                    media_species[item.species.species_id] = item.species
                 key = (item.source, item.species.species_id)
                 existing = evidence.get(key)
                 if (
@@ -863,6 +908,10 @@ def _fetch_confirmed_history(
         accepted_records,
         accepted_manual_records,
         processed - accepted_records,
+        {
+            media_id: tuple(sorted(items.values(), key=lambda item: item.species_id))
+            for media_id, items in species_by_media.items()
+        },
     )
 
 
@@ -872,12 +921,22 @@ def _parse_postcard_state(value: object) -> BirdBuddyPostcard:
     postcard_id = _nonempty_string(value.get("id"))
     observed_at = _nonempty_string(value.get("observed_at"))
     species_values = value.get("species")
+    media_id_values = value.get("media_ids", [])
     if (
         postcard_id is None
         or observed_at is None
         or parse_utc_timestamp(observed_at) is None
         or not isinstance(species_values, list)
+        or not isinstance(media_id_values, list)
     ):
+        raise DataSourceError("Invalid Bird Buddy detection history")
+    media_ids = tuple(
+        media_id
+        for item in media_id_values
+        for media_id in [_nonempty_string(item)]
+        if media_id is not None
+    )
+    if len(media_ids) != len(media_id_values) or len(set(media_ids)) != len(media_ids):
         raise DataSourceError("Invalid Bird Buddy detection history")
     species: list[PostcardSpecies] = []
     for item in species_values:
@@ -889,7 +948,12 @@ def _parse_postcard_state(value: object) -> BirdBuddyPostcard:
         if species_id is None or common_name is None or scientific_name is None:
             raise DataSourceError("Invalid Bird Buddy detection history")
         species.append(PostcardSpecies(species_id, common_name, scientific_name))
-    return BirdBuddyPostcard(postcard_id, observed_at, tuple(species))
+    return BirdBuddyPostcard(
+        postcard_id,
+        observed_at,
+        tuple(species),
+        media_ids=tuple(sorted(media_ids)),
+    )
 
 
 def _parse_archived_species(value: object, species_id: str) -> ArchivedSpecies:
@@ -1007,6 +1071,7 @@ def _postcard_payload(postcard: BirdBuddyPostcard) -> dict[str, object]:
     return {
         "id": postcard.postcard_id,
         "observed_at": postcard.observed_at,
+        "media_ids": list(postcard.media_ids),
         "species": [
             {
                 "id": species.species_id,
@@ -1179,6 +1244,22 @@ def _latest_history_detection(
     return latest
 
 
+def _confirmed_postcard_species(
+    postcard: BirdBuddyPostcard,
+    species_by_media: dict[str, tuple[PostcardSpecies, ...]],
+) -> tuple[PostcardSpecies, ...] | None:
+    if not postcard.media_ids or any(
+        media_id not in species_by_media for media_id in postcard.media_ids
+    ):
+        return None
+    species = {
+        item.species_id: item
+        for media_id in postcard.media_ids
+        for item in species_by_media[media_id]
+    }
+    return tuple(sorted(species.values(), key=lambda item: item.species_id))
+
+
 def _update_history(
     state_dir: Path,
     feeder_id: str,
@@ -1188,6 +1269,7 @@ def _update_history(
     *,
     persist: bool,
     replace_manual_evidence: bool,
+    confirmed_species_by_media: dict[str, tuple[PostcardSpecies, ...]],
 ) -> _HistoryUpdate:
     current_iso = current.isoformat()
     lock = _history_lock(state_dir) if persist else nullcontext()
@@ -1198,19 +1280,37 @@ def _update_history(
             FeederHistory(current_iso, None, None, {}, {}, {}),
         )
         duplicates = 0
-        reclassified = 0
+        reclassified_postcard_ids: set[str] = set()
         for postcard in incoming:
             existing = history.postcards.get(postcard.postcard_id)
             if not postcard.species:
                 if existing is not None:
                     del history.postcards[postcard.postcard_id]
-                    reclassified += 1
+                    reclassified_postcard_ids.add(postcard.postcard_id)
                 continue
-            if existing == postcard:
+            if (
+                existing is not None
+                and existing.observed_at == postcard.observed_at
+                and existing.species == postcard.species
+            ):
                 duplicates += 1
             elif existing is not None:
-                reclassified += 1
+                reclassified_postcard_ids.add(postcard.postcard_id)
             history.postcards[postcard.postcard_id] = postcard
+        for postcard_id, postcard in list(history.postcards.items()):
+            confirmed_species = _confirmed_postcard_species(
+                postcard,
+                confirmed_species_by_media,
+            )
+            if confirmed_species is None or confirmed_species == postcard.species:
+                continue
+            history.postcards[postcard_id] = BirdBuddyPostcard(
+                postcard.postcard_id,
+                postcard.observed_at,
+                confirmed_species,
+                media_ids=postcard.media_ids,
+            )
+            reclassified_postcard_ids.add(postcard_id)
         replaced_sources = {_CONFIRMED_FEEDER_SOURCE}
         if replace_manual_evidence:
             replaced_sources.add(_CONFIRMED_MANUAL_SOURCE)
@@ -1240,7 +1340,7 @@ def _update_history(
         histories[feeder_id] = history
         if persist:
             write_json_atomic(_history_path(state_dir), _history_payload(histories), mode=0o600)
-    return _HistoryUpdate(history, duplicates, reclassified)
+    return _HistoryUpdate(history, duplicates, len(reclassified_postcard_ids))
 
 
 def sync_birdbuddy_detections(
@@ -1271,6 +1371,7 @@ def sync_birdbuddy_detections(
         current,
         persist=persist_history,
         replace_manual_evidence=include_manual_sightings,
+        confirmed_species_by_media=confirmed.species_by_media,
     )
     species = _aggregate_species(
         update.history,

--- a/src/inky_bird_frame/birdbuddy.py
+++ b/src/inky_bird_frame/birdbuddy.py
@@ -179,6 +179,12 @@ _CONFIRMED_SOURCES: Final = {
     _CONFIRMED_FEEDER_SOURCE,
     _CONFIRMED_MANUAL_SOURCE,
 }
+_FEEDER_REFERENCE_TYPES: Final = {
+    "FeederForMember",
+    "FeederForOwner",
+    "FeederForPublic",
+    "FeederForRemoteGuest",
+}
 
 
 @dataclass(frozen=True)
@@ -595,6 +601,8 @@ def _refreshed_access_token(state_dir: Path) -> tuple[str, BirdBuddyFeeder]:
 def _feeder_id(value: object) -> str | None:
     if not isinstance(value, dict):
         return None
+    if _nonempty_string(value.get("__typename")) not in _FEEDER_REFERENCE_TYPES:
+        return None
     return _nonempty_string(value.get("id"))
 
 
@@ -620,7 +628,10 @@ def _parse_postcard(
     if isinstance(media_values, list):
         for media in media_values:
             media_id = _nonempty_string(media.get("id")) if isinstance(media, dict) else None
-            if media_id is None:
+            media_type = (
+                _nonempty_string(media.get("__typename")) if isinstance(media, dict) else None
+            )
+            if media_id is None or media_type is None:
                 media_complete = False
                 continue
             media_ids.add(media_id)
@@ -872,7 +883,7 @@ def _fetch_confirmed_history(
     include_manual_sightings: bool,
 ) -> _ConfirmedHistoryFetch:
     evidence: dict[tuple[str, str], ConfirmedSpeciesEvidence] = {}
-    species_by_media: dict[str, dict[str, PostcardSpecies]] = {}
+    records_by_media: dict[str, _ConfirmedMediaRecord] = {}
     after: str | None = None
     seen_cursors: set[str] = set()
     pages = 0
@@ -912,13 +923,15 @@ def _fetch_confirmed_history(
             if parsed.source == _CONFIRMED_MANUAL_SOURCE:
                 accepted_manual_records += 1
             if parsed.source == _CONFIRMED_FEEDER_SOURCE:
-                parsed_species = {item.species_id: item for item in parsed.species}
-                existing_species = species_by_media.get(parsed.media_id)
-                if existing_species is not None and existing_species != parsed_species:
+                existing_record = records_by_media.get(parsed.media_id)
+                if existing_record is not None and (
+                    existing_record.observed_at != parsed.observed_at
+                    or existing_record.species != parsed.species
+                ):
                     raise DataSourceError(
                         "Bird Buddy confirmed history returned conflicting media records"
                     )
-                species_by_media[parsed.media_id] = parsed_species
+                records_by_media[parsed.media_id] = parsed
             for species in parsed.species:
                 item = ConfirmedSpeciesEvidence(
                     species,
@@ -953,10 +966,7 @@ def _fetch_confirmed_history(
         accepted_records,
         accepted_manual_records,
         processed - accepted_records,
-        {
-            media_id: tuple(sorted(items.values(), key=lambda item: item.species_id))
-            for media_id, items in species_by_media.items()
-        },
+        {media_id: record.species for media_id, record in records_by_media.items()},
     )
 
 
@@ -1522,7 +1532,7 @@ def _update_history(
         reclassified_postcard_ids: set[str] = set()
         for postcard in incoming:
             existing = history.postcards.get(postcard.postcard_id)
-            if not postcard.species:
+            if not postcard.species and not postcard.media_ids:
                 if existing is not None:
                     del history.postcards[postcard.postcard_id]
                     reclassified_postcard_ids.add(postcard.postcard_id)

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -984,7 +984,12 @@ def birdbuddy_login_command(args: argparse.Namespace) -> int:
 
 def birdbuddy_status_command(args: argparse.Namespace) -> int:
     config = _config(args, load_secrets=False)
-    print_result(birdbuddy_status(config.controller.state_dir))
+    print_result(
+        birdbuddy_status(
+            config.controller.state_dir,
+            include_manual_sightings=(config.discovery.birdbuddy_include_manual_sightings),
+        )
+    )
     return 0
 
 

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -98,6 +98,7 @@ class DiscoveryConfig:
     ebird_api_key_env: str | None = field(default=None, repr=False)
     birdweather_token: str | None = field(default=None, repr=False)
     birdweather_token_env: str | None = field(default=None, repr=False)
+    birdbuddy_include_manual_sightings: bool = False
 
 
 @dataclass(frozen=True)
@@ -591,6 +592,11 @@ def load_config(path: Path, *, load_secrets: bool = True) -> AppConfig:
             ebird_api_key_env=ebird_api_key_env,
             birdweather_token=birdweather_token,
             birdweather_token_env=birdweather_token_env,
+            birdbuddy_include_manual_sightings=_optional_boolean(
+                discovery,
+                "birdbuddy_include_manual_sightings",
+                default=False,
+            ),
         ),
         controller=ControllerConfig(
             workspace_dir=_path(_string(controller, "workspace_dir"), base_dir),

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -339,6 +339,7 @@ def discover_species(
                 window=selected_window,
                 limit=selected_limit,
                 persist_history=persist_taxonomy_cache,
+                include_manual_sightings=(config.discovery.birdbuddy_include_manual_sightings),
             )
             resolved, birdbuddy_unresolved = resolve_birdbuddy_species(
                 sync.species,

--- a/src/inky_bird_frame/installation.py
+++ b/src/inky_bird_frame/installation.py
@@ -325,7 +325,10 @@ def _config_permissions(path: Path) -> DiagnosticCheck:
 
 def _birdbuddy_auth_check(config: AppConfig) -> DiagnosticCheck:
     try:
-        status = birdbuddy_status(config.controller.state_dir)
+        status = birdbuddy_status(
+            config.controller.state_dir,
+            include_manual_sightings=(config.discovery.birdbuddy_include_manual_sightings),
+        )
     except InkyBirdFrameError as exc:
         return _fail(
             "birdbuddy_auth",

--- a/tests/test_birdbuddy.py
+++ b/tests/test_birdbuddy.py
@@ -37,7 +37,7 @@ def postcard(
     species_id: str = "species-bluebird",
     common_name: str = "Eastern Bluebird",
     scientific_name: str = "Sialia sialis",
-    media_ids: tuple[str, ...] = (),
+    media_ids: tuple[str, ...] = ("media-1",),
 ) -> BirdBuddyPostcard:
     return BirdBuddyPostcard(
         postcard_id,
@@ -498,14 +498,26 @@ class BirdBuddyTests(unittest.TestCase):
             "feeder-1",
             include_manual_sightings=True,
         )
+        malformed = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
+        malformed["species"] = [{"__typename": "SpeciesBird", "id": None}]
 
-        self.assertEqual(selected[0].source, "selected_feeder")
-        self.assertEqual(selected[0].observed_at, "2026-08-03T10:00:00+00:00")
-        self.assertEqual(selected[0].media_id, "media-1")
-        self.assertEqual(other_feeder, ())
-        self.assertEqual(manual_disabled, ())
-        self.assertEqual(manual_enabled[0].source, "manual")
-        self.assertEqual(watching, ())
+        assert selected is not None
+        assert manual_enabled is not None
+        self.assertEqual(selected.source, "selected_feeder")
+        self.assertEqual(selected.observed_at, "2026-08-03T10:00:00+00:00")
+        self.assertEqual(selected.media_id, "media-1")
+        self.assertEqual(selected.species[0].scientific_name, "Archilochus colubris")
+        self.assertIsNone(other_feeder)
+        self.assertIsNone(manual_disabled)
+        self.assertEqual(manual_enabled.source, "manual")
+        self.assertIsNone(watching)
+        self.assertIsNone(
+            _parse_confirmed_evidence(
+                malformed,
+                "feeder-1",
+                include_manual_sightings=False,
+            )
+        )
 
     def test_confirmed_history_paginates_and_keeps_newest_species_evidence(self) -> None:
         first = {
@@ -565,6 +577,12 @@ class BirdBuddyTests(unittest.TestCase):
         self.assertEqual(result.evidence[0].observed_at, "2026-08-03T10:00:00+00:00")
 
     def test_confirmed_history_links_selected_feeder_species_by_media(self) -> None:
+        species_free = confirmed_node(
+            origin="POSTCARD",
+            feeder_id="feeder-1",
+            media_id="media-2",
+        )
+        species_free["species"] = []
         page = {
             "me": {
                 "mediasOwned": {
@@ -575,7 +593,8 @@ class BirdBuddyTests(unittest.TestCase):
                                 feeder_id="feeder-1",
                                 media_id="media-1",
                             )
-                        }
+                        },
+                        {"node": species_free},
                     ],
                     "pageInfo": {"hasNextPage": False, "endCursor": None},
                 }
@@ -592,6 +611,8 @@ class BirdBuddyTests(unittest.TestCase):
             result.species_by_media["media-1"][0].scientific_name,
             "Archilochus colubris",
         )
+        self.assertEqual(result.species_by_media["media-2"], ())
+        self.assertEqual(result.records_accepted, 2)
 
     def test_confirmed_history_rejects_repeated_pagination_cursor(self) -> None:
         page = {
@@ -806,10 +827,177 @@ class BirdBuddyTests(unittest.TestCase):
             corrected_species,
             (now - timedelta(hours=1)).isoformat(),
             "selected_feeder",
-            "media-1",
         )
         confirmed = _ConfirmedHistoryFetch(
             [confirmed_evidence],
+            1,
+            1,
+            1,
+            0,
+            0,
+            {"media-1": (corrected_species,)},
+        )
+        rejected = _ConfirmedHistoryFetch(
+            [],
+            1,
+            1,
+            1,
+            0,
+            0,
+            {"media-1": ()},
+        )
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            with patch(
+                "inky_bird_frame.birdbuddy._authenticate",
+                return_value=("access", "refresh", [feeder]),
+            ):
+                login_birdbuddy(
+                    state_dir,
+                    email="birder@example.test",
+                    password="private-password",
+                    authorization_confirmed=True,
+                    now=now,
+                )
+            with (
+                patch(
+                    "inky_bird_frame.birdbuddy._refresh_access_token",
+                    return_value=("access", "replacement"),
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_postcards",
+                    return_value=([preview], 2, 1, 0),
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_confirmed_history",
+                    side_effect=[confirmed, rejected],
+                ),
+            ):
+                corrected = sync_birdbuddy_detections(
+                    state_dir,
+                    window=ObservationWindow.LAST_DAY,
+                    limit=20,
+                    now=now,
+                )
+                removed = sync_birdbuddy_detections(
+                    state_dir,
+                    window=ObservationWindow.LAST_DAY,
+                    limit=20,
+                    now=now + timedelta(minutes=5),
+                )
+            history = json.loads((state_dir / "birdbuddy-detections.json").read_text())
+
+        self.assertEqual(
+            [item.scientific_name for item in corrected.species],
+            ["Cardinalis cardinalis"],
+        )
+        self.assertEqual(corrected.species[0].detection_count, 1)
+        self.assertEqual(corrected.stats.reclassified_postcards, 1)
+        self.assertEqual(removed.species, [])
+        self.assertEqual(removed.stats.reclassified_postcards, 1)
+        stored = history["feeders"]["feeder-1"]["postcards"][0]
+        self.assertEqual(stored["media_ids"], ["media-1"])
+        self.assertEqual(stored["species"], [])
+
+    def test_sync_discards_legacy_postcard_without_media_linkage(self) -> None:
+        feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")
+        now = datetime(2026, 8, 3, 12, 0, tzinfo=UTC)
+        legacy = postcard("postcard-1", now - timedelta(hours=2))
+        legacy_payload = {
+            "schema_version": 1,
+            "feeders": {
+                "feeder-1": {
+                    "history_started_at": now.isoformat(),
+                    "earliest_initial_feed_at": legacy.observed_at,
+                    "last_successful_sync_at": now.isoformat(),
+                    "postcards": [
+                        {
+                            "id": legacy.postcard_id,
+                            "observed_at": legacy.observed_at,
+                            "species": [
+                                {
+                                    "id": legacy.species[0].species_id,
+                                    "common_name": legacy.species[0].common_name,
+                                    "scientific_name": legacy.species[0].scientific_name,
+                                }
+                            ],
+                        }
+                    ],
+                    "archived_species": {},
+                    "confirmed_species": [],
+                }
+            },
+        }
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            with patch(
+                "inky_bird_frame.birdbuddy._authenticate",
+                return_value=("access", "refresh", [feeder]),
+            ):
+                login_birdbuddy(
+                    state_dir,
+                    email="birder@example.test",
+                    password="private-password",
+                    authorization_confirmed=True,
+                    now=now,
+                )
+            history_path = state_dir / "birdbuddy-detections.json"
+            history_path.write_text(json.dumps(legacy_payload))
+            history_path.chmod(0o600)
+            with (
+                patch(
+                    "inky_bird_frame.birdbuddy._refresh_access_token",
+                    return_value=("access", "replacement"),
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_postcards",
+                    return_value=([], 2, 0, 0),
+                ),
+            ):
+                result = sync_birdbuddy_detections(
+                    state_dir,
+                    window=ObservationWindow.ALL_TIME,
+                    limit=20,
+                    now=now + timedelta(minutes=5),
+                )
+            migrated = json.loads(history_path.read_text())
+
+        self.assertEqual(result.species, [])
+        self.assertEqual(migrated["feeders"]["feeder-1"]["postcards"], [])
+
+    def test_confirmed_media_reclassifies_archived_postcard_totals(self) -> None:
+        feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")
+        now = datetime(2026, 8, 3, 12, 0, tzinfo=UTC)
+        observed_at = now - timedelta(days=367)
+        original = postcard("postcard-1", observed_at, media_ids=("media-1",))
+        corrected_species = PostcardSpecies(
+            "species-cardinal",
+            "Northern Cardinal",
+            "Cardinalis cardinalis",
+        )
+        original_confirmed = _ConfirmedHistoryFetch(
+            [
+                ConfirmedSpeciesEvidence(
+                    original.species[0],
+                    observed_at.isoformat(),
+                    "selected_feeder",
+                )
+            ],
+            1,
+            1,
+            1,
+            0,
+            0,
+            {"media-1": original.species},
+        )
+        corrected_confirmed = _ConfirmedHistoryFetch(
+            [
+                ConfirmedSpeciesEvidence(
+                    corrected_species,
+                    observed_at.isoformat(),
+                    "selected_feeder",
+                )
+            ],
             1,
             1,
             1,
@@ -837,30 +1025,43 @@ class BirdBuddyTests(unittest.TestCase):
                 ),
                 patch(
                     "inky_bird_frame.birdbuddy._fetch_postcards",
-                    return_value=([preview], 2, 1, 0),
+                    side_effect=[([original], 2, 1, 0), ([], 2, 0, 0)],
                 ),
                 patch(
                     "inky_bird_frame.birdbuddy._fetch_confirmed_history",
-                    return_value=confirmed,
+                    side_effect=[original_confirmed, corrected_confirmed],
                 ),
             ):
-                result = sync_birdbuddy_detections(
+                archived = sync_birdbuddy_detections(
                     state_dir,
-                    window=ObservationWindow.LAST_DAY,
+                    window=ObservationWindow.ALL_TIME,
                     limit=20,
                     now=now,
+                )
+                corrected = sync_birdbuddy_detections(
+                    state_dir,
+                    window=ObservationWindow.ALL_TIME,
+                    limit=20,
+                    now=now + timedelta(minutes=5),
                 )
             history = json.loads((state_dir / "birdbuddy-detections.json").read_text())
 
         self.assertEqual(
-            [item.scientific_name for item in result.species],
+            [item.scientific_name for item in archived.species],
+            ["Sialia sialis"],
+        )
+        self.assertEqual(
+            [item.scientific_name for item in corrected.species],
             ["Cardinalis cardinalis"],
         )
-        self.assertEqual(result.species[0].detection_count, 1)
-        self.assertEqual(result.stats.reclassified_postcards, 1)
-        stored = history["feeders"]["feeder-1"]["postcards"][0]
-        self.assertEqual(stored["media_ids"], ["media-1"])
-        self.assertEqual(stored["species"][0]["id"], "species-cardinal")
+        self.assertEqual(corrected.species[0].detection_count, 1)
+        self.assertEqual(corrected.stats.reclassified_postcards, 1)
+        archived_state = history["feeders"]["feeder-1"]
+        self.assertNotIn("species-bluebird", archived_state["archived_species"])
+        self.assertEqual(
+            archived_state["archived_postcards"][0]["species_ids"],
+            ["species-cardinal"],
+        )
 
     def test_complete_confirmed_snapshot_removes_stale_manual_evidence(self) -> None:
         feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")

--- a/tests/test_birdbuddy.py
+++ b/tests/test_birdbuddy.py
@@ -11,9 +11,12 @@ from unittest.mock import patch
 from inky_bird_frame.birdbuddy import (
     _CONFIRMED_HISTORY,
     _FEED_QUERIES,
+    ArchivedPostcardLink,
+    ArchivedSpecies,
     BirdBuddyFeeder,
     BirdBuddyPostcard,
     ConfirmedSpeciesEvidence,
+    FeederHistory,
     PostcardSpecies,
     _ConfirmedHistoryFetch,
     _fetch_confirmed_history,
@@ -21,6 +24,7 @@ from inky_bird_frame.birdbuddy import (
     _fetch_postcards,
     _parse_confirmed_evidence,
     _parse_postcard,
+    _reconcile_archived_postcards,
     _refresh_access_token,
     birdbuddy_status,
     login_birdbuddy,
@@ -298,6 +302,23 @@ class BirdBuddyTests(unittest.TestCase):
         assert parsed_partial is not None
         self.assertFalse(parsed_partial.complete)
 
+        conflicting_identity = feed_node(
+            recognized_sighting,
+            {
+                "__typename": "SightingRecognizedBird",
+                "species": {
+                    "__typename": "SpeciesBird",
+                    "id": "species-bluebird",
+                    "name": "Conflicting Bluebird",
+                    "scientificName": "Sialia conflictus",
+                },
+            },
+        )
+        parsed_conflict = _parse_postcard(conflicting_identity, "feeder-1")
+        self.assertIsNotNone(parsed_conflict)
+        assert parsed_conflict is not None
+        self.assertFalse(parsed_conflict.complete)
+
         low_confidence_incomplete = {
             **node,
             "inferenceConfidenceLevel": "LOW_CONFIDENCE",
@@ -322,6 +343,53 @@ class BirdBuddyTests(unittest.TestCase):
             self.assertRaisesRegex(DataSourceError, "repeated pagination cursor"),
         ):
             _fetch_postcards("access-secret", "feeder-1")
+
+    def test_feed_rejects_conflicting_duplicate_postcards_across_pages(self) -> None:
+        sighting = {
+            "__typename": "SightingRecognizedBird",
+            "species": {
+                "__typename": "SpeciesBird",
+                "id": "species-bluebird",
+                "name": "Eastern Bluebird",
+                "scientificName": "Sialia sialis",
+            },
+        }
+        first = {
+            "me": {
+                "feed": {
+                    "edges": [{"node": feed_node(sighting)}],
+                    "pageInfo": {"hasNextPage": True, "endCursor": "next"},
+                }
+            }
+        }
+        second = {
+            "me": {
+                "feed": {
+                    "edges": [
+                        {
+                            "node": feed_node(
+                                sighting,
+                                observed_at="2026-08-03T11:00:00+00:00",
+                            )
+                        }
+                    ],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+        with (
+            patch(
+                "inky_bird_frame.birdbuddy._graphql_request",
+                side_effect=[first, second],
+            ),
+            self.assertRaisesRegex(DataSourceError, "conflicting duplicate postcards"),
+        ):
+            _fetch_postcard_variant(
+                "access-secret",
+                "feeder-1",
+                _FEED_QUERIES[0],
+                "SightingRecognizedBird",
+            )
 
     def test_first_feed_page_omits_null_cursor(self) -> None:
         page = {
@@ -512,6 +580,17 @@ class BirdBuddyTests(unittest.TestCase):
         )
         malformed = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
         malformed["species"] = [{"__typename": "SpeciesBird", "id": None}]
+        conflicting_species = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
+        conflicting_species_values = conflicting_species["species"]
+        assert isinstance(conflicting_species_values, list)
+        conflicting_species_values.append(
+            {
+                "__typename": "SpeciesBird",
+                "id": "species-hummingbird",
+                "name": "Conflicting Hummingbird",
+                "scientificName": "Archilochus conflictus",
+            }
+        )
         missing_species_type = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
         missing_species_type["species"] = [{}]
         missing_media_type = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
@@ -537,6 +616,12 @@ class BirdBuddyTests(unittest.TestCase):
         with self.assertRaisesRegex(DataSourceError, "record was incomplete"):
             _parse_confirmed_evidence(
                 malformed,
+                "feeder-1",
+                include_manual_sightings=False,
+            )
+        with self.assertRaisesRegex(DataSourceError, "conflicting species identities"):
+            _parse_confirmed_evidence(
+                conflicting_species,
                 "feeder-1",
                 include_manual_sightings=False,
             )
@@ -597,6 +682,7 @@ class BirdBuddyTests(unittest.TestCase):
                                 origin="CUSTOM_ID",
                                 feeder_id="manual",
                                 observed_at="2026-08-03T10:00:00Z",
+                                media_id="media-2",
                             )
                         },
                         {
@@ -698,6 +784,48 @@ class BirdBuddyTests(unittest.TestCase):
                 "access-secret",
                 "feeder-1",
                 include_manual_sightings=False,
+            )
+
+    def test_confirmed_history_rejects_opted_in_manual_media_conflicts(self) -> None:
+        page = {
+            "me": {
+                "mediasOwned": {
+                    "edges": [
+                        {
+                            "node": confirmed_node(
+                                origin="CUSTOM_ID",
+                                feeder_id="manual",
+                                observed_at="2026-08-03T10:00:00Z",
+                            )
+                        },
+                        {
+                            "node": confirmed_node(
+                                origin="CUSTOM_ID",
+                                feeder_id="manual",
+                                observed_at="2026-08-03T11:00:00Z",
+                            )
+                        },
+                    ],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+        with patch("inky_bird_frame.birdbuddy._graphql_request", return_value=page):
+            ignored = _fetch_confirmed_history(
+                "access-secret",
+                "feeder-1",
+                include_manual_sightings=False,
+            )
+        self.assertEqual(ignored.records_accepted, 0)
+
+        with (
+            patch("inky_bird_frame.birdbuddy._graphql_request", return_value=page),
+            self.assertRaisesRegex(DataSourceError, "conflicting media records"),
+        ):
+            _fetch_confirmed_history(
+                "access-secret",
+                "feeder-1",
+                include_manual_sightings=True,
             )
 
     def test_confirmed_history_rejects_malformed_selected_feeder_record(self) -> None:
@@ -1476,6 +1604,44 @@ class BirdBuddyTests(unittest.TestCase):
             older.observed_at,
         )
         self.assertEqual(after_by_name["Cardinalis cardinalis"].detection_count, 1)
+
+    def test_archived_identity_correction_survives_confirmed_record_removal(self) -> None:
+        observed_at = "2025-08-01T10:00:00+00:00"
+        media_ids = ("media-1",)
+        original = ArchivedSpecies(
+            "species-bluebird",
+            "Eastern Bluebird",
+            "Sialia sialis",
+            1,
+            observed_at,
+        )
+        history = FeederHistory(
+            "2025-01-01T00:00:00+00:00",
+            None,
+            None,
+            {},
+            {original.species_id: original},
+            {},
+            {media_ids: ArchivedPostcardLink(observed_at, media_ids, (original.species_id,))},
+        )
+        corrected = PostcardSpecies(
+            original.species_id,
+            "Eastern Bluebird (updated)",
+            "Sialia sialis",
+        )
+
+        changed = _reconcile_archived_postcards(
+            history,
+            {"media-1": (corrected,)},
+        )
+        _reconcile_archived_postcards(history, {})
+
+        self.assertEqual(changed, 1)
+        self.assertEqual(
+            history.archived_species[original.species_id].common_name,
+            "Eastern Bluebird (updated)",
+        )
+        self.assertEqual(history.archived_postcards, {})
 
     def test_complete_confirmed_snapshot_removes_stale_manual_evidence(self) -> None:
         feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")

--- a/tests/test_birdbuddy.py
+++ b/tests/test_birdbuddy.py
@@ -58,7 +58,7 @@ def feed_node(
         "id": postcard_id,
         "createdAt": observed_at,
         "inferenceConfidenceLevel": "HIGH_CONFIDENCE",
-        "feeder": {"id": "feeder-1"},
+        "feeder": {"__typename": "FeederForMember", "id": "feeder-1"},
         "medias": [{"__typename": "MediaImage", "id": media_id} for media_id in media_ids],
         "sightingReportPreview": {"sightings": list(sightings)},
     }
@@ -73,7 +73,7 @@ def confirmed_node(
 ) -> dict[str, object]:
     return {
         "origin": origin,
-        "feeder": {"id": feeder_id},
+        "feeder": {"__typename": "FeederForMember", "id": feeder_id},
         "media": {"__typename": "MediaImage", "id": media_id, "createdAt": observed_at},
         "species": [
             {
@@ -217,6 +217,17 @@ class BirdBuddyTests(unittest.TestCase):
         assert low_confidence is not None
         self.assertEqual(low_confidence.species, ())
         self.assertIsNone(_parse_postcard(node, "another-feeder"))
+
+        missing_media_type = feed_node(recognized_sighting)
+        missing_media_type["medias"] = [{"__typename": None, "id": "media-1"}]
+        parsed_missing_media_type = _parse_postcard(missing_media_type, "feeder-1")
+        self.assertIsNotNone(parsed_missing_media_type)
+        assert parsed_missing_media_type is not None
+        self.assertFalse(parsed_missing_media_type.complete)
+
+        missing_feeder_type = feed_node(recognized_sighting)
+        missing_feeder_type["feeder"] = {"__typename": None, "id": "feeder-1"}
+        self.assertIsNone(_parse_postcard(missing_feeder_type, "feeder-1"))
 
         unlocked = {
             **node,
@@ -507,6 +518,9 @@ class BirdBuddyTests(unittest.TestCase):
         missing_media_type["media"]["__typename"] = None
         missing_feeder = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
         missing_feeder["feeder"] = None
+        missing_feeder_type = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
+        assert isinstance(missing_feeder_type["feeder"], dict)
+        missing_feeder_type["feeder"]["__typename"] = None
         unsupported_origin = confirmed_node(origin="UNKNOWN", feeder_id="feeder-1")
 
         assert selected is not None
@@ -540,6 +554,12 @@ class BirdBuddyTests(unittest.TestCase):
         with self.assertRaisesRegex(DataSourceError, "record was incomplete"):
             _parse_confirmed_evidence(
                 missing_feeder,
+                "feeder-1",
+                include_manual_sightings=False,
+            )
+        with self.assertRaisesRegex(DataSourceError, "record was incomplete"):
+            _parse_confirmed_evidence(
+                missing_feeder_type,
                 "feeder-1",
                 include_manual_sightings=False,
             )
@@ -644,6 +664,40 @@ class BirdBuddyTests(unittest.TestCase):
         )
         self.assertEqual(result.species_by_media["media-2"], ())
         self.assertEqual(result.records_accepted, 2)
+
+    def test_confirmed_history_rejects_timestamp_conflicts_for_one_media(self) -> None:
+        page = {
+            "me": {
+                "mediasOwned": {
+                    "edges": [
+                        {
+                            "node": confirmed_node(
+                                origin="POSTCARD",
+                                feeder_id="feeder-1",
+                                observed_at="2026-08-03T10:00:00Z",
+                            )
+                        },
+                        {
+                            "node": confirmed_node(
+                                origin="POSTCARD",
+                                feeder_id="feeder-1",
+                                observed_at="2026-08-03T11:00:00Z",
+                            )
+                        },
+                    ],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+        with (
+            patch("inky_bird_frame.birdbuddy._graphql_request", return_value=page),
+            self.assertRaisesRegex(DataSourceError, "conflicting media records"),
+        ):
+            _fetch_confirmed_history(
+                "access-secret",
+                "feeder-1",
+                include_manual_sightings=False,
+            )
 
     def test_confirmed_history_rejects_malformed_selected_feeder_record(self) -> None:
         malformed = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
@@ -1023,6 +1077,76 @@ class BirdBuddyTests(unittest.TestCase):
         stored = history["feeders"]["feeder-1"]["postcards"][0]
         self.assertEqual(stored["media_ids"], ["media-1"])
         self.assertEqual(stored["species"], [])
+
+    def test_confirmed_media_recovers_same_sync_feed_tombstone_as_exact_postcard(self) -> None:
+        feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")
+        now = datetime(2026, 8, 3, 12, 0, tzinfo=UTC)
+        exact = postcard(
+            "postcard-exact",
+            now - timedelta(hours=2),
+            media_ids=("media-exact",),
+        )
+        tombstone = BirdBuddyPostcard(
+            "postcard-confirmed",
+            (now - timedelta(hours=1)).isoformat(),
+            (),
+            media_ids=("media-confirmed",),
+        )
+        evidence = ConfirmedSpeciesEvidence(
+            exact.species[0],
+            tombstone.observed_at,
+            "selected_feeder",
+        )
+        confirmed = _ConfirmedHistoryFetch(
+            [evidence],
+            1,
+            1,
+            1,
+            0,
+            0,
+            {"media-confirmed": exact.species},
+        )
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            with patch(
+                "inky_bird_frame.birdbuddy._authenticate",
+                return_value=("access", "refresh", [feeder]),
+            ):
+                login_birdbuddy(
+                    state_dir,
+                    email="birder@example.test",
+                    password="private-password",
+                    authorization_confirmed=True,
+                    now=now,
+                )
+            with (
+                patch(
+                    "inky_bird_frame.birdbuddy._refresh_access_token",
+                    return_value=("access", "replacement"),
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_postcards",
+                    return_value=([exact, tombstone], 2, 2, 1),
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_confirmed_history",
+                    return_value=confirmed,
+                ),
+            ):
+                result = sync_birdbuddy_detections(
+                    state_dir,
+                    window=ObservationWindow.ALL_TIME,
+                    limit=20,
+                    now=now,
+                )
+            history = json.loads((state_dir / "birdbuddy-detections.json").read_text())
+
+        self.assertEqual(result.species[0].detection_count, 2)
+        stored = {item["id"]: item for item in history["feeders"]["feeder-1"]["postcards"]}
+        self.assertEqual(
+            stored["postcard-confirmed"]["species"][0]["scientific_name"],
+            "Sialia sialis",
+        )
 
     def test_sync_discards_legacy_postcard_without_media_linkage(self) -> None:
         feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")
@@ -1580,7 +1704,11 @@ class BirdBuddyTests(unittest.TestCase):
                                 "id": original.postcard_id,
                                 "createdAt": original.observed_at,
                                 "inferenceConfidenceLevel": "HIGH_CONFIDENCE",
-                                "feeder": {"id": feeder.feeder_id},
+                                "feeder": {
+                                    "__typename": "FeederForMember",
+                                    "id": feeder.feeder_id,
+                                },
+                                "medias": [{"__typename": "MediaImage", "id": "media-1"}],
                                 "sightingReportPreview": None,
                             }
                         }

--- a/tests/test_birdbuddy.py
+++ b/tests/test_birdbuddy.py
@@ -502,6 +502,9 @@ class BirdBuddyTests(unittest.TestCase):
         malformed["species"] = [{"__typename": "SpeciesBird", "id": None}]
         missing_species_type = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
         missing_species_type["species"] = [{}]
+        missing_media_type = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
+        assert isinstance(missing_media_type["media"], dict)
+        missing_media_type["media"]["__typename"] = None
         missing_feeder = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
         missing_feeder["feeder"] = None
         unsupported_origin = confirmed_node(origin="UNKNOWN", feeder_id="feeder-1")
@@ -525,6 +528,12 @@ class BirdBuddyTests(unittest.TestCase):
         with self.assertRaisesRegex(DataSourceError, "record was incomplete"):
             _parse_confirmed_evidence(
                 missing_species_type,
+                "feeder-1",
+                include_manual_sightings=False,
+            )
+        with self.assertRaisesRegex(DataSourceError, "record was incomplete"):
+            _parse_confirmed_evidence(
+                missing_media_type,
                 "feeder-1",
                 include_manual_sightings=False,
             )

--- a/tests/test_birdbuddy.py
+++ b/tests/test_birdbuddy.py
@@ -265,6 +265,7 @@ class BirdBuddyTests(unittest.TestCase):
             {},
             {"sightings": None},
             {"sightings": [None]},
+            {"sightings": [{"__typename": None}]},
             {
                 "sightings": [
                     {

--- a/tests/test_birdbuddy.py
+++ b/tests/test_birdbuddy.py
@@ -9,12 +9,17 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from inky_bird_frame.birdbuddy import (
+    _CONFIRMED_HISTORY,
     _FEED_QUERIES,
     BirdBuddyFeeder,
     BirdBuddyPostcard,
+    ConfirmedSpeciesEvidence,
     PostcardSpecies,
+    _ConfirmedHistoryFetch,
+    _fetch_confirmed_history,
     _fetch_postcard_variant,
     _fetch_postcards,
+    _parse_confirmed_evidence,
     _parse_postcard,
     _refresh_access_token,
     birdbuddy_status,
@@ -55,7 +60,36 @@ def feed_node(
     }
 
 
+def confirmed_node(
+    *,
+    origin: str,
+    feeder_id: str,
+    observed_at: str = "2026-08-03T10:00:00Z",
+) -> dict[str, object]:
+    return {
+        "origin": origin,
+        "feeder": {"id": feeder_id},
+        "media": {"createdAt": observed_at},
+        "species": [
+            {
+                "__typename": "SpeciesBird",
+                "id": "species-hummingbird",
+                "name": "Ruby-throated Hummingbird",
+                "scientificName": "Archilochus colubris",
+            }
+        ],
+    }
+
+
 class BirdBuddyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        confirmed = patch(
+            "inky_bird_frame.birdbuddy._fetch_confirmed_history",
+            return_value=_ConfirmedHistoryFetch([], 1, 0, 0, 0, 0),
+        )
+        confirmed.start()
+        self.addCleanup(confirmed.stop)
+
     def test_feed_operation_is_read_only_and_metadata_only(self) -> None:
         self.assertEqual(len(_FEED_QUERIES), 2)
         combined = "\n".join(_FEED_QUERIES)
@@ -69,6 +103,10 @@ class BirdBuddyTests(unittest.TestCase):
             "feederUpdate",
         ):
             self.assertNotIn(forbidden, combined)
+        self.assertNotIn("mutation", _CONFIRMED_HISTORY.casefold())
+        self.assertIn("mediasOwned", _CONFIRMED_HISTORY)
+        for forbidden in ("contentUrl", "thumbnailUrl", "locationCity", "ownerName"):
+            self.assertNotIn(forbidden, _CONFIRMED_HISTORY)
 
     def test_login_requires_authorized_access_confirmation_before_network(self) -> None:
         with (
@@ -420,6 +458,116 @@ class BirdBuddyTests(unittest.TestCase):
         self.assertEqual(processed, 1)
         self.assertEqual(ignored, 1)
 
+    def test_confirmed_history_filters_by_provenance_and_selected_feeder(self) -> None:
+        selected = _parse_confirmed_evidence(
+            confirmed_node(origin="POSTCARD", feeder_id="feeder-1"),
+            "feeder-1",
+            include_manual_sightings=False,
+        )
+        other_feeder = _parse_confirmed_evidence(
+            confirmed_node(origin="POSTCARD", feeder_id="feeder-2"),
+            "feeder-1",
+            include_manual_sightings=True,
+        )
+        manual_disabled = _parse_confirmed_evidence(
+            confirmed_node(origin="CUSTOM_ID", feeder_id="manual"),
+            "feeder-1",
+            include_manual_sightings=False,
+        )
+        manual_enabled = _parse_confirmed_evidence(
+            confirmed_node(origin="CUSTOM_ID", feeder_id="manual"),
+            "feeder-1",
+            include_manual_sightings=True,
+        )
+        watching = _parse_confirmed_evidence(
+            confirmed_node(origin="WATCHING", feeder_id="feeder-1"),
+            "feeder-1",
+            include_manual_sightings=True,
+        )
+
+        self.assertEqual(selected[0].source, "selected_feeder")
+        self.assertEqual(selected[0].observed_at, "2026-08-03T10:00:00+00:00")
+        self.assertEqual(other_feeder, ())
+        self.assertEqual(manual_disabled, ())
+        self.assertEqual(manual_enabled[0].source, "manual")
+        self.assertEqual(watching, ())
+
+    def test_confirmed_history_paginates_and_keeps_newest_species_evidence(self) -> None:
+        first = {
+            "me": {
+                "mediasOwned": {
+                    "edges": [
+                        {
+                            "node": confirmed_node(
+                                origin="CUSTOM_ID",
+                                feeder_id="manual",
+                                observed_at="2026-08-03T09:00:00Z",
+                            )
+                        }
+                    ],
+                    "pageInfo": {"hasNextPage": True, "endCursor": "next"},
+                }
+            }
+        }
+        second = {
+            "me": {
+                "mediasOwned": {
+                    "edges": [
+                        {
+                            "node": confirmed_node(
+                                origin="CUSTOM_ID",
+                                feeder_id="manual",
+                                observed_at="2026-08-03T10:00:00Z",
+                            )
+                        },
+                        {
+                            "node": confirmed_node(
+                                origin="POSTCARD",
+                                feeder_id="another-feeder",
+                            )
+                        },
+                    ],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+        with patch(
+            "inky_bird_frame.birdbuddy._graphql_request",
+            side_effect=[first, second],
+        ):
+            result = _fetch_confirmed_history(
+                "access-secret",
+                "feeder-1",
+                include_manual_sightings=True,
+            )
+
+        self.assertEqual(result.pages, 2)
+        self.assertEqual(result.records_processed, 3)
+        self.assertEqual(result.records_accepted, 2)
+        self.assertEqual(result.manual_records_accepted, 2)
+        self.assertEqual(result.records_ignored, 1)
+        self.assertEqual(len(result.evidence), 1)
+        self.assertEqual(result.evidence[0].observed_at, "2026-08-03T10:00:00+00:00")
+
+    def test_confirmed_history_rejects_repeated_pagination_cursor(self) -> None:
+        page = {
+            "me": {
+                "mediasOwned": {
+                    "edges": [],
+                    "pageInfo": {"hasNextPage": True, "endCursor": "same"},
+                }
+            }
+        }
+        with (
+            patch("inky_bird_frame.birdbuddy._graphql_request", return_value=page),
+            self.assertRaisesRegex(DataSourceError, "repeated pagination cursor"),
+        ):
+            _fetch_confirmed_history(
+                "access-secret",
+                "feeder-1",
+                include_manual_sightings=False,
+            )
+
     def test_revoked_refresh_token_has_actionable_redacted_error(self) -> None:
         with (
             patch(
@@ -472,6 +620,192 @@ class BirdBuddyTests(unittest.TestCase):
             self.assertIn("second-refresh", auth_payload)
             self.assertNotIn("second-access", auth_payload)
             self.assertEqual(stat.S_IMODE(history_path.stat().st_mode), 0o600)
+
+    def test_manual_confirmed_history_is_opt_in_and_persisted_privately(self) -> None:
+        feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")
+        now = datetime(2026, 8, 3, 12, 0, tzinfo=UTC)
+        hummingbird = ConfirmedSpeciesEvidence(
+            PostcardSpecies(
+                "species-hummingbird",
+                "Ruby-throated Hummingbird",
+                "Archilochus colubris",
+            ),
+            "2026-08-03T10:00:00+00:00",
+            "manual",
+        )
+        confirmed = _ConfirmedHistoryFetch([hummingbird], 1, 1, 1, 1, 0)
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            with patch(
+                "inky_bird_frame.birdbuddy._authenticate",
+                return_value=("access", "refresh", [feeder]),
+            ):
+                login_birdbuddy(
+                    state_dir,
+                    email="birder@example.test",
+                    password="private-password",
+                    authorization_confirmed=True,
+                    now=now,
+                )
+            with (
+                patch(
+                    "inky_bird_frame.birdbuddy._refresh_access_token",
+                    return_value=("access", "replacement"),
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_postcards",
+                    return_value=([], 2, 0, 0),
+                ),
+            ):
+                with patch(
+                    "inky_bird_frame.birdbuddy._fetch_confirmed_history",
+                    return_value=confirmed,
+                ):
+                    included = sync_birdbuddy_detections(
+                        state_dir,
+                        window=ObservationWindow.LAST_DAY,
+                        limit=20,
+                        now=now,
+                        include_manual_sightings=True,
+                    )
+                excluded = sync_birdbuddy_detections(
+                    state_dir,
+                    window=ObservationWindow.LAST_DAY,
+                    limit=20,
+                    now=now,
+                    include_manual_sightings=False,
+                )
+            included_status = birdbuddy_status(state_dir, include_manual_sightings=True)
+            excluded_status = birdbuddy_status(state_dir)
+            history_path = state_dir / "birdbuddy-detections.json"
+            history_payload = history_path.read_text()
+            history_permissions = stat.S_IMODE(history_path.stat().st_mode)
+
+        self.assertEqual(len(included.species), 1)
+        self.assertEqual(included.species[0].scientific_name, "Archilochus colubris")
+        self.assertEqual(included.species[0].detection_count, 1)
+        self.assertEqual(included.stats.manual_records_accepted, 1)
+        self.assertEqual(excluded.species, [])
+        self.assertEqual(history_permissions, 0o600)
+        self.assertIn('"source": "manual"', history_payload)
+        self.assertNotIn("access", history_payload)
+        included_history = included_status["history"]
+        excluded_history = excluded_status["history"]
+        assert isinstance(included_history, dict)
+        assert isinstance(excluded_history, dict)
+        self.assertEqual(included_history["latest_detection_at"], "2026-08-03T10:00:00+00:00")
+        self.assertIsNone(excluded_history["latest_detection_at"])
+
+    def test_confirmed_history_does_not_inflate_exact_postcard_count(self) -> None:
+        feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")
+        now = datetime(2026, 8, 3, 12, 0, tzinfo=UTC)
+        exact = postcard("postcard-1", now - timedelta(hours=2))
+        confirmed = ConfirmedSpeciesEvidence(
+            exact.species[0],
+            (now - timedelta(hours=1)).isoformat(),
+            "selected_feeder",
+        )
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            with patch(
+                "inky_bird_frame.birdbuddy._authenticate",
+                return_value=("access", "refresh", [feeder]),
+            ):
+                login_birdbuddy(
+                    state_dir,
+                    email="birder@example.test",
+                    password="private-password",
+                    authorization_confirmed=True,
+                    now=now,
+                )
+            with (
+                patch(
+                    "inky_bird_frame.birdbuddy._refresh_access_token",
+                    return_value=("access", "replacement"),
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_postcards",
+                    return_value=([exact], 2, 1, 0),
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_confirmed_history",
+                    return_value=_ConfirmedHistoryFetch([confirmed], 1, 1, 1, 0, 0),
+                ),
+            ):
+                result = sync_birdbuddy_detections(
+                    state_dir,
+                    window=ObservationWindow.LAST_DAY,
+                    limit=20,
+                    now=now,
+                )
+
+        self.assertEqual(result.species[0].detection_count, 1)
+        self.assertEqual(
+            result.species[0].latest_detection_at,
+            (now - timedelta(hours=1)).isoformat(),
+        )
+
+    def test_complete_confirmed_snapshot_removes_stale_manual_evidence(self) -> None:
+        feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")
+        now = datetime(2026, 8, 3, 12, 0, tzinfo=UTC)
+        hummingbird = ConfirmedSpeciesEvidence(
+            PostcardSpecies(
+                "species-hummingbird",
+                "Ruby-throated Hummingbird",
+                "Archilochus colubris",
+            ),
+            "2026-08-03T10:00:00+00:00",
+            "manual",
+        )
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            with patch(
+                "inky_bird_frame.birdbuddy._authenticate",
+                return_value=("access", "refresh", [feeder]),
+            ):
+                login_birdbuddy(
+                    state_dir,
+                    email="birder@example.test",
+                    password="private-password",
+                    authorization_confirmed=True,
+                    now=now,
+                )
+            with (
+                patch(
+                    "inky_bird_frame.birdbuddy._refresh_access_token",
+                    return_value=("access", "replacement"),
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_postcards",
+                    return_value=([], 2, 0, 0),
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_confirmed_history",
+                    side_effect=[
+                        _ConfirmedHistoryFetch([hummingbird], 1, 1, 1, 1, 0),
+                        _ConfirmedHistoryFetch([], 1, 0, 0, 0, 0),
+                    ],
+                ),
+            ):
+                first = sync_birdbuddy_detections(
+                    state_dir,
+                    window=ObservationWindow.ALL_TIME,
+                    limit=20,
+                    now=now,
+                    include_manual_sightings=True,
+                )
+                removed = sync_birdbuddy_detections(
+                    state_dir,
+                    window=ObservationWindow.ALL_TIME,
+                    limit=20,
+                    now=now + timedelta(minutes=15),
+                    include_manual_sightings=True,
+                )
+            history = json.loads((state_dir / "birdbuddy-detections.json").read_text())
+
+        self.assertEqual(len(first.species), 1)
+        self.assertEqual(removed.species, [])
+        self.assertEqual(history["feeders"]["feeder-1"]["confirmed_species"], [])
 
     def test_preview_sync_does_not_persist_detection_history(self) -> None:
         feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")

--- a/tests/test_birdbuddy.py
+++ b/tests/test_birdbuddy.py
@@ -500,6 +500,8 @@ class BirdBuddyTests(unittest.TestCase):
         )
         malformed = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
         malformed["species"] = [{"__typename": "SpeciesBird", "id": None}]
+        missing_species_type = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
+        missing_species_type["species"] = [{}]
         missing_feeder = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
         missing_feeder["feeder"] = None
         unsupported_origin = confirmed_node(origin="UNKNOWN", feeder_id="feeder-1")
@@ -517,6 +519,12 @@ class BirdBuddyTests(unittest.TestCase):
         with self.assertRaisesRegex(DataSourceError, "record was incomplete"):
             _parse_confirmed_evidence(
                 malformed,
+                "feeder-1",
+                include_manual_sightings=False,
+            )
+        with self.assertRaisesRegex(DataSourceError, "record was incomplete"):
+            _parse_confirmed_evidence(
+                missing_species_type,
                 "feeder-1",
                 include_manual_sightings=False,
             )
@@ -989,6 +997,7 @@ class BirdBuddyTests(unittest.TestCase):
                     limit=20,
                     now=now + timedelta(minutes=5),
                 )
+            status = birdbuddy_status(state_dir)
             history = json.loads((state_dir / "birdbuddy-detections.json").read_text())
 
         self.assertEqual(
@@ -999,6 +1008,9 @@ class BirdBuddyTests(unittest.TestCase):
         self.assertEqual(corrected.stats.reclassified_postcards, 1)
         self.assertEqual(removed.species, [])
         self.assertEqual(removed.stats.reclassified_postcards, 1)
+        status_history = status["history"]
+        assert isinstance(status_history, dict)
+        self.assertIsNone(status_history["latest_detection_at"])
         stored = history["feeders"]["feeder-1"]["postcards"][0]
         self.assertEqual(stored["media_ids"], ["media-1"])
         self.assertEqual(stored["species"], [])

--- a/tests/test_birdbuddy.py
+++ b/tests/test_birdbuddy.py
@@ -26,6 +26,7 @@ from inky_bird_frame.birdbuddy import (
     _parse_postcard,
     _reconcile_archived_postcards,
     _refresh_access_token,
+    _sync_lock,
     birdbuddy_status,
     login_birdbuddy,
     logout_birdbuddy,
@@ -329,6 +330,12 @@ class BirdBuddyTests(unittest.TestCase):
         assert parsed_low_confidence is not None
         self.assertFalse(parsed_low_confidence.complete)
 
+        missing_confidence = {**node, "inferenceConfidenceLevel": None}
+        parsed_missing_confidence = _parse_postcard(missing_confidence, "feeder-1")
+        self.assertIsNotNone(parsed_missing_confidence)
+        assert parsed_missing_confidence is not None
+        self.assertFalse(parsed_missing_confidence.complete)
+
     def test_feed_rejects_repeated_pagination_cursor(self) -> None:
         page = {
             "me": {
@@ -390,6 +397,78 @@ class BirdBuddyTests(unittest.TestCase):
                 _FEED_QUERIES[0],
                 "SightingRecognizedBird",
             )
+
+    def test_feed_rejects_malformed_duplicate_across_query_variants(self) -> None:
+        sighting = {
+            "__typename": "SightingRecognizedBird",
+            "species": {
+                "__typename": "SpeciesBird",
+                "id": "species-bluebird",
+                "name": "Eastern Bluebird",
+                "scientificName": "Sialia sialis",
+            },
+        }
+        malformed = feed_node(sighting)
+        malformed["createdAt"] = None
+        responses = [
+            {
+                "me": {
+                    "feed": {
+                        "edges": [{"node": feed_node(sighting)}],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            },
+            {
+                "me": {
+                    "feed": {
+                        "edges": [{"node": malformed}],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            },
+        ]
+        with (
+            patch("inky_bird_frame.birdbuddy._graphql_request", side_effect=responses),
+            self.assertRaisesRegex(DataSourceError, "invalid duplicate postcard"),
+        ):
+            _fetch_postcards("access-secret", "feeder-1")
+
+    def test_feed_rejects_confidence_mismatch_across_query_variants(self) -> None:
+        sighting = {
+            "__typename": "SightingRecognizedBird",
+            "species": {
+                "__typename": "SpeciesBird",
+                "id": "species-bluebird",
+                "name": "Eastern Bluebird",
+                "scientificName": "Sialia sialis",
+            },
+        }
+        low_confidence = feed_node(sighting)
+        low_confidence["inferenceConfidenceLevel"] = "LOW_CONFIDENCE"
+        responses = [
+            {
+                "me": {
+                    "feed": {
+                        "edges": [{"node": feed_node(sighting)}],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            },
+            {
+                "me": {
+                    "feed": {
+                        "edges": [{"node": low_confidence}],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            },
+        ]
+        with (
+            patch("inky_bird_frame.birdbuddy._graphql_request", side_effect=responses),
+            self.assertRaisesRegex(DataSourceError, "inconsistent postcard confidence levels"),
+        ):
+            _fetch_postcards("access-secret", "feeder-1")
 
     def test_first_feed_page_omits_null_cursor(self) -> None:
         page = {
@@ -828,6 +907,38 @@ class BirdBuddyTests(unittest.TestCase):
                 include_manual_sightings=True,
             )
 
+    def test_confirmed_history_rejects_species_identity_conflicts_across_media(self) -> None:
+        manual = confirmed_node(
+            origin="CUSTOM_ID",
+            feeder_id="manual",
+            media_id="media-2",
+        )
+        species = manual["species"]
+        assert isinstance(species, list)
+        conflicting = species[0]
+        assert isinstance(conflicting, dict)
+        conflicting["name"] = "Conflicting Hummingbird"
+        page = {
+            "me": {
+                "mediasOwned": {
+                    "edges": [
+                        {"node": confirmed_node(origin="POSTCARD", feeder_id="feeder-1")},
+                        {"node": manual},
+                    ],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+        with (
+            patch("inky_bird_frame.birdbuddy._graphql_request", return_value=page),
+            self.assertRaisesRegex(DataSourceError, "conflicting species identities"),
+        ):
+            _fetch_confirmed_history(
+                "access-secret",
+                "feeder-1",
+                include_manual_sightings=True,
+            )
+
     def test_confirmed_history_rejects_malformed_selected_feeder_record(self) -> None:
         malformed = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
         malformed["species"] = [{"__typename": "SpeciesBird", "id": None}]
@@ -920,6 +1031,24 @@ class BirdBuddyTests(unittest.TestCase):
             self.assertIn("second-refresh", auth_payload)
             self.assertNotIn("second-access", auth_payload)
             self.assertEqual(stat.S_IMODE(history_path.stat().st_mode), 0o600)
+
+    def test_persistent_sync_rejects_overlapping_fetch_and_commit_transaction(self) -> None:
+        feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            with (
+                _sync_lock(state_dir),
+                patch(
+                    "inky_bird_frame.birdbuddy._refreshed_access_token",
+                    return_value=("access", feeder),
+                ),
+                self.assertRaisesRegex(DataSourceError, "sync is already running"),
+            ):
+                sync_birdbuddy_detections(
+                    state_dir,
+                    window=ObservationWindow.ALL_TIME,
+                    limit=20,
+                )
 
     def test_malformed_confirmed_snapshot_preserves_detection_history(self) -> None:
         feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")

--- a/tests/test_birdbuddy.py
+++ b/tests/test_birdbuddy.py
@@ -500,6 +500,9 @@ class BirdBuddyTests(unittest.TestCase):
         )
         malformed = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
         malformed["species"] = [{"__typename": "SpeciesBird", "id": None}]
+        missing_feeder = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
+        missing_feeder["feeder"] = None
+        unsupported_origin = confirmed_node(origin="UNKNOWN", feeder_id="feeder-1")
 
         assert selected is not None
         assert manual_enabled is not None
@@ -511,13 +514,24 @@ class BirdBuddyTests(unittest.TestCase):
         self.assertIsNone(manual_disabled)
         self.assertEqual(manual_enabled.source, "manual")
         self.assertIsNone(watching)
-        self.assertIsNone(
+        with self.assertRaisesRegex(DataSourceError, "record was incomplete"):
             _parse_confirmed_evidence(
                 malformed,
                 "feeder-1",
                 include_manual_sightings=False,
             )
-        )
+        with self.assertRaisesRegex(DataSourceError, "record was incomplete"):
+            _parse_confirmed_evidence(
+                missing_feeder,
+                "feeder-1",
+                include_manual_sightings=False,
+            )
+        with self.assertRaisesRegex(DataSourceError, "unsupported origin"):
+            _parse_confirmed_evidence(
+                unsupported_origin,
+                "feeder-1",
+                include_manual_sightings=False,
+            )
 
     def test_confirmed_history_paginates_and_keeps_newest_species_evidence(self) -> None:
         first = {
@@ -614,6 +628,27 @@ class BirdBuddyTests(unittest.TestCase):
         self.assertEqual(result.species_by_media["media-2"], ())
         self.assertEqual(result.records_accepted, 2)
 
+    def test_confirmed_history_rejects_malformed_selected_feeder_record(self) -> None:
+        malformed = confirmed_node(origin="POSTCARD", feeder_id="feeder-1")
+        malformed["species"] = [{"__typename": "SpeciesBird", "id": None}]
+        page = {
+            "me": {
+                "mediasOwned": {
+                    "edges": [{"node": malformed}],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+        with (
+            patch("inky_bird_frame.birdbuddy._graphql_request", return_value=page),
+            self.assertRaisesRegex(DataSourceError, "record was incomplete"),
+        ):
+            _fetch_confirmed_history(
+                "access-secret",
+                "feeder-1",
+                include_manual_sightings=False,
+            )
+
     def test_confirmed_history_rejects_repeated_pagination_cursor(self) -> None:
         page = {
             "me": {
@@ -685,6 +720,75 @@ class BirdBuddyTests(unittest.TestCase):
             self.assertIn("second-refresh", auth_payload)
             self.assertNotIn("second-access", auth_payload)
             self.assertEqual(stat.S_IMODE(history_path.stat().st_mode), 0o600)
+
+    def test_malformed_confirmed_snapshot_preserves_detection_history(self) -> None:
+        feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")
+        now = datetime(2026, 8, 3, 12, 0, tzinfo=UTC)
+        confirmed = _ConfirmedHistoryFetch(
+            [
+                ConfirmedSpeciesEvidence(
+                    PostcardSpecies(
+                        "species-hummingbird",
+                        "Ruby-throated Hummingbird",
+                        "Archilochus colubris",
+                    ),
+                    "2026-08-03T10:00:00+00:00",
+                    "selected_feeder",
+                )
+            ],
+            1,
+            1,
+            1,
+            0,
+            0,
+        )
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            with patch(
+                "inky_bird_frame.birdbuddy._authenticate",
+                return_value=("access", "refresh", [feeder]),
+            ):
+                login_birdbuddy(
+                    state_dir,
+                    email="birder@example.test",
+                    password="private-password",
+                    authorization_confirmed=True,
+                    now=now,
+                )
+            with (
+                patch(
+                    "inky_bird_frame.birdbuddy._refresh_access_token",
+                    return_value=("access", "replacement"),
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_postcards",
+                    return_value=([], 1, 0, 0),
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_confirmed_history",
+                    side_effect=[
+                        confirmed,
+                        DataSourceError("Bird Buddy confirmed history record was incomplete"),
+                    ],
+                ),
+            ):
+                sync_birdbuddy_detections(
+                    state_dir,
+                    window=ObservationWindow.ALL_TIME,
+                    limit=20,
+                    now=now,
+                )
+                history_path = state_dir / "birdbuddy-detections.json"
+                before = history_path.read_bytes()
+                with self.assertRaisesRegex(DataSourceError, "record was incomplete"):
+                    sync_birdbuddy_detections(
+                        state_dir,
+                        window=ObservationWindow.ALL_TIME,
+                        limit=20,
+                        now=now + timedelta(minutes=5),
+                    )
+
+            self.assertEqual(history_path.read_bytes(), before)
 
     def test_manual_confirmed_history_is_opt_in_and_persisted_privately(self) -> None:
         feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")
@@ -965,6 +1069,80 @@ class BirdBuddyTests(unittest.TestCase):
         self.assertEqual(result.species, [])
         self.assertEqual(migrated["feeders"]["feeder-1"]["postcards"], [])
 
+    def test_sync_preserves_inactive_feeder_legacy_postcards(self) -> None:
+        selected_feeder = BirdBuddyFeeder("feeder-2", "Patio feeder", "member")
+        now = datetime(2026, 8, 3, 12, 0, tzinfo=UTC)
+
+        def legacy_history(postcard_id: str) -> dict[str, object]:
+            observed_at = (now - timedelta(hours=2)).isoformat()
+            return {
+                "history_started_at": now.isoformat(),
+                "earliest_initial_feed_at": observed_at,
+                "last_successful_sync_at": now.isoformat(),
+                "postcards": [
+                    {
+                        "id": postcard_id,
+                        "observed_at": observed_at,
+                        "species": [
+                            {
+                                "id": "species-bluebird",
+                                "common_name": "Eastern Bluebird",
+                                "scientific_name": "Sialia sialis",
+                            }
+                        ],
+                    }
+                ],
+                "archived_species": {},
+                "confirmed_species": [],
+            }
+
+        payload = {
+            "schema_version": 1,
+            "feeders": {
+                "feeder-1": legacy_history("postcard-1"),
+                "feeder-2": legacy_history("postcard-2"),
+            },
+        }
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            with patch(
+                "inky_bird_frame.birdbuddy._authenticate",
+                return_value=("access", "refresh", [selected_feeder]),
+            ):
+                login_birdbuddy(
+                    state_dir,
+                    email="birder@example.test",
+                    password="private-password",
+                    authorization_confirmed=True,
+                    now=now,
+                )
+            history_path = state_dir / "birdbuddy-detections.json"
+            history_path.write_text(json.dumps(payload))
+            history_path.chmod(0o600)
+            with (
+                patch(
+                    "inky_bird_frame.birdbuddy._refresh_access_token",
+                    return_value=("access", "replacement"),
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_postcards",
+                    return_value=([], 2, 0, 0),
+                ),
+            ):
+                sync_birdbuddy_detections(
+                    state_dir,
+                    window=ObservationWindow.ALL_TIME,
+                    limit=20,
+                    now=now + timedelta(minutes=5),
+                )
+            migrated = json.loads(history_path.read_text())
+
+        self.assertEqual(
+            migrated["feeders"]["feeder-1"]["postcards"][0]["id"],
+            "postcard-1",
+        )
+        self.assertEqual(migrated["feeders"]["feeder-2"]["postcards"], [])
+
     def test_confirmed_media_reclassifies_archived_postcard_totals(self) -> None:
         feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")
         now = datetime(2026, 8, 3, 12, 0, tzinfo=UTC)
@@ -1062,6 +1240,96 @@ class BirdBuddyTests(unittest.TestCase):
             archived_state["archived_postcards"][0]["species_ids"],
             ["species-cardinal"],
         )
+
+    def test_archived_reclassification_recomputes_latest_detection(self) -> None:
+        feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")
+        now = datetime(2026, 8, 3, 12, 0, tzinfo=UTC)
+        older = postcard(
+            "postcard-older",
+            now - timedelta(days=368),
+            media_ids=("media-older",),
+        )
+        newer = postcard(
+            "postcard-newer",
+            now - timedelta(days=367),
+            media_ids=("media-newer",),
+        )
+        corrected_species = PostcardSpecies(
+            "species-cardinal",
+            "Northern Cardinal",
+            "Cardinalis cardinalis",
+        )
+        original_confirmed = _ConfirmedHistoryFetch(
+            [],
+            1,
+            1,
+            1,
+            0,
+            0,
+            {"media-newer": newer.species},
+        )
+        corrected_confirmed = _ConfirmedHistoryFetch(
+            [],
+            1,
+            1,
+            1,
+            0,
+            0,
+            {"media-newer": (corrected_species,)},
+        )
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            with patch(
+                "inky_bird_frame.birdbuddy._authenticate",
+                return_value=("access", "refresh", [feeder]),
+            ):
+                login_birdbuddy(
+                    state_dir,
+                    email="birder@example.test",
+                    password="private-password",
+                    authorization_confirmed=True,
+                    now=now,
+                )
+            with (
+                patch(
+                    "inky_bird_frame.birdbuddy._refresh_access_token",
+                    return_value=("access", "replacement"),
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_postcards",
+                    side_effect=[([older, newer], 2, 2, 0), ([], 2, 0, 0)],
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_confirmed_history",
+                    side_effect=[original_confirmed, corrected_confirmed],
+                ),
+            ):
+                before = sync_birdbuddy_detections(
+                    state_dir,
+                    window=ObservationWindow.ALL_TIME,
+                    limit=20,
+                    now=now,
+                )
+                after = sync_birdbuddy_detections(
+                    state_dir,
+                    window=ObservationWindow.ALL_TIME,
+                    limit=20,
+                    now=now + timedelta(minutes=5),
+                )
+
+        before_by_name = {item.scientific_name: item for item in before.species}
+        after_by_name = {item.scientific_name: item for item in after.species}
+        self.assertEqual(before_by_name["Sialia sialis"].detection_count, 2)
+        self.assertEqual(
+            before_by_name["Sialia sialis"].latest_detection_at,
+            newer.observed_at,
+        )
+        self.assertEqual(after_by_name["Sialia sialis"].detection_count, 1)
+        self.assertEqual(
+            after_by_name["Sialia sialis"].latest_detection_at,
+            older.observed_at,
+        )
+        self.assertEqual(after_by_name["Cardinalis cardinalis"].detection_count, 1)
 
     def test_complete_confirmed_snapshot_removes_stale_manual_evidence(self) -> None:
         feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")

--- a/tests/test_birdbuddy.py
+++ b/tests/test_birdbuddy.py
@@ -37,11 +37,13 @@ def postcard(
     species_id: str = "species-bluebird",
     common_name: str = "Eastern Bluebird",
     scientific_name: str = "Sialia sialis",
+    media_ids: tuple[str, ...] = (),
 ) -> BirdBuddyPostcard:
     return BirdBuddyPostcard(
         postcard_id,
         observed_at.astimezone(UTC).replace(microsecond=0).isoformat(),
         (PostcardSpecies(species_id, common_name, scientific_name),),
+        media_ids=media_ids,
     )
 
 
@@ -49,6 +51,7 @@ def feed_node(
     *sightings: object,
     postcard_id: str = "postcard-1",
     observed_at: str = "2026-08-03T10:00:00+00:00",
+    media_ids: tuple[str, ...] = ("media-1",),
 ) -> dict[str, object]:
     return {
         "__typename": "FeedItemNewPostcard",
@@ -56,6 +59,7 @@ def feed_node(
         "createdAt": observed_at,
         "inferenceConfidenceLevel": "HIGH_CONFIDENCE",
         "feeder": {"id": "feeder-1"},
+        "medias": [{"__typename": "MediaImage", "id": media_id} for media_id in media_ids],
         "sightingReportPreview": {"sightings": list(sightings)},
     }
 
@@ -65,11 +69,12 @@ def confirmed_node(
     origin: str,
     feeder_id: str,
     observed_at: str = "2026-08-03T10:00:00Z",
+    media_id: str = "media-1",
 ) -> dict[str, object]:
     return {
         "origin": origin,
         "feeder": {"id": feeder_id},
-        "media": {"createdAt": observed_at},
+        "media": {"__typename": "MediaImage", "id": media_id, "createdAt": observed_at},
         "species": [
             {
                 "__typename": "SpeciesBird",
@@ -95,6 +100,7 @@ class BirdBuddyTests(unittest.TestCase):
         combined = "\n".join(_FEED_QUERIES)
         self.assertNotIn("mutation", combined.casefold())
         self.assertEqual(combined.count("species {"), 2)
+        self.assertEqual(combined.count("medias { __typename id }"), 2)
         for forbidden in (
             "contentUrl",
             "sightingCreateFromPostcard",
@@ -105,6 +111,14 @@ class BirdBuddyTests(unittest.TestCase):
             self.assertNotIn(forbidden, combined)
         self.assertNotIn("mutation", _CONFIRMED_HISTORY.casefold())
         self.assertIn("mediasOwned", _CONFIRMED_HISTORY)
+        self.assertIn("media { __typename id createdAt }", _CONFIRMED_HISTORY)
+        for feeder_type in (
+            "FeederForMember",
+            "FeederForOwner",
+            "FeederForPublic",
+            "FeederForRemoteGuest",
+        ):
+            self.assertIn(f"... on {feeder_type} {{ id }}", _CONFIRMED_HISTORY)
         for forbidden in ("contentUrl", "thumbnailUrl", "locationCity", "ownerName"):
             self.assertNotIn(forbidden, _CONFIRMED_HISTORY)
 
@@ -487,6 +501,7 @@ class BirdBuddyTests(unittest.TestCase):
 
         self.assertEqual(selected[0].source, "selected_feeder")
         self.assertEqual(selected[0].observed_at, "2026-08-03T10:00:00+00:00")
+        self.assertEqual(selected[0].media_id, "media-1")
         self.assertEqual(other_feeder, ())
         self.assertEqual(manual_disabled, ())
         self.assertEqual(manual_enabled[0].source, "manual")
@@ -548,6 +563,35 @@ class BirdBuddyTests(unittest.TestCase):
         self.assertEqual(result.records_ignored, 1)
         self.assertEqual(len(result.evidence), 1)
         self.assertEqual(result.evidence[0].observed_at, "2026-08-03T10:00:00+00:00")
+
+    def test_confirmed_history_links_selected_feeder_species_by_media(self) -> None:
+        page = {
+            "me": {
+                "mediasOwned": {
+                    "edges": [
+                        {
+                            "node": confirmed_node(
+                                origin="POSTCARD",
+                                feeder_id="feeder-1",
+                                media_id="media-1",
+                            )
+                        }
+                    ],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+        with patch("inky_bird_frame.birdbuddy._graphql_request", return_value=page):
+            result = _fetch_confirmed_history(
+                "access-secret",
+                "feeder-1",
+                include_manual_sightings=False,
+            )
+
+        self.assertEqual(
+            result.species_by_media["media-1"][0].scientific_name,
+            "Archilochus colubris",
+        )
 
     def test_confirmed_history_rejects_repeated_pagination_cursor(self) -> None:
         page = {
@@ -744,6 +788,79 @@ class BirdBuddyTests(unittest.TestCase):
             result.species[0].latest_detection_at,
             (now - timedelta(hours=1)).isoformat(),
         )
+
+    def test_confirmed_media_reclassifies_linked_cached_postcard(self) -> None:
+        feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")
+        now = datetime(2026, 8, 3, 12, 0, tzinfo=UTC)
+        preview = postcard(
+            "postcard-1",
+            now - timedelta(hours=2),
+            media_ids=("media-1",),
+        )
+        corrected_species = PostcardSpecies(
+            "species-cardinal",
+            "Northern Cardinal",
+            "Cardinalis cardinalis",
+        )
+        confirmed_evidence = ConfirmedSpeciesEvidence(
+            corrected_species,
+            (now - timedelta(hours=1)).isoformat(),
+            "selected_feeder",
+            "media-1",
+        )
+        confirmed = _ConfirmedHistoryFetch(
+            [confirmed_evidence],
+            1,
+            1,
+            1,
+            0,
+            0,
+            {"media-1": (corrected_species,)},
+        )
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            with patch(
+                "inky_bird_frame.birdbuddy._authenticate",
+                return_value=("access", "refresh", [feeder]),
+            ):
+                login_birdbuddy(
+                    state_dir,
+                    email="birder@example.test",
+                    password="private-password",
+                    authorization_confirmed=True,
+                    now=now,
+                )
+            with (
+                patch(
+                    "inky_bird_frame.birdbuddy._refresh_access_token",
+                    return_value=("access", "replacement"),
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_postcards",
+                    return_value=([preview], 2, 1, 0),
+                ),
+                patch(
+                    "inky_bird_frame.birdbuddy._fetch_confirmed_history",
+                    return_value=confirmed,
+                ),
+            ):
+                result = sync_birdbuddy_detections(
+                    state_dir,
+                    window=ObservationWindow.LAST_DAY,
+                    limit=20,
+                    now=now,
+                )
+            history = json.loads((state_dir / "birdbuddy-detections.json").read_text())
+
+        self.assertEqual(
+            [item.scientific_name for item in result.species],
+            ["Cardinalis cardinalis"],
+        )
+        self.assertEqual(result.species[0].detection_count, 1)
+        self.assertEqual(result.stats.reclassified_postcards, 1)
+        stored = history["feeders"]["feeder-1"]["postcards"][0]
+        self.assertEqual(stored["media_ids"], ["media-1"])
+        self.assertEqual(stored["species"][0]["id"], "species-cardinal")
 
     def test_complete_confirmed_snapshot_removes_stale_manual_evidence(self) -> None:
         feeder = BirdBuddyFeeder("feeder-1", "Garden feeder", "member")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -217,6 +217,19 @@ class ConfigTests(unittest.TestCase):
             config = load_config(path)
 
         self.assertEqual(config.discovery.sources, (DiscoveryProvider.BIRDBUDDY,))
+        self.assertFalse(config.discovery.birdbuddy_include_manual_sightings)
+
+    def test_birdbuddy_manual_sightings_are_explicitly_opted_in(self) -> None:
+        configured = CONFIG.replace(
+            "[discovery]\n",
+            '[discovery]\nsources = ["birdbuddy"]\nbirdbuddy_include_manual_sightings = true\n',
+        )
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(configured)
+            config = load_config(path)
+
+        self.assertTrue(config.discovery.birdbuddy_include_manual_sightings)
 
     def test_legacy_all_source_does_not_implicitly_enable_birdbuddy(self) -> None:
         configured = CONFIG.replace(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -191,6 +191,7 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(result.species, [resolved])
         self.assertEqual(result.providers[0].details, stats.as_dict())
         self.assertEqual(sync.call_args.kwargs["window"], ObservationWindow.LAST_WEEK)
+        self.assertFalse(sync.call_args.kwargs["include_manual_sightings"])
         location.assert_not_called()
 
     def test_birdbuddy_failure_does_not_block_other_provider(self) -> None:


### PR DESCRIPTION
## Summary

- reconcile Bird Buddy confirmed-history metadata with the short-lived postcard feed
- add a default-off option for manually added sightings while always excluding watching-list records
- preserve exact postcard counts and use confirmed history only as conservative presence and latest-time evidence
- document provenance, privacy, deployment, and all-time-history semantics

## Configuration

Set `birdbuddy_include_manual_sightings = true` under `[discovery]` to include Bird Buddy records whose origin is `CUSTOM_ID`. The default remains false.

## Validation

- Ruff format/check
- strict MyPy
- 463 tests plus 26 subtests
- catalog validation: 108 species
- package build
- actionlint
- live authorized account: default-off excluded the manual record; opt-in returned Ruby-throated Hummingbird with count 1

Live validation used `persist_history=False`; it did not write detection history.