### PR TITLE
Release version 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.2.8"
+version = "0.3.0"
 description = "Generate and display reusable bird field-journal plates"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/inky_bird_frame/__init__.py
+++ b/src/inky_bird_frame/__init__.py
@@ -1,3 +1,3 @@
 """Local bird field-journal plates for Pimoroni Inky displays."""
 
-__version__ = "0.2.8"
+__version__ = "0.3.0"

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.2.8"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary

- bump the package and runtime version to 0.3.0
- release the opt-in read-only Bird Buddy provider and confirmed-history reconciliation
- include the recent BirdWeather observability, review-gate, documentation, and catalog work
- preserve configuration compatibility; manual Bird Buddy sightings remain default-off

## Live validation

The Bird Buddy work was deployed from merged main before this version bump. An authorized account verified the confirmed-manual path and the broad-taxonomy negative path. Non-species records were ignored without affecting other providers, credentials continued rotating across restarts, scheduled refreshes remained healthy, and no private observation data was published.

The seven-day retention observation continues after release. The provider is opt-in, read-only, unsupported by Bird Buddy, and isolated from other discovery sources.

## Validation

- uv sync --extra dev --locked
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy
- uv run pytest: 480 passed, 26 subtests passed
- uv run inky-bird-frame catalog validate --catalog catalog: 109 species
- workflow action pinning check
- actionlint
- shellcheck deploy/*.sh
- package and runtime version consistency
- uv build
- git diff --check

## Release scope

This PR changes version metadata only. The functional changes were separately reviewed, merged, deployed, and live-verified.