### PR TITLE
Keep retried observations eligible

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -194,11 +194,13 @@ unchanged. The next scheduled cycle retries from the current remote branch.
 | eligible | No terminal state exists | Yes |
 
 `retry TAXON_ID` archives incomplete pending, rejected, or failed state and
-makes that taxon eligible. For failed quality reviews, it retains the final actionable
-corrections as durable input to the first new generation attempt while
-preserving cached research and references. Add `--refresh-research` when those
-inputs themselves need to be replaced. Invalid approval debris is archived and
-removed from the local index and active catalog before regeneration; a fully
+makes that taxon eligible. A validated identity recovered from retained state is
+also added to the generation queue, so eligibility survives the original
+observation window. For failed quality reviews, retry retains the final
+actionable corrections as durable input to the first new generation attempt
+while preserving cached research and references. Add `--refresh-research` when
+those inputs themselves need to be replaced. Invalid approval debris is archived
+and removed from the local index and active catalog before regeneration; a fully
 valid approved entry remains protected. `retry TAXON_ID --source-attempt N` additionally
 selects a retained portrait as the edit base. The archive-relative source path
 stays in private retry state, and the passing manifest records its SHA-256 for

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,9 +91,11 @@ and require consistent proportions across the primary specimen and anatomical
 studies without encoding an arbitrary universal ratio.
 
 Transient per-taxon failures are written to a durable retry schedule with capped
-exponential backoff. Deferred taxa are skipped without consuming the successful
-generation quota, and the cycle scans later work up to a separate configured
-attempt cap. Shared catalog or state corruption still fails closed.
+exponential backoff. Each record retains the species identity needed for an
+explicit retry even when failure occurs before profile creation and the original
+observation later expires. Deferred taxa are skipped without consuming the
+successful generation quota, and the cycle scans later work up to a separate
+configured attempt cap. Shared catalog or state corruption still fails closed.
 
 Notification delivery is an independent durable outbox. Application state is
 committed first, each destination is acknowledged separately, and provider

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -359,10 +359,11 @@ only; they never enter the approved catalog or rotation.
   artifacts and use `retry TAXON_ID --source-attempt N` when a specific attempt
   is a strong edit base. The command archives that portrait, refreshes cached
   references and profile data only when `--refresh-research` is also supplied,
-  and preserves the selected attempt's corrections for the first edit. By
-  default, validated research and references are reused. Omit `--source-attempt`
-  when no retained image should be reused. Transient source failures retain the
-  guidance and edit source until
+  preserves the selected attempt's corrections for the first edit, and keeps
+  the validated retained identity in the generation queue if the original
+  observation later expires. By default, validated research and references are
+  reused. Omit `--source-attempt` when no retained image should be reused.
+  Transient source failures retain the guidance and edit source until
   generation reaches a successful or terminal quality result. If retry finds an
   interrupted, fully invalid approval directory, it archives that debris and
   removes the stale local catalog entry before regeneration; a valid approved

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -75,8 +75,10 @@ published.
 failing species receives durable exponential backoff and no longer consumes the
 successful-generation quota on every cycle. Insufficient licensed references
 use the longer `insufficient_references_retry_minutes` delay because source
-availability changes slowly. Later birds continue through the queue. Exhausted
-factual or visual review remains terminal and requires `retry TAXON_ID`.
+availability changes slowly. The retry record also retains species identity so
+an explicit retry can requeue work that failed before profile creation. Later
+birds continue through the queue. Exhausted factual or visual review remains
+terminal and requires `retry TAXON_ID`.
 
 Discovery requests and validates species-rank iNaturalist results so genera,
 families, and other aggregate taxa never enter generation. Species context uses

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -729,7 +729,8 @@ def retry_command(args: argparse.Namespace) -> int:
         terminal_sources = list(sources)
         retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
         existing_guidance = retry_store.quality_guidance(args.taxon_id)
-        deferred = retry_store.get(args.taxon_id) is not None
+        retry_record = retry_store.get(args.taxon_id)
+        deferred = retry_record is not None
         if not sources and not deferred and source_candidate is None and source_run is None:
             raise ValueError(
                 f"No failed, rejected, or deferred candidate exists for taxon {args.taxon_id}"
@@ -762,6 +763,17 @@ def retry_command(args: argparse.Namespace) -> int:
         identity = _retry_species_identity(args.taxon_id, terminal_sources)
         if identity is None:
             identity = _retry_species_identity(args.taxon_id, [profile_cache])
+        if (
+            identity is None
+            and retry_record is not None
+            and retry_record.common_name is not None
+            and retry_record.scientific_name is not None
+        ):
+            identity = (
+                retry_record.common_name,
+                retry_record.scientific_name,
+                retry_store.path,
+            )
         if identity is None and correction_source is not None:
             identity = _retry_species_identity(
                 args.taxon_id,

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -61,7 +61,7 @@ from .controller import (
 )
 from .display import show_on_inky
 from .display_node import run_display_cycle
-from .errors import DataSourceError, InkyBirdFrameError, SpeciesStateError
+from .errors import CatalogError, DataSourceError, InkyBirdFrameError, SpeciesStateError
 from .images import prepare_uploaded_image
 from .installation import InstallationRole, doctor, setup
 from .notifications import (
@@ -790,11 +790,18 @@ def retry_command(args: argparse.Namespace) -> int:
                 config.controller.state_dir / "generation-queue.json",
             )
         profile_cache = config.controller.state_dir / "profiles" / str(args.taxon_id)
-        cached_profile_identity = (
-            _retry_species_identity(args.taxon_id, [profile_cache])
-            if profile_cache.exists() and (not refresh_research or identity is None)
-            else None
-        )
+        profile_identity_error: CatalogError | None = None
+        try:
+            cached_profile_identity = (
+                _retry_species_identity(args.taxon_id, [profile_cache])
+                if profile_cache.exists() and (not refresh_research or identity is None)
+                else None
+            )
+        except CatalogError as exc:
+            if not refresh_research:
+                raise
+            profile_identity_error = exc
+            cached_profile_identity = None
         if identity is None:
             identity = cached_profile_identity
         incompatible_cached_profile = (
@@ -810,6 +817,8 @@ def retry_command(args: argparse.Namespace) -> int:
         reference_cache = config.controller.state_dir / "references" / str(args.taxon_id)
         if identity is None:
             identity = _retry_species_identity(args.taxon_id, [reference_cache])
+        if identity is None and profile_identity_error is not None:
+            raise profile_identity_error
         cleared_cached_references = refresh_research and reference_cache.exists()
         if cleared_cached_references:
             sources.append(reference_cache)

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -745,43 +745,6 @@ def retry_command(args: argparse.Namespace) -> int:
             ),
             None,
         )
-        profile_cache = config.controller.state_dir / "profiles" / str(args.taxon_id)
-        cached_profile_identity = (
-            _retry_species_identity(args.taxon_id, [profile_cache])
-            if observed is not None and profile_cache.exists()
-            else None
-        )
-        incompatible_cached_profile = (
-            observed is not None
-            and cached_profile_identity is not None
-            and cached_profile_identity[:2] != (observed.common_name, observed.scientific_name)
-        )
-        cleared_cached_profile = (
-            refresh_research or incompatible_cached_profile
-        ) and profile_cache.exists()
-        if cleared_cached_profile:
-            sources.append(profile_cache)
-        reference_cache = config.controller.state_dir / "references" / str(args.taxon_id)
-        cleared_cached_references = refresh_research and reference_cache.exists()
-        if cleared_cached_references:
-            sources.append(reference_cache)
-        correction_owner = (
-            next(
-                (source for source in sources if correction_source.is_relative_to(source)),
-                None,
-            )
-            if correction_source is not None
-            else None
-        )
-        retained_correction_source = (
-            correction_source if source_candidate is not None or source_run is not None else None
-        )
-        if (
-            correction_source is not None
-            and correction_owner is None
-            and retained_correction_source is None
-        ):
-            raise SpeciesStateError("The selected correction source is outside retained state")
         terminal_identity = _retry_species_identity(args.taxon_id, terminal_sources)
         identity = (
             (
@@ -803,10 +766,47 @@ def retry_command(args: argparse.Namespace) -> int:
                 retry_record.scientific_name,
                 retry_store.path,
             )
+        profile_cache = config.controller.state_dir / "profiles" / str(args.taxon_id)
+        cached_profile_identity = (
+            _retry_species_identity(args.taxon_id, [profile_cache])
+            if profile_cache.exists()
+            else None
+        )
         if identity is None:
-            identity = _retry_species_identity(args.taxon_id, [profile_cache])
-        if identity is None:
+            identity = cached_profile_identity
+        incompatible_cached_profile = (
+            identity is not None
+            and cached_profile_identity is not None
+            and cached_profile_identity[:2] != identity[:2]
+        )
+        cleared_cached_profile = (
+            refresh_research or incompatible_cached_profile
+        ) and profile_cache.exists()
+        if cleared_cached_profile:
+            sources.append(profile_cache)
+        reference_cache = config.controller.state_dir / "references" / str(args.taxon_id)
+        cleared_cached_references = refresh_research and reference_cache.exists()
+        if cleared_cached_references:
+            sources.append(reference_cache)
+        if identity is None and not cleared_cached_references:
             identity = _retry_species_identity(args.taxon_id, [reference_cache])
+        correction_owner = (
+            next(
+                (source for source in sources if correction_source.is_relative_to(source)),
+                None,
+            )
+            if correction_source is not None
+            else None
+        )
+        retained_correction_source = (
+            correction_source if source_candidate is not None or source_run is not None else None
+        )
+        if (
+            correction_source is not None
+            and correction_owner is None
+            and retained_correction_source is None
+        ):
+            raise SpeciesStateError("The selected correction source is outside retained state")
         if identity is None and correction_source is not None:
             identity = _retry_species_identity(
                 args.taxon_id,

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -779,6 +779,12 @@ def retry_command(args: argparse.Namespace) -> int:
                 args.taxon_id,
                 [correction_source.parent, correction_source.parent.parent],
             )
+        if identity is not None and retry_record is not None:
+            retry_record = retry_store.set_identity(
+                args.taxon_id,
+                identity[0],
+                identity[1],
+            )
         invalid_approved_archive = archive_invalid_approved_catalog_state(
             config,
             args.taxon_id,

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -40,6 +40,7 @@ from .config import (
     load_config,
 )
 from .controller import (
+    HUMAN_REVIEW_SOURCE,
     REVIEW_FAILURE_FALLBACK,
     add_collection_member,
     archive_invalid_approved_catalog_state,
@@ -755,21 +756,20 @@ def retry_command(args: argparse.Namespace) -> int:
             if observed is not None
             else terminal_identity
         )
-        if identity is None:
-            queued = next(
-                (
-                    species
-                    for species in read_generation_queue(config)
-                    if species.taxon_id == args.taxon_id
-                ),
-                None,
+        queued = next(
+            (
+                species
+                for species in read_generation_queue(config)
+                if species.taxon_id == args.taxon_id
+            ),
+            None,
+        )
+        if identity is None and queued is not None and HUMAN_REVIEW_SOURCE in queued.sources:
+            identity = (
+                queued.common_name,
+                queued.scientific_name,
+                config.controller.state_dir / "generation-queue.json",
             )
-            if queued is not None:
-                identity = (
-                    queued.common_name,
-                    queued.scientific_name,
-                    config.controller.state_dir / "generation-queue.json",
-                )
         if (
             identity is None
             and retry_record is not None
@@ -780,6 +780,12 @@ def retry_command(args: argparse.Namespace) -> int:
                 retry_record.common_name,
                 retry_record.scientific_name,
                 retry_store.path,
+            )
+        if identity is None and queued is not None:
+            identity = (
+                queued.common_name,
+                queued.scientific_name,
+                config.controller.state_dir / "generation-queue.json",
             )
         profile_cache = config.controller.state_dir / "profiles" / str(args.taxon_id)
         cached_profile_identity = (
@@ -800,11 +806,11 @@ def retry_command(args: argparse.Namespace) -> int:
         if cleared_cached_profile:
             sources.append(profile_cache)
         reference_cache = config.controller.state_dir / "references" / str(args.taxon_id)
+        if identity is None:
+            identity = _retry_species_identity(args.taxon_id, [reference_cache])
         cleared_cached_references = refresh_research and reference_cache.exists()
         if cleared_cached_references:
             sources.append(reference_cache)
-        if identity is None and not cleared_cached_references:
-            identity = _retry_species_identity(args.taxon_id, [reference_cache])
         correction_owner = (
             next(
                 (source for source in sources if correction_source.is_relative_to(source)),

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -805,6 +805,12 @@ def retry_command(args: argparse.Namespace) -> int:
                     existing_guidance.invariant_findings if existing_guidance is not None else ()
                 ),
             )
+        terminal_source_set = set(terminal_sources)
+        cache_moves = [move for move in archive_plan if move[0] not in terminal_source_set]
+        terminal_moves = [move for move in archive_plan if move[0] in terminal_source_set]
+        for source, destination in cache_moves:
+            shutil.move(str(source), destination)
+            moved.append(str(destination))
         queued_for_generation = False
         if identity is not None:
             ensure_generation_retry(
@@ -815,7 +821,7 @@ def retry_command(args: argparse.Namespace) -> int:
                 identity[2],
             )
             queued_for_generation = True
-        for source, destination in archive_plan:
+        for source, destination in terminal_moves:
             shutil.move(str(source), destination)
             moved.append(str(destination))
         retry_store.clear(args.taxon_id)

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -758,7 +758,12 @@ def retry_command(args: argparse.Namespace) -> int:
             ),
             None,
         )
-        terminal_identity = _retry_species_identity(args.taxon_id, terminal_sources)
+        deferred_identity_errors: list[CatalogError | SpeciesStateError] = []
+        terminal_identity = _retry_species_identity(
+            args.taxon_id,
+            terminal_sources,
+            deferred_malformed_errors=deferred_identity_errors,
+        )
         identity = (
             (
                 observed.common_name,
@@ -802,12 +807,11 @@ def retry_command(args: argparse.Namespace) -> int:
                 config.controller.state_dir / "generation-queue.json",
             )
         profile_cache = config.controller.state_dir / "profiles" / str(args.taxon_id)
-        profile_identity_errors: list[CatalogError | SpeciesStateError] = []
         cached_profile_identity = (
             _retry_species_identity(
                 args.taxon_id,
                 [profile_cache],
-                deferred_malformed_errors=(profile_identity_errors if refresh_research else None),
+                deferred_malformed_errors=(deferred_identity_errors if refresh_research else None),
             )
             if profile_cache.exists() and (not refresh_research or identity is None)
             else None
@@ -827,8 +831,6 @@ def retry_command(args: argparse.Namespace) -> int:
         reference_cache = config.controller.state_dir / "references" / str(args.taxon_id)
         if identity is None:
             identity = _retry_species_identity(args.taxon_id, [reference_cache])
-        if identity is None and profile_identity_errors:
-            raise profile_identity_errors[0]
         cleared_cached_references = refresh_research and reference_cache.exists()
         if cleared_cached_references:
             sources.append(reference_cache)
@@ -854,6 +856,8 @@ def retry_command(args: argparse.Namespace) -> int:
                 args.taxon_id,
                 [correction_source.parent, correction_source.parent.parent],
             )
+        if identity is None and deferred_identity_errors:
+            raise deferred_identity_errors[0]
         if identity is None:
             raise SpeciesStateError(
                 f"Taxon {args.taxon_id} has no recoverable species identity; "

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -755,17 +755,6 @@ def retry_command(args: argparse.Namespace) -> int:
             if observed is not None
             else terminal_identity
         )
-        if (
-            identity is None
-            and retry_record is not None
-            and retry_record.common_name is not None
-            and retry_record.scientific_name is not None
-        ):
-            identity = (
-                retry_record.common_name,
-                retry_record.scientific_name,
-                retry_store.path,
-            )
         if identity is None:
             queued = next(
                 (
@@ -781,6 +770,17 @@ def retry_command(args: argparse.Namespace) -> int:
                     queued.scientific_name,
                     config.controller.state_dir / "generation-queue.json",
                 )
+        if (
+            identity is None
+            and retry_record is not None
+            and retry_record.common_name is not None
+            and retry_record.scientific_name is not None
+        ):
+            identity = (
+                retry_record.common_name,
+                retry_record.scientific_name,
+                retry_store.path,
+            )
         profile_cache = config.controller.state_dir / "profiles" / str(args.taxon_id)
         cached_profile_identity = (
             _retry_species_identity(args.taxon_id, [profile_cache])

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -583,6 +583,8 @@ def _retry_candidate_guidance(
 def _retry_species_identity(
     taxon_id: int,
     sources: list[Path],
+    *,
+    deferred_malformed_errors: list[CatalogError | SpeciesStateError] | None = None,
 ) -> tuple[str, str, Path] | None:
     identity: tuple[str, str, Path] | None = None
     for source in dict.fromkeys(sources):
@@ -590,9 +592,19 @@ def _retry_species_identity(
             identity_path = source / filename
             if not identity_path.is_file():
                 continue
-            payload = read_json(identity_path)
+            try:
+                payload = read_json(identity_path)
+            except CatalogError as exc:
+                if deferred_malformed_errors is None:
+                    raise
+                deferred_malformed_errors.append(exc)
+                continue
             if not isinstance(payload, dict):
-                raise SpeciesStateError(f"Invalid retained candidate identity: {identity_path}")
+                error = SpeciesStateError(f"Invalid retained candidate identity: {identity_path}")
+                if deferred_malformed_errors is None:
+                    raise error
+                deferred_malformed_errors.append(error)
+                continue
             retained_taxon_id = payload.get("taxon_id")
             if retained_taxon_id is None:
                 continue
@@ -790,18 +802,16 @@ def retry_command(args: argparse.Namespace) -> int:
                 config.controller.state_dir / "generation-queue.json",
             )
         profile_cache = config.controller.state_dir / "profiles" / str(args.taxon_id)
-        profile_identity_error: CatalogError | None = None
-        try:
-            cached_profile_identity = (
-                _retry_species_identity(args.taxon_id, [profile_cache])
-                if profile_cache.exists() and (not refresh_research or identity is None)
-                else None
+        profile_identity_errors: list[CatalogError | SpeciesStateError] = []
+        cached_profile_identity = (
+            _retry_species_identity(
+                args.taxon_id,
+                [profile_cache],
+                deferred_malformed_errors=(profile_identity_errors if refresh_research else None),
             )
-        except CatalogError as exc:
-            if not refresh_research:
-                raise
-            profile_identity_error = exc
-            cached_profile_identity = None
+            if profile_cache.exists() and (not refresh_research or identity is None)
+            else None
+        )
         if identity is None:
             identity = cached_profile_identity
         incompatible_cached_profile = (
@@ -817,8 +827,8 @@ def retry_command(args: argparse.Namespace) -> int:
         reference_cache = config.controller.state_dir / "references" / str(args.taxon_id)
         if identity is None:
             identity = _retry_species_identity(args.taxon_id, [reference_cache])
-        if identity is None and profile_identity_error is not None:
-            raise profile_identity_error
+        if identity is None and profile_identity_errors:
+            raise profile_identity_errors[0]
         cleared_cached_references = refresh_research and reference_cache.exists()
         if cleared_cached_references:
             sources.append(reference_cache)

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -812,7 +812,22 @@ def retry_command(args: argparse.Namespace) -> int:
                 args.taxon_id,
                 [correction_source.parent, correction_source.parent.parent],
             )
-        if identity is None and retry_record is not None:
+        if identity is None:
+            queued = next(
+                (
+                    species
+                    for species in read_generation_queue(config)
+                    if species.taxon_id == args.taxon_id
+                ),
+                None,
+            )
+            if queued is not None:
+                identity = (
+                    queued.common_name,
+                    queued.scientific_name,
+                    config.controller.state_dir / "generation-queue.json",
+                )
+        if identity is None:
             raise SpeciesStateError(
                 f"Taxon {args.taxon_id} has no recoverable species identity; "
                 "wait for rediscovery or restore its retained profile or references"

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -762,10 +762,6 @@ def retry_command(args: argparse.Namespace) -> int:
         ):
             raise SpeciesStateError("The selected correction source is outside retained state")
         identity = _retry_species_identity(args.taxon_id, terminal_sources)
-        if identity is None:
-            identity = _retry_species_identity(args.taxon_id, [profile_cache])
-        if identity is None:
-            identity = _retry_species_identity(args.taxon_id, [reference_cache])
         if (
             identity is None
             and retry_record is not None
@@ -777,6 +773,10 @@ def retry_command(args: argparse.Namespace) -> int:
                 retry_record.scientific_name,
                 retry_store.path,
             )
+        if identity is None:
+            identity = _retry_species_identity(args.taxon_id, [profile_cache])
+        if identity is None:
+            identity = _retry_species_identity(args.taxon_id, [reference_cache])
         if identity is None and correction_source is not None:
             identity = _retry_species_identity(
                 args.taxon_id,

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -766,10 +766,25 @@ def retry_command(args: argparse.Namespace) -> int:
                 retry_record.scientific_name,
                 retry_store.path,
             )
+        if identity is None:
+            queued = next(
+                (
+                    species
+                    for species in read_generation_queue(config)
+                    if species.taxon_id == args.taxon_id
+                ),
+                None,
+            )
+            if queued is not None:
+                identity = (
+                    queued.common_name,
+                    queued.scientific_name,
+                    config.controller.state_dir / "generation-queue.json",
+                )
         profile_cache = config.controller.state_dir / "profiles" / str(args.taxon_id)
         cached_profile_identity = (
             _retry_species_identity(args.taxon_id, [profile_cache])
-            if profile_cache.exists()
+            if profile_cache.exists() and (not refresh_research or identity is None)
             else None
         )
         if identity is None:
@@ -812,21 +827,6 @@ def retry_command(args: argparse.Namespace) -> int:
                 args.taxon_id,
                 [correction_source.parent, correction_source.parent.parent],
             )
-        if identity is None:
-            queued = next(
-                (
-                    species
-                    for species in read_generation_queue(config)
-                    if species.taxon_id == args.taxon_id
-                ),
-                None,
-            )
-            if queued is not None:
-                identity = (
-                    queued.common_name,
-                    queued.scientific_name,
-                    config.controller.state_dir / "generation-queue.json",
-                )
         if identity is None:
             raise SpeciesStateError(
                 f"Taxon {args.taxon_id} has no recoverable species identity; "

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -44,6 +44,7 @@ from .controller import (
     add_collection_member,
     archive_invalid_approved_catalog_state,
     collection_status,
+    current_discovery_species,
     discover_species,
     enqueue_seed_species,
     ensure_generation_retry,
@@ -761,7 +762,24 @@ def retry_command(args: argparse.Namespace) -> int:
             and retained_correction_source is None
         ):
             raise SpeciesStateError("The selected correction source is outside retained state")
-        identity = _retry_species_identity(args.taxon_id, terminal_sources)
+        terminal_identity = _retry_species_identity(args.taxon_id, terminal_sources)
+        observed = next(
+            (
+                species
+                for species in current_discovery_species(config)
+                if species.taxon_id == args.taxon_id
+            ),
+            None,
+        )
+        identity = (
+            (
+                observed.common_name,
+                observed.scientific_name,
+                config.controller.state_dir / "discovery.json",
+            )
+            if observed is not None
+            else terminal_identity
+        )
         if (
             identity is None
             and retry_record is not None

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -610,6 +610,30 @@ def _retry_species_identity(
     return identity
 
 
+def _retry_archive_plan(
+    state_dir: Path,
+    sources: list[Path],
+    correction_owner: Path | None,
+    correction_source: Path | None,
+) -> tuple[list[tuple[Path, Path]], Path | None]:
+    archive = state_dir / "archive"
+    archive.mkdir(parents=True, exist_ok=True)
+    reserved: set[Path] = set()
+    moves: list[tuple[Path, Path]] = []
+    archived_correction_source: Path | None = None
+    for source in dict.fromkeys(sources):
+        destination = archive / source.name
+        counter = 1
+        while destination.exists() or destination in reserved:
+            destination = archive / f"{source.name}-{counter}"
+            counter += 1
+        reserved.add(destination)
+        moves.append((source, destination))
+        if source == correction_owner and correction_source is not None:
+            archived_correction_source = destination / correction_source.relative_to(source)
+    return moves, archived_correction_source
+
+
 def retry_command(args: argparse.Namespace) -> int:
     config = _config(args)
     replace_approved = bool(getattr(args, "replace_approved", False))
@@ -702,6 +726,7 @@ def retry_command(args: argparse.Namespace) -> int:
         sources.extend(
             sorted((config.controller.state_dir / "rejected").glob(f"{args.taxon_id}-*"))
         )
+        terminal_sources = list(sources)
         retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
         existing_guidance = retry_store.quality_guidance(args.taxon_id)
         deferred = retry_store.get(args.taxon_id) is not None
@@ -734,40 +759,26 @@ def retry_command(args: argparse.Namespace) -> int:
             and retained_correction_source is None
         ):
             raise SpeciesStateError("The selected correction source is outside retained state")
-        identity_sources = list(sources)
-        if correction_source is not None:
-            identity_sources.append(correction_source.parent)
-            identity_sources.append(correction_source.parent.parent)
-        identity = _retry_species_identity(args.taxon_id, identity_sources)
-        queued_for_generation = False
-        if identity is not None:
-            ensure_generation_retry(
-                config,
+        identity = _retry_species_identity(args.taxon_id, terminal_sources)
+        if identity is None:
+            identity = _retry_species_identity(args.taxon_id, [profile_cache])
+        if identity is None and correction_source is not None:
+            identity = _retry_species_identity(
                 args.taxon_id,
-                identity[0],
-                identity[1],
-                identity[2],
+                [correction_source.parent, correction_source.parent.parent],
             )
-            queued_for_generation = True
         invalid_approved_archive = archive_invalid_approved_catalog_state(
             config,
             args.taxon_id,
         )
-        archive = config.controller.state_dir / "archive"
-        archive.mkdir(parents=True, exist_ok=True)
         moved = [str(invalid_approved_archive)] if invalid_approved_archive is not None else []
-        archived_correction_source = retained_correction_source
-        for source in sources:
-            destination = archive / source.name
-            counter = 1
-            while destination.exists():
-                destination = archive / f"{source.name}-{counter}"
-                counter += 1
-            if source == correction_owner and correction_source is not None:
-                archived_correction_source = destination / correction_source.relative_to(source)
-            shutil.move(str(source), destination)
-            moved.append(str(destination))
-        retry_store.clear(args.taxon_id)
+        archive_plan, planned_correction_source = _retry_archive_plan(
+            config.controller.state_dir,
+            sources,
+            correction_owner,
+            correction_source,
+        )
+        archived_correction_source = retained_correction_source or planned_correction_source
         final_guidance = existing_guidance
         if quality_findings:
             final_guidance = retry_store.set_quality_guidance(
@@ -782,6 +793,20 @@ def retry_command(args: argparse.Namespace) -> int:
                     existing_guidance.invariant_findings if existing_guidance is not None else ()
                 ),
             )
+        queued_for_generation = False
+        if identity is not None:
+            ensure_generation_retry(
+                config,
+                args.taxon_id,
+                identity[0],
+                identity[1],
+                identity[2],
+            )
+            queued_for_generation = True
+        for source, destination in archive_plan:
+            shutil.move(str(source), destination)
+            moved.append(str(destination))
+        retry_store.clear(args.taxon_id)
     print_result(
         {
             "taxon_id": args.taxon_id,

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -737,8 +737,28 @@ def retry_command(args: argparse.Namespace) -> int:
             raise ValueError(
                 f"No failed, rejected, or deferred candidate exists for taxon {args.taxon_id}"
             )
+        observed = next(
+            (
+                species
+                for species in current_discovery_species(config)
+                if species.taxon_id == args.taxon_id
+            ),
+            None,
+        )
         profile_cache = config.controller.state_dir / "profiles" / str(args.taxon_id)
-        cleared_cached_profile = refresh_research and profile_cache.exists()
+        cached_profile_identity = (
+            _retry_species_identity(args.taxon_id, [profile_cache])
+            if observed is not None and profile_cache.exists()
+            else None
+        )
+        incompatible_cached_profile = (
+            observed is not None
+            and cached_profile_identity is not None
+            and cached_profile_identity[:2] != (observed.common_name, observed.scientific_name)
+        )
+        cleared_cached_profile = (
+            refresh_research or incompatible_cached_profile
+        ) and profile_cache.exists()
         if cleared_cached_profile:
             sources.append(profile_cache)
         reference_cache = config.controller.state_dir / "references" / str(args.taxon_id)
@@ -763,14 +783,6 @@ def retry_command(args: argparse.Namespace) -> int:
         ):
             raise SpeciesStateError("The selected correction source is outside retained state")
         terminal_identity = _retry_species_identity(args.taxon_id, terminal_sources)
-        observed = next(
-            (
-                species
-                for species in current_discovery_species(config)
-                if species.taxon_id == args.taxon_id
-            ),
-            None,
-        )
         identity = (
             (
                 observed.common_name,
@@ -799,6 +811,11 @@ def retry_command(args: argparse.Namespace) -> int:
             identity = _retry_species_identity(
                 args.taxon_id,
                 [correction_source.parent, correction_source.parent.parent],
+            )
+        if identity is None and retry_record is not None:
+            raise SpeciesStateError(
+                f"Taxon {args.taxon_id} has no recoverable species identity; "
+                "wait for rediscovery or restore its retained profile or references"
             )
         if identity is not None and retry_record is not None:
             retry_record = retry_store.set_identity(

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -49,6 +49,7 @@ from .controller import (
     ensure_generation_retry,
     exclusive_cycle_lock,
     import_approved_collection,
+    read_generation_queue,
     read_generation_queue_partition,
     remove_collection_member,
     retry_approved_candidate,
@@ -583,7 +584,7 @@ def _retry_species_identity(
 ) -> tuple[str, str, Path] | None:
     identity: tuple[str, str, Path] | None = None
     for source in dict.fromkeys(sources):
-        for filename in ("profile.json", "manifest.json", "failure.json"):
+        for filename in ("profile.json", "references.json", "manifest.json", "failure.json"):
             identity_path = source / filename
             if not identity_path.is_file():
                 continue
@@ -763,6 +764,8 @@ def retry_command(args: argparse.Namespace) -> int:
         identity = _retry_species_identity(args.taxon_id, terminal_sources)
         if identity is None:
             identity = _retry_species_identity(args.taxon_id, [profile_cache])
+        if identity is None:
+            identity = _retry_species_identity(args.taxon_id, [reference_cache])
         if (
             identity is None
             and retry_record is not None
@@ -814,11 +817,7 @@ def retry_command(args: argparse.Namespace) -> int:
         terminal_source_set = set(terminal_sources)
         cache_moves = [move for move in archive_plan if move[0] not in terminal_source_set]
         terminal_moves = [move for move in archive_plan if move[0] in terminal_source_set]
-        for source, destination in cache_moves:
-            shutil.move(str(source), destination)
-            moved.append(str(destination))
-        queued_for_generation = False
-        if identity is not None:
+        if identity is not None and terminal_moves:
             ensure_generation_retry(
                 config,
                 args.taxon_id,
@@ -826,11 +825,24 @@ def retry_command(args: argparse.Namespace) -> int:
                 identity[1],
                 identity[2],
             )
-            queued_for_generation = True
+        for source, destination in cache_moves:
+            shutil.move(str(source), destination)
+            moved.append(str(destination))
+        if identity is not None and not terminal_moves:
+            ensure_generation_retry(
+                config,
+                args.taxon_id,
+                identity[0],
+                identity[1],
+                identity[2],
+            )
         for source, destination in terminal_moves:
             shutil.move(str(source), destination)
             moved.append(str(destination))
         retry_store.clear(args.taxon_id)
+        queued_for_generation = any(
+            species.taxon_id == args.taxon_id for species in read_generation_queue(config)
+        )
     print_result(
         {
             "taxon_id": args.taxon_id,

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -46,6 +46,7 @@ from .controller import (
     collection_status,
     discover_species,
     enqueue_seed_species,
+    ensure_generation_retry,
     exclusive_cycle_lock,
     import_approved_collection,
     read_generation_queue_partition,
@@ -576,6 +577,39 @@ def _retry_candidate_guidance(
     return (rejection_reason.strip(),), portrait
 
 
+def _retry_species_identity(
+    taxon_id: int,
+    sources: list[Path],
+) -> tuple[str, str, Path] | None:
+    identity: tuple[str, str, Path] | None = None
+    for source in dict.fromkeys(sources):
+        for filename in ("profile.json", "manifest.json", "failure.json"):
+            identity_path = source / filename
+            if not identity_path.is_file():
+                continue
+            payload = read_json(identity_path)
+            if not isinstance(payload, dict):
+                raise SpeciesStateError(f"Invalid retained candidate identity: {identity_path}")
+            retained_taxon_id = payload.get("taxon_id")
+            if retained_taxon_id is None:
+                continue
+            if retained_taxon_id != taxon_id:
+                raise SpeciesStateError(
+                    f"Retained candidate identity does not match taxon {taxon_id}: {identity_path}"
+                )
+            common_name = payload.get("common_name")
+            scientific_name = payload.get("scientific_name")
+            if not isinstance(common_name, str) or not isinstance(scientific_name, str):
+                continue
+            candidate_identity = (common_name, scientific_name, identity_path)
+            if identity is not None and identity[:2] != candidate_identity[:2]:
+                raise SpeciesStateError(
+                    f"Retained candidate identities conflict for taxon {taxon_id}"
+                )
+            identity = candidate_identity
+    return identity
+
+
 def retry_command(args: argparse.Namespace) -> int:
     config = _config(args)
     replace_approved = bool(getattr(args, "replace_approved", False))
@@ -700,6 +734,21 @@ def retry_command(args: argparse.Namespace) -> int:
             and retained_correction_source is None
         ):
             raise SpeciesStateError("The selected correction source is outside retained state")
+        identity_sources = list(sources)
+        if correction_source is not None:
+            identity_sources.append(correction_source.parent)
+            identity_sources.append(correction_source.parent.parent)
+        identity = _retry_species_identity(args.taxon_id, identity_sources)
+        queued_for_generation = False
+        if identity is not None:
+            ensure_generation_retry(
+                config,
+                args.taxon_id,
+                identity[0],
+                identity[1],
+                identity[2],
+            )
+            queued_for_generation = True
         invalid_approved_archive = archive_invalid_approved_catalog_state(
             config,
             args.taxon_id,
@@ -749,6 +798,7 @@ def retry_command(args: argparse.Namespace) -> int:
             "source_candidate": source_candidate,
             "source_run": source_run,
             "correction_override_count": len(correction_override),
+            "queued_for_generation": queued_for_generation,
             "preserved_correction_source": (
                 final_guidance is not None and final_guidance.source_plate is not None
             ),

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -754,7 +754,7 @@ def retry_command(args: argparse.Namespace) -> int:
                 config.controller.state_dir / "discovery.json",
             )
             if observed is not None
-            else terminal_identity
+            else None
         )
         queued = next(
             (
@@ -781,6 +781,8 @@ def retry_command(args: argparse.Namespace) -> int:
                 retry_record.scientific_name,
                 retry_store.path,
             )
+        if identity is None:
+            identity = terminal_identity
         if identity is None and queued is not None:
             identity = (
                 queued.common_name,

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -1747,6 +1747,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 )
             synchronize_generation_retry_identity(config, queued_species, queued)
             generation_species.append(queued)
+        retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
         approved = approved_taxon_ids(config.controller.catalog_dir)
         eligible = [
             species

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -591,6 +591,7 @@ def synchronize_generation_retry_identity(
         None,
     )
     queued = queued_species[queued_index] if queued_index is not None else None
+    has_human_review_queue = queued is not None and HUMAN_REVIEW_SOURCE in queued.sources
     queue_identity_changed = (
         queued is not None
         and HUMAN_REVIEW_SOURCE in queued.sources
@@ -628,7 +629,7 @@ def synchronize_generation_retry_identity(
         queued_species[queued_index] = replacement
     if retry_identity_changed and not queue_identity_changed:
         retry_store.set_identity(species.taxon_id, species.common_name, species.scientific_name)
-    if retry_identity_changed or queue_identity_changed:
+    if retry is not None or has_human_review_queue:
         _archive_incompatible_retry_profile(config.controller.state_dir, species)
     if retry_identity_changed and queue_identity_changed:
         retry_store.set_identity(species.taxon_id, species.common_name, species.scientific_name)

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -561,8 +561,10 @@ def ensure_generation_retry(
         )
         if queued_index is not None:
             queued = queued_species[queued_index]
-            if queued.common_name != species.common_name or queued.scientific_name != (
-                species.scientific_name
+            if (
+                HUMAN_REVIEW_SOURCE not in queued.sources
+                or queued.common_name != species.common_name
+                or queued.scientific_name != species.scientific_name
             ):
                 queued_species[queued_index] = species
                 _write_generation_queue(config, queued_species)

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -599,11 +599,9 @@ def synchronize_generation_retry_identity(
             or queued.scientific_name != species.scientific_name
         )
     )
-    if retry_identity_changed or queue_identity_changed:
-        _archive_incompatible_retry_profile(config.controller.state_dir, species)
     if queue_identity_changed:
         assert queued_index is not None
-        queued_species[queued_index] = BirdSpecies(
+        replacement = BirdSpecies(
             taxon_id=species.taxon_id,
             common_name=species.common_name,
             scientific_name=species.scientific_name,
@@ -621,10 +619,18 @@ def synchronize_generation_retry_identity(
                 ),
                 None,
             )
-            if persisted_index is not None:
-                persisted_species[persisted_index] = queued_species[queued_index]
-                _write_generation_queue(config, persisted_species)
-    if retry_identity_changed:
+            if persisted_index is None:
+                raise SpeciesStateError(
+                    f"Human-review queue entry disappeared for taxon {species.taxon_id}"
+                )
+            persisted_species[persisted_index] = replacement
+            _write_generation_queue(config, persisted_species)
+        queued_species[queued_index] = replacement
+    if retry_identity_changed and not queue_identity_changed:
+        retry_store.set_identity(species.taxon_id, species.common_name, species.scientific_name)
+    if retry_identity_changed or queue_identity_changed:
+        _archive_incompatible_retry_profile(config.controller.state_dir, species)
+    if retry_identity_changed and queue_identity_changed:
         retry_store.set_identity(species.taxon_id, species.common_name, species.scientific_name)
 
 

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -538,6 +538,37 @@ def _write_generation_queue(config: AppConfig, species: list[BirdSpecies]) -> No
     )
 
 
+def ensure_generation_retry(
+    config: AppConfig,
+    taxon_id: int,
+    common_name: object,
+    scientific_name: object,
+    source: Path,
+) -> None:
+    """Keep an operator-requested retry eligible after its observation expires."""
+    species = _replacement_species(
+        taxon_id,
+        common_name,
+        scientific_name,
+        source,
+    )
+    with catalog_state_lock(config.controller.state_dir):
+        queued_species = read_generation_queue(config)
+        queued = next(
+            (item for item in queued_species if item.taxon_id == taxon_id),
+            None,
+        )
+        if queued is not None:
+            if (
+                queued.common_name != species.common_name
+                or queued.scientific_name != species.scientific_name
+            ):
+                raise CatalogError(f"Generation queue identity differs for taxon {taxon_id}")
+            return
+        queued_species.append(species)
+        _write_generation_queue(config, queued_species)
+
+
 def _migrate_legacy_seed_queue(
     state: CollectionState,
     queued_species: list[BirdSpecies],

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -1745,6 +1745,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                     sources=queued.sources,
                     latest_detection_at=queued.latest_detection_at,
                 )
+            synchronize_generation_retry_identity(config, queued_species, queued)
             generation_species.append(queued)
         approved = approved_taxon_ids(config.controller.catalog_dir)
         eligible = [

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -571,33 +571,33 @@ def ensure_generation_retry(
         _write_generation_queue(config, queued_species)
 
 
-def synchronize_generation_retry_identity(config: AppConfig, species: BirdSpecies) -> None:
+def synchronize_generation_retry_identity(
+    queued_species: list[BirdSpecies], species: BirdSpecies
+) -> None:
     """Refresh a retry-only queue entry from the latest observed taxonomy."""
-    with catalog_state_lock(config.controller.state_dir):
-        queued_species = read_generation_queue(config)
-        queued_index = next(
-            (
-                index
-                for index, queued in enumerate(queued_species)
-                if queued.taxon_id == species.taxon_id
-            ),
-            None,
-        )
-        if queued_index is None:
-            return
-        queued = queued_species[queued_index]
-        if HUMAN_REVIEW_SOURCE not in queued.sources or (
-            queued.common_name == species.common_name
-            and queued.scientific_name == species.scientific_name
-        ):
-            return
-        queued_species[queued_index] = _replacement_species(
-            species.taxon_id,
-            species.common_name,
-            species.scientific_name,
-            _generation_queue_path(config),
-        )
-        _write_generation_queue(config, queued_species)
+    queued_index = next(
+        (
+            index
+            for index, queued in enumerate(queued_species)
+            if queued.taxon_id == species.taxon_id
+        ),
+        None,
+    )
+    if queued_index is None:
+        return
+    queued = queued_species[queued_index]
+    if HUMAN_REVIEW_SOURCE not in queued.sources or (
+        queued.common_name == species.common_name
+        and queued.scientific_name == species.scientific_name
+    ):
+        return
+    queued_species[queued_index] = BirdSpecies(
+        taxon_id=species.taxon_id,
+        common_name=species.common_name,
+        scientific_name=species.scientific_name,
+        observation_count=0,
+        source=HUMAN_REVIEW_SOURCE,
+    )
 
 
 def _migrate_legacy_seed_queue(
@@ -1731,7 +1731,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 retry_store.clear(species.taxon_id)
                 retry_store.clear_quality_guidance(species.taxon_id)
             except InsufficientReferencesError as exc:
-                synchronize_generation_retry_identity(config, species)
+                synchronize_generation_retry_identity(queued_species, species)
                 retry = retry_store.record_failure(
                     species.taxon_id,
                     exc,
@@ -1751,7 +1751,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                     }
                 )
             except DataSourceError as exc:
-                synchronize_generation_retry_identity(config, species)
+                synchronize_generation_retry_identity(queued_species, species)
                 retry = retry_store.record_failure(
                     species.taxon_id,
                     exc,
@@ -1806,7 +1806,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
             except CatalogError:
                 raise
             except InkyBirdFrameError as exc:
-                synchronize_generation_retry_identity(config, species)
+                synchronize_generation_retry_identity(queued_species, species)
                 retry = retry_store.record_failure(
                     species.taxon_id,
                     exc,

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -601,11 +601,8 @@ def synchronize_generation_retry_identity(
     )
     if retry_identity_changed or queue_identity_changed:
         _archive_incompatible_retry_profile(config.controller.state_dir, species)
-    if retry_identity_changed:
-        retry_store.set_identity(species.taxon_id, species.common_name, species.scientific_name)
-    if queued_index is None or queued is None or HUMAN_REVIEW_SOURCE not in queued.sources:
-        return
     if queue_identity_changed:
+        assert queued_index is not None
         queued_species[queued_index] = BirdSpecies(
             taxon_id=species.taxon_id,
             common_name=species.common_name,
@@ -627,6 +624,8 @@ def synchronize_generation_retry_identity(
             if persisted_index is not None:
                 persisted_species[persisted_index] = queued_species[queued_index]
                 _write_generation_queue(config, persisted_species)
+    if retry_identity_changed:
+        retry_store.set_identity(species.taxon_id, species.common_name, species.scientific_name)
 
 
 def _archive_incompatible_retry_profile(state_dir: Path, species: BirdSpecies) -> None:
@@ -635,7 +634,10 @@ def _archive_incompatible_retry_profile(state_dir: Path, species: BirdSpecies) -
     profile_path = profile_cache / "profile.json"
     if not profile_path.is_file():
         return
-    raw = read_json(profile_path)
+    try:
+        raw = read_json(profile_path)
+    except CatalogError:
+        return
     if not isinstance(raw, dict):
         return
     cached_taxon_id = raw.get("taxon_id")

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -586,31 +586,38 @@ def synchronize_generation_retry_identity(
     if queued_index is None:
         return
     queued = queued_species[queued_index]
-    if HUMAN_REVIEW_SOURCE not in queued.sources or (
-        queued.common_name == species.common_name
-        and queued.scientific_name == species.scientific_name
-    ):
+    if HUMAN_REVIEW_SOURCE not in queued.sources:
         return
-    queued_species[queued_index] = BirdSpecies(
-        taxon_id=species.taxon_id,
-        common_name=species.common_name,
-        scientific_name=species.scientific_name,
-        observation_count=0,
-        source=HUMAN_REVIEW_SOURCE,
-    )
-    with catalog_state_lock(config.controller.state_dir):
-        persisted_species = read_generation_queue(config)
-        persisted_index = next(
-            (
-                index
-                for index, queued in enumerate(persisted_species)
-                if queued.taxon_id == species.taxon_id and HUMAN_REVIEW_SOURCE in queued.sources
-            ),
-            None,
+    if queued.common_name != species.common_name or queued.scientific_name != (
+        species.scientific_name
+    ):
+        queued_species[queued_index] = BirdSpecies(
+            taxon_id=species.taxon_id,
+            common_name=species.common_name,
+            scientific_name=species.scientific_name,
+            observation_count=0,
+            source=HUMAN_REVIEW_SOURCE,
         )
-        if persisted_index is not None:
-            persisted_species[persisted_index] = queued_species[queued_index]
-            _write_generation_queue(config, persisted_species)
+        with catalog_state_lock(config.controller.state_dir):
+            persisted_species = read_generation_queue(config)
+            persisted_index = next(
+                (
+                    index
+                    for index, persisted in enumerate(persisted_species)
+                    if persisted.taxon_id == species.taxon_id
+                    and HUMAN_REVIEW_SOURCE in persisted.sources
+                ),
+                None,
+            )
+            if persisted_index is not None:
+                persisted_species[persisted_index] = queued_species[queued_index]
+                _write_generation_queue(config, persisted_species)
+    retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
+    retry = retry_store.get(species.taxon_id)
+    if retry is not None and (
+        retry.common_name != species.common_name or retry.scientific_name != species.scientific_name
+    ):
+        retry_store.set_identity(species.taxon_id, species.common_name, species.scientific_name)
 
 
 def _migrate_legacy_seed_queue(

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -593,6 +593,7 @@ def synchronize_generation_retry_identity(
     if queued.common_name != species.common_name or queued.scientific_name != (
         species.scientific_name
     ):
+        _archive_incompatible_retry_profile(config.controller.state_dir, species)
         queued_species[queued_index] = BirdSpecies(
             taxon_id=species.taxon_id,
             common_name=species.common_name,
@@ -620,6 +621,32 @@ def synchronize_generation_retry_identity(
         retry.common_name != species.common_name or retry.scientific_name != species.scientific_name
     ):
         retry_store.set_identity(species.taxon_id, species.common_name, species.scientific_name)
+
+
+def _archive_incompatible_retry_profile(state_dir: Path, species: BirdSpecies) -> None:
+    """Preserve a valid cached profile whose taxonomy no longer matches discovery."""
+    profile_cache = state_dir / "profiles" / str(species.taxon_id)
+    profile_path = profile_cache / "profile.json"
+    if not profile_path.is_file():
+        return
+    raw = read_json(profile_path)
+    if not isinstance(raw, dict):
+        return
+    cached_taxon_id = raw.get("taxon_id")
+    cached_common_name = raw.get("common_name")
+    cached_scientific_name = raw.get("scientific_name")
+    if not (
+        isinstance(cached_taxon_id, int)
+        and isinstance(cached_common_name, str)
+        and isinstance(cached_scientific_name, str)
+    ):
+        return
+    if (
+        cached_taxon_id != species.taxon_id
+        or cached_common_name != species.common_name
+        or cached_scientific_name != species.scientific_name
+    ):
+        _archive_controller_paths(state_dir, [profile_cache])
 
 
 def _migrate_legacy_seed_queue(

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -1709,6 +1709,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                     initial_minutes=config.controller.retry_initial_minutes,
                     maximum_minutes=config.controller.retry_max_minutes,
                     fixed_minutes=config.controller.insufficient_references_retry_minutes,
+                    species=species,
                 )
                 failures.append(
                     {
@@ -1726,6 +1727,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                     now=datetime.now(UTC),
                     initial_minutes=config.controller.retry_initial_minutes,
                     maximum_minutes=config.controller.retry_max_minutes,
+                    species=species,
                 )
                 failures.append(
                     {
@@ -1779,6 +1781,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                     now=datetime.now(UTC),
                     initial_minutes=config.controller.retry_initial_minutes,
                     maximum_minutes=config.controller.retry_max_minutes,
+                    species=species,
                 )
                 failures.append(
                     {

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -576,7 +576,12 @@ def ensure_generation_retry(
 def synchronize_generation_retry_identity(
     config: AppConfig, queued_species: list[BirdSpecies], species: BirdSpecies
 ) -> None:
-    """Refresh a retry-only queue entry from the latest observed taxonomy."""
+    """Refresh durable retry state from the latest observed taxonomy."""
+    retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
+    retry = retry_store.get(species.taxon_id)
+    retry_identity_changed = retry is not None and (
+        retry.common_name != species.common_name or retry.scientific_name != species.scientific_name
+    )
     queued_index = next(
         (
             index
@@ -585,15 +590,22 @@ def synchronize_generation_retry_identity(
         ),
         None,
     )
-    if queued_index is None:
-        return
-    queued = queued_species[queued_index]
-    if HUMAN_REVIEW_SOURCE not in queued.sources:
-        return
-    if queued.common_name != species.common_name or queued.scientific_name != (
-        species.scientific_name
-    ):
+    queued = queued_species[queued_index] if queued_index is not None else None
+    queue_identity_changed = (
+        queued is not None
+        and HUMAN_REVIEW_SOURCE in queued.sources
+        and (
+            queued.common_name != species.common_name
+            or queued.scientific_name != species.scientific_name
+        )
+    )
+    if retry_identity_changed or queue_identity_changed:
         _archive_incompatible_retry_profile(config.controller.state_dir, species)
+    if retry_identity_changed:
+        retry_store.set_identity(species.taxon_id, species.common_name, species.scientific_name)
+    if queued_index is None or queued is None or HUMAN_REVIEW_SOURCE not in queued.sources:
+        return
+    if queue_identity_changed:
         queued_species[queued_index] = BirdSpecies(
             taxon_id=species.taxon_id,
             common_name=species.common_name,
@@ -615,12 +627,6 @@ def synchronize_generation_retry_identity(
             if persisted_index is not None:
                 persisted_species[persisted_index] = queued_species[queued_index]
                 _write_generation_queue(config, persisted_species)
-    retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
-    retry = retry_store.get(species.taxon_id)
-    if retry is not None and (
-        retry.common_name != species.common_name or retry.scientific_name != species.scientific_name
-    ):
-        retry_store.set_identity(species.taxon_id, species.common_name, species.scientific_name)
 
 
 def _archive_incompatible_retry_profile(state_dir: Path, species: BirdSpecies) -> None:

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -554,16 +554,18 @@ def ensure_generation_retry(
     )
     with catalog_state_lock(config.controller.state_dir):
         queued_species = read_generation_queue(config)
-        queued = next(
-            (item for item in queued_species if item.taxon_id == taxon_id),
+        _migrate_legacy_queue_before_human_review(config, queued_species, taxon_id)
+        queued_index = next(
+            (index for index, item in enumerate(queued_species) if item.taxon_id == taxon_id),
             None,
         )
-        if queued is not None:
-            if (
-                queued.common_name != species.common_name
-                or queued.scientific_name != species.scientific_name
+        if queued_index is not None:
+            queued = queued_species[queued_index]
+            if queued.common_name != species.common_name or queued.scientific_name != (
+                species.scientific_name
             ):
-                raise CatalogError(f"Generation queue identity differs for taxon {taxon_id}")
+                queued_species[queued_index] = species
+                _write_generation_queue(config, queued_species)
             return
         queued_species.append(species)
         _write_generation_queue(config, queued_species)
@@ -915,7 +917,7 @@ def _archive_controller_paths(state_dir: Path, sources: list[Path]) -> list[str]
     return moved
 
 
-def _migrate_legacy_queue_before_replacement(
+def _migrate_legacy_queue_before_human_review(
     config: AppConfig,
     queued_species: list[BirdSpecies],
     taxon_id: int,
@@ -996,7 +998,7 @@ def retry_approved_candidate(
                 )
                 if not already_prepared:
                     raise ValueError(f"No approved candidate exists for taxon {taxon_id}")
-                _migrate_legacy_queue_before_replacement(config, queued_species, taxon_id)
+                _migrate_legacy_queue_before_human_review(config, queued_species, taxon_id)
                 assert guidance is not None
                 cache_sources = [
                     path
@@ -1048,7 +1050,7 @@ def retry_approved_candidate(
                 or queued.scientific_name != species.scientific_name
             ):
                 raise CatalogError(f"Generation queue identity differs for taxon {taxon_id}")
-            _migrate_legacy_queue_before_replacement(config, queued_species, taxon_id)
+            _migrate_legacy_queue_before_human_review(config, queued_species, taxon_id)
 
             rejected_paths = sorted(
                 (config.controller.state_dir / "rejected").glob(f"{taxon_id}-*")

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -572,7 +572,7 @@ def ensure_generation_retry(
 
 
 def synchronize_generation_retry_identity(
-    queued_species: list[BirdSpecies], species: BirdSpecies
+    config: AppConfig, queued_species: list[BirdSpecies], species: BirdSpecies
 ) -> None:
     """Refresh a retry-only queue entry from the latest observed taxonomy."""
     queued_index = next(
@@ -598,6 +598,19 @@ def synchronize_generation_retry_identity(
         observation_count=0,
         source=HUMAN_REVIEW_SOURCE,
     )
+    with catalog_state_lock(config.controller.state_dir):
+        persisted_species = read_generation_queue(config)
+        persisted_index = next(
+            (
+                index
+                for index, queued in enumerate(persisted_species)
+                if queued.taxon_id == species.taxon_id and HUMAN_REVIEW_SOURCE in queued.sources
+            ),
+            None,
+        )
+        if persisted_index is not None:
+            persisted_species[persisted_index] = queued_species[queued_index]
+            _write_generation_queue(config, persisted_species)
 
 
 def _migrate_legacy_seed_queue(
@@ -1731,7 +1744,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 retry_store.clear(species.taxon_id)
                 retry_store.clear_quality_guidance(species.taxon_id)
             except InsufficientReferencesError as exc:
-                synchronize_generation_retry_identity(queued_species, species)
+                synchronize_generation_retry_identity(config, queued_species, species)
                 retry = retry_store.record_failure(
                     species.taxon_id,
                     exc,
@@ -1751,7 +1764,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                     }
                 )
             except DataSourceError as exc:
-                synchronize_generation_retry_identity(queued_species, species)
+                synchronize_generation_retry_identity(config, queued_species, species)
                 retry = retry_store.record_failure(
                     species.taxon_id,
                     exc,
@@ -1806,7 +1819,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
             except CatalogError:
                 raise
             except InkyBirdFrameError as exc:
-                synchronize_generation_retry_identity(queued_species, species)
+                synchronize_generation_retry_identity(config, queued_species, species)
                 retry = retry_store.record_failure(
                     species.taxon_id,
                     exc,

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -702,7 +702,7 @@ def enqueue_seed_species(
                         collection,
                         legacy_seed_queue_migrated_at=migrated_at,
                     )
-                _write_active_catalog(config, _current_discovery_species(config))
+                _write_active_catalog(config, current_discovery_species(config))
 
     return {
         "window": window.value if window is not None else None,
@@ -846,7 +846,7 @@ def _read_discovery_snapshot(config: AppConfig) -> DiscoverySnapshot:
     return DiscoverySnapshot(refreshed, place_name, state, species)
 
 
-def _current_discovery_species(config: AppConfig) -> list[BirdSpecies]:
+def current_discovery_species(config: AppConfig) -> list[BirdSpecies]:
     if not _snapshot_path(config).exists():
         return []
     return _read_discovery_snapshot(config).species
@@ -857,7 +857,7 @@ def archive_invalid_approved_catalog_state(
     taxon_id: int,
 ) -> Path | None:
     with catalog_state_lock(config.controller.state_dir):
-        observed = _current_discovery_species(config)
+        observed = current_discovery_species(config)
         approved_path = find_taxon_directory(
             config.controller.catalog_dir / "species",
             taxon_id,
@@ -1011,7 +1011,7 @@ def retry_approved_candidate(
 
             retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
             queued_species = read_generation_queue(config)
-            observed = _current_discovery_species(config)
+            observed = current_discovery_species(config)
             resumable = (
                 _resumable_approved_replacement(
                     config.controller.state_dir,
@@ -1187,7 +1187,7 @@ def collection_status(
     return _collection_summary(
         state.entries,
         approved if approved is not None else read_catalog_entries(config.controller.catalog_dir),
-        _current_discovery_species(config),
+        current_discovery_species(config),
         legacy_seed_queue_migrated_at=state.legacy_seed_queue_migrated_at,
     )
 
@@ -1227,7 +1227,7 @@ def _change_collection(
                     raise ValueError("collection additions require an origin")
                 updated, added = add_collection_taxa(current, requested_taxa, origin)
                 removed = []
-            observed = _current_discovery_species(config)
+            observed = current_discovery_species(config)
             summary = _collection_summary(
                 updated,
                 approved,

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -571,6 +571,35 @@ def ensure_generation_retry(
         _write_generation_queue(config, queued_species)
 
 
+def synchronize_generation_retry_identity(config: AppConfig, species: BirdSpecies) -> None:
+    """Refresh a retry-only queue entry from the latest observed taxonomy."""
+    with catalog_state_lock(config.controller.state_dir):
+        queued_species = read_generation_queue(config)
+        queued_index = next(
+            (
+                index
+                for index, queued in enumerate(queued_species)
+                if queued.taxon_id == species.taxon_id
+            ),
+            None,
+        )
+        if queued_index is None:
+            return
+        queued = queued_species[queued_index]
+        if HUMAN_REVIEW_SOURCE not in queued.sources or (
+            queued.common_name == species.common_name
+            and queued.scientific_name == species.scientific_name
+        ):
+            return
+        queued_species[queued_index] = _replacement_species(
+            species.taxon_id,
+            species.common_name,
+            species.scientific_name,
+            _generation_queue_path(config),
+        )
+        _write_generation_queue(config, queued_species)
+
+
 def _migrate_legacy_seed_queue(
     state: CollectionState,
     queued_species: list[BirdSpecies],
@@ -1702,6 +1731,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 retry_store.clear(species.taxon_id)
                 retry_store.clear_quality_guidance(species.taxon_id)
             except InsufficientReferencesError as exc:
+                synchronize_generation_retry_identity(config, species)
                 retry = retry_store.record_failure(
                     species.taxon_id,
                     exc,
@@ -1721,6 +1751,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                     }
                 )
             except DataSourceError as exc:
+                synchronize_generation_retry_identity(config, species)
                 retry = retry_store.record_failure(
                     species.taxon_id,
                     exc,
@@ -1775,6 +1806,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
             except CatalogError:
                 raise
             except InkyBirdFrameError as exc:
+                synchronize_generation_retry_identity(config, species)
                 retry = retry_store.record_failure(
                     species.taxon_id,
                     exc,

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -1670,6 +1670,8 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 "Discovery state is stale; a successful refresh is required before generation"
             )
         species_list = snapshot.species
+        for species in species_list:
+            synchronize_generation_retry_identity(config, queued_species, species)
         generation_species = list(species_list)
         observed_taxa = {species.taxon_id for species in species_list}
         generation_species.extend(
@@ -1744,7 +1746,6 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 retry_store.clear(species.taxon_id)
                 retry_store.clear_quality_guidance(species.taxon_id)
             except InsufficientReferencesError as exc:
-                synchronize_generation_retry_identity(config, queued_species, species)
                 retry = retry_store.record_failure(
                     species.taxon_id,
                     exc,
@@ -1764,7 +1765,6 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                     }
                 )
             except DataSourceError as exc:
-                synchronize_generation_retry_identity(config, queued_species, species)
                 retry = retry_store.record_failure(
                     species.taxon_id,
                     exc,
@@ -1819,7 +1819,6 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
             except CatalogError:
                 raise
             except InkyBirdFrameError as exc:
-                synchronize_generation_retry_identity(config, queued_species, species)
                 retry = retry_store.record_failure(
                     species.taxon_id,
                     exc,

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -1725,9 +1725,27 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
             synchronize_generation_retry_identity(config, queued_species, species)
         generation_species = list(species_list)
         observed_taxa = {species.taxon_id for species in species_list}
-        generation_species.extend(
-            species for species in queued_species if species.taxon_id not in observed_taxa
-        )
+        retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
+        for queued in queued_species:
+            if queued.taxon_id in observed_taxa:
+                continue
+            retry = retry_store.get(queued.taxon_id)
+            if (
+                HUMAN_REVIEW_SOURCE not in queued.sources
+                and retry is not None
+                and retry.common_name is not None
+                and retry.scientific_name is not None
+            ):
+                queued = BirdSpecies(
+                    taxon_id=queued.taxon_id,
+                    common_name=retry.common_name,
+                    scientific_name=retry.scientific_name,
+                    observation_count=queued.observation_count,
+                    source=queued.source,
+                    sources=queued.sources,
+                    latest_detection_at=queued.latest_detection_at,
+                )
+            generation_species.append(queued)
         approved = approved_taxon_ids(config.controller.catalog_dir)
         eligible = [
             species
@@ -1737,7 +1755,6 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
         ]
         generated: list[dict[str, object]] = []
         failures: list[dict[str, object]] = []
-        retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
         attempted_count = 0
         for species in eligible:
             if len(generated) >= config.controller.generations_per_cycle:

--- a/src/inky_bird_frame/retry.py
+++ b/src/inky_bird_frame/retry.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta
 from pathlib import Path, PurePosixPath
 from typing import cast
@@ -151,6 +151,26 @@ class RetryStore:
     def clear(self, taxon_id: int) -> None:
         if self._records.pop(taxon_id, None) is not None:
             self._write()
+
+    def set_identity(
+        self,
+        taxon_id: int,
+        common_name: str,
+        scientific_name: str,
+    ) -> RetryRecord:
+        record = self.get(taxon_id)
+        if record is None:
+            raise ValueError(f"No retry record exists for taxon {taxon_id}")
+        if not common_name.strip() or not scientific_name.strip():
+            raise ValueError("retry species identity names must be non-empty")
+        updated = replace(
+            record,
+            common_name=common_name,
+            scientific_name=scientific_name,
+        )
+        self._records[taxon_id] = updated
+        self._write()
+        return updated
 
     def quality_guidance(self, taxon_id: int) -> RetryGuidance | None:
         return self._quality_guidance.get(taxon_id)

--- a/src/inky_bird_frame/retry.py
+++ b/src/inky_bird_frame/retry.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from pathlib import Path, PurePosixPath
 from typing import cast
 
+from .birds import BirdSpecies
 from .catalog import utc_now
 from .errors import CatalogError
 from .http import write_json_atomic
@@ -23,9 +24,11 @@ class RetryRecord:
     first_failed_at: datetime
     last_failed_at: datetime
     next_attempt_at: datetime
+    common_name: str | None = None
+    scientific_name: str | None = None
 
     def as_dict(self) -> dict[str, object]:
-        return {
+        value: dict[str, object] = {
             "taxon_id": self.taxon_id,
             "attempts": self.attempts,
             "error_type": self.error_type,
@@ -34,6 +37,10 @@ class RetryRecord:
             "last_failed_at": self.last_failed_at.isoformat(),
             "next_attempt_at": self.next_attempt_at.isoformat(),
         }
+        if self.common_name is not None and self.scientific_name is not None:
+            value["common_name"] = self.common_name
+            value["scientific_name"] = self.scientific_name
+        return value
 
 
 @dataclass(frozen=True)
@@ -105,8 +112,21 @@ class RetryStore:
         initial_minutes: int,
         maximum_minutes: int,
         fixed_minutes: int | None = None,
+        species: BirdSpecies | None = None,
     ) -> RetryRecord:
         previous = self.get(taxon_id)
+        if species is not None and species.taxon_id != taxon_id:
+            raise ValueError("retry species identity must match taxon_id")
+        common_name: str | None
+        scientific_name: str | None
+        if species is not None:
+            if not species.common_name.strip() or not species.scientific_name.strip():
+                raise ValueError("retry species identity names must be non-empty")
+            common_name = species.common_name
+            scientific_name = species.scientific_name
+        else:
+            common_name = previous.common_name if previous is not None else None
+            scientific_name = previous.scientific_name if previous is not None else None
         attempts = (previous.attempts if previous is not None else 0) + 1
         delay = (
             fixed_minutes
@@ -121,6 +141,8 @@ class RetryStore:
             first_failed_at=previous.first_failed_at if previous is not None else now,
             last_failed_at=now,
             next_attempt_at=now + timedelta(minutes=delay),
+            common_name=common_name,
+            scientific_name=scientific_name,
         )
         self._records[taxon_id] = record
         self._write()
@@ -211,6 +233,8 @@ def _parse_record(raw: object, source: Path) -> RetryRecord:
     attempts = raw.get("attempts")
     error_type = raw.get("error_type")
     error = raw.get("error")
+    common_name = raw.get("common_name")
+    scientific_name = raw.get("scientific_name")
     if (
         not isinstance(taxon_id, int)
         or isinstance(taxon_id, bool)
@@ -222,6 +246,16 @@ def _parse_record(raw: object, source: Path) -> RetryRecord:
         or not error_type
         or not isinstance(error, str)
         or not error
+        or (common_name is None) != (scientific_name is None)
+        or (
+            common_name is not None
+            and (
+                not isinstance(common_name, str)
+                or not common_name.strip()
+                or not isinstance(scientific_name, str)
+                or not scientific_name.strip()
+            )
+        )
     ):
         raise CatalogError(f"Invalid retry record: {source}")
     return RetryRecord(
@@ -232,6 +266,8 @@ def _parse_record(raw: object, source: Path) -> RetryRecord:
         first_failed_at=_parse_datetime(raw.get("first_failed_at"), source),
         last_failed_at=_parse_datetime(raw.get("last_failed_at"), source),
         next_attempt_at=_parse_datetime(raw.get("next_attempt_at"), source),
+        common_name=common_name,
+        scientific_name=scientific_name,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,6 +59,19 @@ def controller_config(state_dir: Path, catalog_dir: Path | None = None) -> Simpl
     )
 
 
+def write_test_species_identity(directory: Path) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "profile.json").write_text(
+        json.dumps(
+            {
+                "taxon_id": 42,
+                "common_name": "Example Bird",
+                "scientific_name": "Avis exemplum",
+            }
+        )
+    )
+
+
 class CliTests(unittest.TestCase):
     def test_birdbuddy_commands_parse_explicit_authorization_and_logout(self) -> None:
         login = build_parser().parse_args(
@@ -657,6 +670,7 @@ rotation_mode = "shuffle_bag"
             review = failed / "attempt-01/quality-review.json"
             review.parent.mkdir(parents=True)
             review.write_text(json.dumps({"passed": False, "findings": ["Fix the feet"]}))
+            write_test_species_identity(failed)
             profile = state_dir / "profiles/42/profile.json"
             profile.parent.mkdir(parents=True)
             profile.write_text("{}")
@@ -683,6 +697,7 @@ rotation_mode = "shuffle_bag"
             state_dir = Path(temporary)
             failed = state_dir / "failed/42-example-bird"
             failed.mkdir(parents=True)
+            write_test_species_identity(failed)
             old_review = failed / "attempt-99/quality-review.json"
             old_review.parent.mkdir()
             old_review.write_text(json.dumps({"passed": False, "findings": ["Outdated finding"]}))
@@ -722,6 +737,7 @@ rotation_mode = "shuffle_bag"
             state_dir = Path(temporary)
             failed = state_dir / "failed/42-example-bird"
             failed.mkdir(parents=True)
+            write_test_species_identity(failed)
             catalog_dir = state_dir / "catalog"
             debris = catalog_dir / "species/42-example-bird"
             debris.mkdir(parents=True)
@@ -754,6 +770,7 @@ rotation_mode = "shuffle_bag"
             review = state_dir / "failed/42-example-bird/attempt-01/quality-review.json"
             review.parent.mkdir(parents=True)
             review.write_text(json.dumps({"passed": False, "findings": []}))
+            write_test_species_identity(review.parent.parent)
             config = controller_config(state_dir)
             output = io.StringIO()
 
@@ -817,6 +834,7 @@ rotation_mode = "shuffle_bag"
                     }
                 )
             )
+            write_test_species_identity(review.parent.parent)
             config = controller_config(state_dir)
 
             with (
@@ -831,27 +849,25 @@ rotation_mode = "shuffle_bag"
         if guidance is not None:
             self.assertEqual(guidance.findings, ("Correct the measurement ranges",))
 
-    def test_retry_archives_incomplete_pending_candidate(self) -> None:
+    def test_retry_preserves_incomplete_pending_candidate_without_identity(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)
             pending = state_dir / "pending/42-example-bird"
             pending.mkdir(parents=True)
             (pending / "portrait.png").write_bytes(b"partial")
             config = controller_config(state_dir)
-            output = io.StringIO()
 
-            with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(SpeciesStateError, "no recoverable species identity"),
+            ):
                 retry_command(Namespace(taxon_id=42))
 
-            result = json.loads(output.getvalue())["data"]
             archived = state_dir / "archive/42-example-bird"
             pending_exists = pending.exists()
-            archived_portrait_exists = (archived / "portrait.png").is_file()
 
-        self.assertEqual(result["status"], "eligible")
-        self.assertEqual(result["archived"], [str(archived)])
-        self.assertFalse(pending_exists)
-        self.assertTrue(archived_portrait_exists)
+        self.assertTrue(pending_exists)
+        self.assertFalse(archived.exists())
 
     def test_retry_rejects_complete_pending_candidate(self) -> None:
         with TemporaryDirectory() as temporary:
@@ -1728,6 +1744,7 @@ rotation_mode = "shuffle_bag"
                     }
                 )
             )
+            write_test_species_identity(failed.parent)
             invariant = "Keep the source-matched bill proportion."
             RetryStore(state_dir / "generation-retries.json").set_quality_guidance(
                 42,
@@ -1801,6 +1818,8 @@ rotation_mode = "shuffle_bag"
                         "schema_version": 1,
                         "status": "rejected",
                         "taxon_id": 42,
+                        "common_name": "Example Bird",
+                        "scientific_name": "Avis exemplum",
                         "rejection_reason": rejection_reason,
                         "assets": {
                             "portrait": {
@@ -1849,6 +1868,8 @@ rotation_mode = "shuffle_bag"
                         "schema_version": 1,
                         "status": "rejected",
                         "taxon_id": 42,
+                        "common_name": "Example Bird",
+                        "scientific_name": "Avis exemplum",
                         "rejection_reason": rejection_reason,
                         "assets": {
                             "portrait": {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1302,18 +1302,25 @@ rotation_mode = "shuffle_bag"
                 species=species,
             )
             config = controller_config(state_dir)
+            output = io.StringIO()
 
             with (
                 patch("inky_bird_frame.cli._config", return_value=config),
-                redirect_stdout(io.StringIO()),
+                redirect_stdout(output),
             ):
                 retry_command(Namespace(taxon_id=42))
 
             queue = read_generation_queue(cast(AppConfig, config))
+            result = json.loads(output.getvalue())["data"]
+            profile_exists = profile.exists()
+            archived_profile_exists = (state_dir / "archive/42/profile.json").is_file()
 
         self.assertEqual([item.taxon_id for item in queue], [42])
         self.assertEqual(queue[0].common_name, "Current Bird Name")
         self.assertEqual(queue[0].scientific_name, "Avis current")
+        self.assertTrue(result["cleared_cached_profile"])
+        self.assertFalse(profile_exists)
+        self.assertTrue(archived_profile_exists)
 
     def test_retry_persists_guidance_before_archiving_terminal_state(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,7 +34,11 @@ from inky_bird_frame.cli import (
     status_command,
 )
 from inky_bird_frame.config import DiscoveryProvider
-from inky_bird_frame.controller import REVIEW_FAILURE_FALLBACK, exclusive_cycle_lock
+from inky_bird_frame.controller import (
+    REVIEW_FAILURE_FALLBACK,
+    exclusive_cycle_lock,
+    read_generation_queue,
+)
 from inky_bird_frame.errors import (
     ConfigurationError,
     DataSourceError,
@@ -965,6 +969,15 @@ rotation_mode = "shuffle_bag"
                         }
                     )
                 )
+            (failed / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Example Bird",
+                        "scientific_name": "Avis exemplum",
+                    }
+                )
+            )
             config = controller_config(state_dir)
             output = io.StringIO()
 
@@ -978,14 +991,18 @@ rotation_mode = "shuffle_bag"
                 if guidance is not None and guidance.source_plate is not None
                 else None
             )
+            queue = read_generation_queue(config)
 
         self.assertTrue(result["preserved_correction_source"])
+        self.assertTrue(result["queued_for_generation"])
         self.assertEqual(result["source_attempt"], 1)
         self.assertIsNotNone(guidance)
         if guidance is not None:
             self.assertEqual(guidance.findings, ("Fix the tail",))
             self.assertIsNotNone(guidance.source_plate)
         self.assertEqual(source_bytes, b"portrait-1")
+        self.assertEqual([item.taxon_id for item in queue], [42])
+        self.assertEqual(queue[0].source, "human-review")
 
     def test_retry_preserves_selected_attempt_from_archived_run(self) -> None:
         with TemporaryDirectory() as temporary:
@@ -993,7 +1010,15 @@ rotation_mode = "shuffle_bag"
             run = state_dir / "archive/42-20260803T060207Z"
             attempt = run / "attempt-03"
             attempt.mkdir(parents=True)
-            (run / "profile.json").write_text(json.dumps({"taxon_id": 42}))
+            (run / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Example Bird",
+                        "scientific_name": "Avis exemplum",
+                    }
+                )
+            )
             (attempt / "portrait.png").write_bytes(b"best earlier portrait")
             (attempt / "quality-review.json").write_text(
                 json.dumps(
@@ -1023,6 +1048,7 @@ rotation_mode = "shuffle_bag"
                 if guidance is not None and guidance.source_plate is not None
                 else None
             )
+            queue = read_generation_queue(config)
 
         self.assertTrue(result["preserved_correction_source"])
         self.assertEqual(result["source_run"], run.name)
@@ -1032,6 +1058,8 @@ rotation_mode = "shuffle_bag"
         if guidance is not None:
             self.assertEqual(guidance.findings, ("Darken both irises",))
         self.assertEqual(source_bytes, b"best earlier portrait")
+        self.assertTrue(result["queued_for_generation"])
+        self.assertEqual([item.taxon_id for item in queue], [42])
 
     def test_retry_rejects_symlinked_attempt_from_archived_run(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,6 +37,7 @@ from inky_bird_frame.cli import (
 )
 from inky_bird_frame.config import AppConfig, DiscoveryProvider
 from inky_bird_frame.controller import (
+    HUMAN_REVIEW_SOURCE,
     REVIEW_FAILURE_FALLBACK,
     exclusive_cycle_lock,
     read_generation_queue,
@@ -1227,6 +1228,48 @@ rotation_mode = "shuffle_bag"
         self.assertEqual(queue[0].common_name, "Referenced Bird")
         self.assertEqual(queue[0].scientific_name, "Avis relata")
 
+    def test_retry_refreshes_references_after_recovering_legacy_identity(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            reference_cache = state_dir / "references/42"
+            reference_cache.mkdir(parents=True)
+            (reference_cache / "references.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "taxon_id": 42,
+                        "common_name": "Referenced Bird",
+                        "scientific_name": "Avis relata",
+                        "references": [],
+                    }
+                )
+            )
+            RetryStore(state_dir / "generation-retries.json").record_failure(
+                42,
+                GenerationError("legacy transient failure"),
+                now=datetime(2026, 8, 2, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(io.StringIO()),
+            ):
+                retry_command(Namespace(taxon_id=42, refresh_research=True))
+
+            queue = read_generation_queue(cast(AppConfig, config))
+            archived_references = state_dir / "archive/42/references.json"
+            archived_references_exists = archived_references.is_file()
+            reference_cache_exists = reference_cache.exists()
+
+        self.assertEqual([item.taxon_id for item in queue], [42])
+        self.assertEqual(queue[0].common_name, "Referenced Bird")
+        self.assertEqual(queue[0].scientific_name, "Avis relata")
+        self.assertTrue(archived_references_exists)
+        self.assertFalse(reference_cache_exists)
+
     def test_retry_uses_deferred_record_identity_when_profile_was_not_created(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)
@@ -1337,6 +1380,63 @@ rotation_mode = "shuffle_bag"
         self.assertTrue(result["cleared_cached_profile"])
         self.assertFalse(profile_exists)
         self.assertTrue(archived_profile_exists)
+
+    def test_retry_prefers_deferred_identity_over_non_human_queue(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            (state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "species": [
+                            {
+                                "taxon_id": 42,
+                                "common_name": "Old Seed Name",
+                                "scientific_name": "Avis old",
+                                "observation_count": 1,
+                                "source": "eBird",
+                                "sources": ["eBird"],
+                            }
+                        ],
+                    }
+                )
+            )
+            current_species = BirdSpecies(42, "Current Bird Name", "Avis current", 1, "eBird")
+            RetryStore(state_dir / "generation-retries.json").record_failure(
+                42,
+                GenerationError("temporary failure"),
+                now=datetime(2026, 8, 2, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+                species=current_species,
+            )
+            profile = state_dir / "profiles/42/profile.json"
+            profile.parent.mkdir(parents=True)
+            profile.write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": current_species.common_name,
+                        "scientific_name": current_species.scientific_name,
+                    }
+                )
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(io.StringIO()),
+            ):
+                retry_command(Namespace(taxon_id=42))
+
+            queue = read_generation_queue(cast(AppConfig, config))
+            profile_exists = profile.is_file()
+
+        self.assertEqual([item.taxon_id for item in queue], [42])
+        self.assertEqual(queue[0].common_name, current_species.common_name)
+        self.assertEqual(queue[0].scientific_name, current_species.scientific_name)
+        self.assertEqual(queue[0].source, HUMAN_REVIEW_SOURCE)
+        self.assertTrue(profile_exists)
 
     def test_retry_persists_guidance_before_archiving_terminal_state(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1179,6 +1179,65 @@ rotation_mode = "shuffle_bag"
         self.assertEqual([item.taxon_id for item in queue], [42])
         self.assertTrue(failed_exists)
 
+    def test_retry_archives_refresh_caches_before_activating_terminal_retry(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-example-bird"
+            attempt = failed / "attempt-01"
+            attempt.mkdir(parents=True)
+            (attempt / "portrait.png").write_bytes(b"strong source")
+            (attempt / "quality-review.json").write_text(
+                json.dumps(
+                    {
+                        "passed": False,
+                        "findings": ["Correct the ruler"],
+                        "correction_findings": ["Correct the ruler"],
+                    }
+                )
+            )
+            (failed / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Example Bird",
+                        "scientific_name": "Avis exemplum",
+                    }
+                )
+            )
+            profile_cache = state_dir / "profiles/42"
+            profile_cache.mkdir(parents=True)
+            (profile_cache / "profile.json").write_text("{}")
+            reference_cache = state_dir / "references/42"
+            reference_cache.mkdir(parents=True)
+            (reference_cache / "references.json").write_text("{}")
+            moved_sources: list[Path] = []
+
+            def interrupt_reference_move(source: str, _destination: Path) -> None:
+                moved_sources.append(Path(source))
+                if Path(source) == reference_cache:
+                    raise OSError("cache archival interrupted")
+
+            config = controller_config(state_dir)
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                patch("inky_bird_frame.cli.shutil.move", side_effect=interrupt_reference_move),
+                self.assertRaisesRegex(OSError, "cache archival interrupted"),
+            ):
+                retry_command(
+                    Namespace(
+                        taxon_id=42,
+                        source_attempt=1,
+                        refresh_research=True,
+                    )
+                )
+
+            queue = read_generation_queue(cast(AppConfig, config))
+            failed_exists = failed.is_dir()
+
+        self.assertEqual(moved_sources, [profile_cache, reference_cache])
+        self.assertEqual(queue, [])
+        self.assertTrue(failed_exists)
+
     def test_retry_prefers_current_identity_over_older_edit_source(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1650,6 +1650,7 @@ rotation_mode = "shuffle_bag"
             pending = state_dir / "pending/42-example-bird"
             pending.mkdir(parents=True)
             (pending / "portrait.png").write_bytes(b"incomplete candidate")
+            (pending / "profile.json").write_text("[]")
             (state_dir / "generation-queue.json").write_text(
                 json.dumps(
                     {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -708,7 +708,7 @@ rotation_mode = "shuffle_bag"
             )
             profile = state_dir / "profiles/42/profile.json"
             profile.parent.mkdir(parents=True)
-            profile.write_text("{}")
+            profile.write_text("{malformed")
             references = state_dir / "references/42/references.json"
             references.parent.mkdir(parents=True)
             references.write_text("{}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1065,6 +1065,147 @@ rotation_mode = "shuffle_bag"
         self.assertEqual(queue[0].scientific_name, "Avis current")
         self.assertEqual(queue[0].source, "human-review")
 
+    def test_retry_uses_cached_profile_for_expired_deferred_observation(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            profile = state_dir / "profiles/42/profile.json"
+            profile.parent.mkdir(parents=True)
+            profile.write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Deferred Bird",
+                        "scientific_name": "Avis dilata",
+                    }
+                )
+            )
+            store = RetryStore(state_dir / "generation-retries.json")
+            store.record_failure(
+                42,
+                GenerationError("transient failure"),
+                now=datetime(2026, 8, 2, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(io.StringIO()),
+            ):
+                retry_command(Namespace(taxon_id=42))
+
+            queue = read_generation_queue(cast(AppConfig, config))
+            profile_exists = profile.is_file()
+
+        self.assertEqual([item.taxon_id for item in queue], [42])
+        self.assertEqual(queue[0].common_name, "Deferred Bird")
+        self.assertTrue(profile_exists)
+
+    def test_retry_persists_guidance_before_archiving_terminal_state(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-example-bird"
+            attempt = failed / "attempt-01"
+            attempt.mkdir(parents=True)
+            (attempt / "portrait.png").write_bytes(b"strong source")
+            (attempt / "quality-review.json").write_text(
+                json.dumps(
+                    {
+                        "passed": False,
+                        "findings": ["Correct the ruler"],
+                        "correction_findings": ["Correct the ruler"],
+                    }
+                )
+            )
+            (failed / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Example Bird",
+                        "scientific_name": "Avis exemplum",
+                    }
+                )
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                patch("inky_bird_frame.cli.shutil.move", side_effect=OSError("interrupted")),
+                self.assertRaisesRegex(OSError, "interrupted"),
+            ):
+                retry_command(Namespace(taxon_id=42, source_attempt=1))
+
+            guidance = RetryStore(state_dir / "generation-retries.json").quality_guidance(42)
+            queue = read_generation_queue(cast(AppConfig, config))
+            failed_exists = failed.is_dir()
+
+        self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(guidance.findings, ("Correct the ruler",))
+            self.assertEqual(
+                guidance.source_plate,
+                "archive/42-example-bird/attempt-01/portrait.png",
+            )
+        self.assertEqual([item.taxon_id for item in queue], [42])
+        self.assertTrue(failed_exists)
+
+    def test_retry_prefers_current_identity_over_older_edit_source(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-current-run"
+            failed.mkdir(parents=True)
+            (failed / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Current Bird Name",
+                        "scientific_name": "Avis current",
+                    }
+                )
+            )
+            run = state_dir / "archive/42-older-run"
+            attempt = run / "attempt-01"
+            attempt.mkdir(parents=True)
+            (run / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Old Bird Name",
+                        "scientific_name": "Avis old",
+                    }
+                )
+            )
+            (attempt / "portrait.png").write_bytes(b"older strong source")
+            (attempt / "quality-review.json").write_text(
+                json.dumps(
+                    {
+                        "passed": False,
+                        "findings": ["Correct the ruler"],
+                        "correction_findings": ["Correct the ruler"],
+                    }
+                )
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(io.StringIO()),
+            ):
+                retry_command(
+                    Namespace(
+                        taxon_id=42,
+                        source_run=run.name,
+                        source_attempt=1,
+                    )
+                )
+
+            queue = read_generation_queue(cast(AppConfig, config))
+
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0].common_name, "Current Bird Name")
+        self.assertEqual(queue[0].scientific_name, "Avis current")
+
     def test_retry_preserves_selected_attempt_from_archived_run(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1102,6 +1102,35 @@ rotation_mode = "shuffle_bag"
         self.assertEqual(queue[0].common_name, "Deferred Bird")
         self.assertTrue(profile_exists)
 
+    def test_retry_uses_deferred_record_identity_when_profile_was_not_created(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            species = BirdSpecies(42, "Early Failure Bird", "Avis immatura", 1, "eBird")
+            store = RetryStore(state_dir / "generation-retries.json")
+            store.record_failure(
+                42,
+                GenerationError("reference lookup failed"),
+                now=datetime(2026, 8, 2, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+                species=species,
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(io.StringIO()),
+            ):
+                retry_command(Namespace(taxon_id=42))
+
+            queue = read_generation_queue(cast(AppConfig, config))
+            retry_record = RetryStore(state_dir / "generation-retries.json").get(42)
+
+        self.assertEqual([item.taxon_id for item in queue], [42])
+        self.assertEqual(queue[0].common_name, "Early Failure Bird")
+        self.assertEqual(queue[0].scientific_name, "Avis immatura")
+        self.assertIsNone(retry_record)
+
     def test_retry_persists_guidance_before_archiving_terminal_state(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1066,6 +1066,57 @@ rotation_mode = "shuffle_bag"
         self.assertEqual(queue[0].scientific_name, "Avis current")
         self.assertEqual(queue[0].source, "human-review")
 
+    def test_retry_preserves_current_observed_identity_after_observation_expires(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-old-bird-name"
+            failed.mkdir(parents=True)
+            (failed / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Old Bird Name",
+                        "scientific_name": "Avis old",
+                    }
+                )
+            )
+            discovery = state_dir / "discovery.json"
+            discovery.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "refreshed_at": "2026-08-05T12:00:00+00:00",
+                        "place_name": "Exampleville",
+                        "state": "XY",
+                        "species": [
+                            {
+                                "taxon_id": 42,
+                                "common_name": "Current Bird Name",
+                                "scientific_name": "Avis current",
+                                "observation_count": 1,
+                                "source": "eBird",
+                                "sources": ["eBird"],
+                            }
+                        ],
+                    }
+                )
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(io.StringIO()),
+            ):
+                retry_command(Namespace(taxon_id=42))
+
+            discovery.unlink()
+            queue = read_generation_queue(cast(AppConfig, config))
+
+        self.assertEqual([item.taxon_id for item in queue], [42])
+        self.assertEqual(queue[0].common_name, "Current Bird Name")
+        self.assertEqual(queue[0].scientific_name, "Avis current")
+        self.assertEqual(queue[0].source, "human-review")
+
     def test_retry_uses_cached_profile_for_expired_deferred_observation(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1169,6 +1169,56 @@ rotation_mode = "shuffle_bag"
         self.assertEqual(queue[0].scientific_name, "Avis immatura")
         self.assertIsNone(retry_record)
 
+    def test_retry_prefers_deferred_record_identity_over_stale_caches(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            profile = state_dir / "profiles/42/profile.json"
+            profile.parent.mkdir(parents=True)
+            profile.write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Old Profile Name",
+                        "scientific_name": "Avis profile",
+                    }
+                )
+            )
+            references = state_dir / "references/42/references.json"
+            references.parent.mkdir(parents=True)
+            references.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "taxon_id": 42,
+                        "common_name": "Old Reference Name",
+                        "scientific_name": "Avis reference",
+                        "references": [],
+                    }
+                )
+            )
+            species = BirdSpecies(42, "Current Bird Name", "Avis current", 1, "eBird")
+            RetryStore(state_dir / "generation-retries.json").record_failure(
+                42,
+                GenerationError("reference lookup failed"),
+                now=datetime(2026, 8, 2, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+                species=species,
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(io.StringIO()),
+            ):
+                retry_command(Namespace(taxon_id=42))
+
+            queue = read_generation_queue(cast(AppConfig, config))
+
+        self.assertEqual([item.taxon_id for item in queue], [42])
+        self.assertEqual(queue[0].common_name, "Current Bird Name")
+        self.assertEqual(queue[0].scientific_name, "Avis current")
+
     def test_retry_persists_guidance_before_archiving_terminal_state(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -993,6 +993,7 @@ rotation_mode = "shuffle_bag"
                 else None
             )
             queue = read_generation_queue(cast(AppConfig, config))
+            collection = json.loads((state_dir / "collection.json").read_text())
 
         self.assertTrue(result["preserved_correction_source"])
         self.assertTrue(result["queued_for_generation"])
@@ -1003,6 +1004,65 @@ rotation_mode = "shuffle_bag"
             self.assertIsNotNone(guidance.source_plate)
         self.assertEqual(source_bytes, b"portrait-1")
         self.assertEqual([item.taxon_id for item in queue], [42])
+        self.assertEqual(queue[0].source, "human-review")
+        self.assertEqual(collection["taxa"], [])
+        self.assertIsNotNone(collection["legacy_seed_queue_migrated_at"])
+
+    def test_retry_refreshes_stale_queued_identity(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-example-bird"
+            attempt = failed / "attempt-01"
+            attempt.mkdir(parents=True)
+            (attempt / "portrait.png").write_bytes(b"strong source")
+            (attempt / "quality-review.json").write_text(
+                json.dumps(
+                    {
+                        "passed": False,
+                        "findings": ["Correct the ruler"],
+                        "correction_findings": ["Correct the ruler"],
+                    }
+                )
+            )
+            (failed / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Current Bird Name",
+                        "scientific_name": "Avis current",
+                    }
+                )
+            )
+            (state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "species": [
+                            {
+                                "taxon_id": 42,
+                                "common_name": "Old Bird Name",
+                                "scientific_name": "Avis old",
+                                "observation_count": 1,
+                                "source": "iNaturalist",
+                                "sources": ["iNaturalist"],
+                            }
+                        ],
+                    }
+                )
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(io.StringIO()),
+            ):
+                retry_command(Namespace(taxon_id=42, source_attempt=1))
+
+            queue = read_generation_queue(cast(AppConfig, config))
+
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0].common_name, "Current Bird Name")
+        self.assertEqual(queue[0].scientific_name, "Avis current")
         self.assertEqual(queue[0].source, "human-review")
 
     def test_retry_preserves_selected_attempt_from_archived_run(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1292,7 +1292,7 @@ rotation_mode = "shuffle_bag"
             )
             profile_cache = state_dir / "profiles/42"
             profile_cache.mkdir(parents=True)
-            (profile_cache / "profile.json").write_text("{not valid json")
+            (profile_cache / "profile.json").write_text("[]")
             RetryStore(state_dir / "generation-retries.json").record_failure(
                 42,
                 GenerationError("legacy transient failure"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1154,6 +1154,52 @@ rotation_mode = "shuffle_bag"
         self.assertFalse(cached_profile_exists)
         self.assertTrue(archived_profile_exists)
 
+    def test_retry_prefers_refreshed_human_review_queue_over_terminal_identity(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-old-bird-name"
+            failed.mkdir(parents=True)
+            (failed / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Old Bird Name",
+                        "scientific_name": "Avis old",
+                    }
+                )
+            )
+            (state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "species": [
+                            {
+                                "taxon_id": 42,
+                                "common_name": "Current Bird Name",
+                                "scientific_name": "Avis current",
+                                "observation_count": 0,
+                                "source": HUMAN_REVIEW_SOURCE,
+                                "sources": [HUMAN_REVIEW_SOURCE],
+                            }
+                        ],
+                    }
+                )
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(io.StringIO()),
+            ):
+                retry_command(Namespace(taxon_id=42))
+
+            queue = read_generation_queue(cast(AppConfig, config))
+
+        self.assertEqual([item.taxon_id for item in queue], [42])
+        self.assertEqual(queue[0].common_name, "Current Bird Name")
+        self.assertEqual(queue[0].scientific_name, "Avis current")
+        self.assertEqual(queue[0].source, HUMAN_REVIEW_SOURCE)
+
     def test_retry_uses_cached_profile_for_expired_deferred_observation(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1290,6 +1290,9 @@ rotation_mode = "shuffle_bag"
                     }
                 )
             )
+            profile_cache = state_dir / "profiles/42"
+            profile_cache.mkdir(parents=True)
+            (profile_cache / "profile.json").write_text("{not valid json")
             RetryStore(state_dir / "generation-retries.json").record_failure(
                 42,
                 GenerationError("legacy transient failure"),
@@ -1306,15 +1309,19 @@ rotation_mode = "shuffle_bag"
                 retry_command(Namespace(taxon_id=42, refresh_research=True))
 
             queue = read_generation_queue(cast(AppConfig, config))
-            archived_references = state_dir / "archive/42/references.json"
+            archived_references = state_dir / "archive/42-1/references.json"
             archived_references_exists = archived_references.is_file()
+            archived_profile_exists = (state_dir / "archive/42/profile.json").is_file()
             reference_cache_exists = reference_cache.exists()
+            profile_cache_exists = profile_cache.exists()
 
         self.assertEqual([item.taxon_id for item in queue], [42])
         self.assertEqual(queue[0].common_name, "Referenced Bird")
         self.assertEqual(queue[0].scientific_name, "Avis relata")
         self.assertTrue(archived_references_exists)
+        self.assertTrue(archived_profile_exists)
         self.assertFalse(reference_cache_exists)
+        self.assertFalse(profile_cache_exists)
 
     def test_retry_uses_deferred_record_identity_when_profile_was_not_created(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1103,6 +1103,43 @@ rotation_mode = "shuffle_bag"
         self.assertEqual(queue[0].common_name, "Deferred Bird")
         self.assertTrue(profile_exists)
 
+    def test_retry_uses_reference_manifest_for_legacy_deferred_observation(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            references = state_dir / "references/42/references.json"
+            references.parent.mkdir(parents=True)
+            references.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "taxon_id": 42,
+                        "common_name": "Referenced Bird",
+                        "scientific_name": "Avis relata",
+                        "references": [],
+                    }
+                )
+            )
+            RetryStore(state_dir / "generation-retries.json").record_failure(
+                42,
+                GenerationError("legacy transient failure"),
+                now=datetime(2026, 8, 2, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(io.StringIO()),
+            ):
+                retry_command(Namespace(taxon_id=42))
+
+            queue = read_generation_queue(cast(AppConfig, config))
+
+        self.assertEqual([item.taxon_id for item in queue], [42])
+        self.assertEqual(queue[0].common_name, "Referenced Bird")
+        self.assertEqual(queue[0].scientific_name, "Avis relata")
+
     def test_retry_uses_deferred_record_identity_when_profile_was_not_created(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)
@@ -1180,23 +1217,15 @@ rotation_mode = "shuffle_bag"
         self.assertEqual([item.taxon_id for item in queue], [42])
         self.assertTrue(failed_exists)
 
-    def test_retry_archives_refresh_caches_before_activating_terminal_retry(self) -> None:
+    def test_retry_queues_cache_identity_while_terminal_state_blocks_generation(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)
-            failed = state_dir / "failed/42-example-bird"
-            attempt = failed / "attempt-01"
-            attempt.mkdir(parents=True)
-            (attempt / "portrait.png").write_bytes(b"strong source")
-            (attempt / "quality-review.json").write_text(
-                json.dumps(
-                    {
-                        "passed": False,
-                        "findings": ["Correct the ruler"],
-                        "correction_findings": ["Correct the ruler"],
-                    }
-                )
-            )
-            (failed / "profile.json").write_text(
+            pending = state_dir / "pending/42-example-bird"
+            pending.mkdir(parents=True)
+            (pending / "portrait.png").write_bytes(b"incomplete candidate")
+            profile_cache = state_dir / "profiles/42"
+            profile_cache.mkdir(parents=True)
+            (profile_cache / "profile.json").write_text(
                 json.dumps(
                     {
                         "taxon_id": 42,
@@ -1205,9 +1234,6 @@ rotation_mode = "shuffle_bag"
                     }
                 )
             )
-            profile_cache = state_dir / "profiles/42"
-            profile_cache.mkdir(parents=True)
-            (profile_cache / "profile.json").write_text("{}")
             reference_cache = state_dir / "references/42"
             reference_cache.mkdir(parents=True)
             (reference_cache / "references.json").write_text("{}")
@@ -1227,17 +1253,17 @@ rotation_mode = "shuffle_bag"
                 retry_command(
                     Namespace(
                         taxon_id=42,
-                        source_attempt=1,
                         refresh_research=True,
                     )
                 )
 
             queue = read_generation_queue(cast(AppConfig, config))
-            failed_exists = failed.is_dir()
+            pending_exists = pending.is_dir()
 
         self.assertEqual(moved_sources, [profile_cache, reference_cache])
-        self.assertEqual(queue, [])
-        self.assertTrue(failed_exists)
+        self.assertEqual([item.taxon_id for item in queue], [42])
+        self.assertEqual(queue[0].common_name, "Example Bird")
+        self.assertTrue(pending_exists)
 
     def test_retry_preserves_identity_across_partial_cache_archival(self) -> None:
         with TemporaryDirectory() as temporary:
@@ -1295,6 +1321,39 @@ rotation_mode = "shuffle_bag"
         self.assertEqual([item.taxon_id for item in queue], [42])
         self.assertEqual(queue[0].common_name, "Legacy Deferred Bird")
         self.assertIsNone(final_record)
+
+    def test_retry_reports_existing_queue_membership_without_recoverable_identity(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            pending = state_dir / "pending/42-example-bird"
+            pending.mkdir(parents=True)
+            (pending / "portrait.png").write_bytes(b"incomplete candidate")
+            (state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "species": [
+                            {
+                                "taxon_id": 42,
+                                "common_name": "Queued Bird",
+                                "scientific_name": "Avis ordinata",
+                                "observation_count": 0,
+                                "source": "human-review",
+                                "sources": ["human-review"],
+                            }
+                        ],
+                    }
+                )
+            )
+            config = controller_config(state_dir)
+            output = io.StringIO()
+
+            with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
+                retry_command(Namespace(taxon_id=42))
+
+            result = json.loads(output.getvalue())["data"]
+
+        self.assertTrue(result["queued_for_generation"])
 
     def test_retry_prefers_current_identity_over_older_edit_source(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -779,6 +779,7 @@ rotation_mode = "shuffle_bag"
                 now=datetime(2026, 8, 2, tzinfo=UTC),
                 initial_minutes=5,
                 maximum_minutes=60,
+                species=BirdSpecies(42, "Deferred Bird", "Avis dilata", 1, "eBird"),
             )
             expected = store.set_quality_guidance(
                 42,
@@ -1080,6 +1081,17 @@ rotation_mode = "shuffle_bag"
                     }
                 )
             )
+            cached_profile = state_dir / "profiles/42/profile.json"
+            cached_profile.parent.mkdir(parents=True)
+            cached_profile.write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Old Bird Name",
+                        "scientific_name": "Avis old",
+                    }
+                )
+            )
             discovery = state_dir / "discovery.json"
             discovery.write_text(
                 json.dumps(
@@ -1102,20 +1114,28 @@ rotation_mode = "shuffle_bag"
                 )
             )
             config = controller_config(state_dir)
+            output = io.StringIO()
 
             with (
                 patch("inky_bird_frame.cli._config", return_value=config),
-                redirect_stdout(io.StringIO()),
+                redirect_stdout(output),
             ):
                 retry_command(Namespace(taxon_id=42))
 
             discovery.unlink()
             queue = read_generation_queue(cast(AppConfig, config))
+            result = json.loads(output.getvalue())["data"]
+            archived_profile = state_dir / "archive/42/profile.json"
+            cached_profile_exists = cached_profile.exists()
+            archived_profile_exists = archived_profile.is_file()
 
         self.assertEqual([item.taxon_id for item in queue], [42])
         self.assertEqual(queue[0].common_name, "Current Bird Name")
         self.assertEqual(queue[0].scientific_name, "Avis current")
         self.assertEqual(queue[0].source, "human-review")
+        self.assertTrue(result["cleared_cached_profile"])
+        self.assertFalse(cached_profile_exists)
+        self.assertTrue(archived_profile_exists)
 
     def test_retry_uses_cached_profile_for_expired_deferred_observation(self) -> None:
         with TemporaryDirectory() as temporary:
@@ -1219,6 +1239,31 @@ rotation_mode = "shuffle_bag"
         self.assertEqual(queue[0].common_name, "Early Failure Bird")
         self.assertEqual(queue[0].scientific_name, "Avis immatura")
         self.assertIsNone(retry_record)
+
+    def test_retry_retains_legacy_deferred_record_without_recoverable_identity(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            store = RetryStore(state_dir / "generation-retries.json")
+            expected = store.record_failure(
+                42,
+                GenerationError("reference lookup failed"),
+                now=datetime(2026, 8, 2, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(SpeciesStateError, "no recoverable species identity"),
+            ):
+                retry_command(Namespace(taxon_id=42))
+
+            retained = RetryStore(state_dir / "generation-retries.json").get(42)
+            queue = read_generation_queue(cast(AppConfig, config))
+
+        self.assertEqual(retained, expected)
+        self.assertEqual(queue, [])
 
     def test_retry_prefers_deferred_record_identity_over_stale_caches(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import shutil
 import stat
 import unittest
 from argparse import Namespace
@@ -1237,6 +1238,63 @@ rotation_mode = "shuffle_bag"
         self.assertEqual(moved_sources, [profile_cache, reference_cache])
         self.assertEqual(queue, [])
         self.assertTrue(failed_exists)
+
+    def test_retry_preserves_identity_across_partial_cache_archival(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            profile_cache = state_dir / "profiles/42"
+            profile_cache.mkdir(parents=True)
+            (profile_cache / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Legacy Deferred Bird",
+                        "scientific_name": "Avis dilata",
+                    }
+                )
+            )
+            reference_cache = state_dir / "references/42"
+            reference_cache.mkdir(parents=True)
+            (reference_cache / "references.json").write_text("{}")
+            RetryStore(state_dir / "generation-retries.json").record_failure(
+                42,
+                GenerationError("legacy transient failure"),
+                now=datetime(2026, 8, 2, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+            )
+            real_move = shutil.move
+
+            def interrupt_reference_move(source: str, destination: Path) -> None:
+                if Path(source) == reference_cache:
+                    raise OSError("cache archival interrupted")
+                real_move(source, destination)
+
+            config = controller_config(state_dir)
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                patch("inky_bird_frame.cli.shutil.move", side_effect=interrupt_reference_move),
+                self.assertRaisesRegex(OSError, "cache archival interrupted"),
+            ):
+                retry_command(Namespace(taxon_id=42, refresh_research=True))
+
+            interrupted_record = RetryStore(state_dir / "generation-retries.json").get(42)
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(io.StringIO()),
+            ):
+                retry_command(Namespace(taxon_id=42, refresh_research=True))
+
+            queue = read_generation_queue(cast(AppConfig, config))
+            final_record = RetryStore(state_dir / "generation-retries.json").get(42)
+
+        self.assertIsNotNone(interrupted_record)
+        if interrupted_record is not None:
+            self.assertEqual(interrupted_record.common_name, "Legacy Deferred Bird")
+            self.assertEqual(interrupted_record.scientific_name, "Avis dilata")
+        self.assertEqual([item.taxon_id for item in queue], [42])
+        self.assertEqual(queue[0].common_name, "Legacy Deferred Bird")
+        self.assertIsNone(final_record)
 
     def test_retry_prefers_current_identity_over_older_edit_source(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from importlib.metadata import version
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import patch
 
 import inky_bird_frame
@@ -33,7 +34,7 @@ from inky_bird_frame.cli import (
     species_to_dict,
     status_command,
 )
-from inky_bird_frame.config import DiscoveryProvider
+from inky_bird_frame.config import AppConfig, DiscoveryProvider
 from inky_bird_frame.controller import (
     REVIEW_FAILURE_FALLBACK,
     exclusive_cycle_lock,
@@ -991,7 +992,7 @@ rotation_mode = "shuffle_bag"
                 if guidance is not None and guidance.source_plate is not None
                 else None
             )
-            queue = read_generation_queue(config)
+            queue = read_generation_queue(cast(AppConfig, config))
 
         self.assertTrue(result["preserved_correction_source"])
         self.assertTrue(result["queued_for_generation"])
@@ -1048,7 +1049,7 @@ rotation_mode = "shuffle_bag"
                 if guidance is not None and guidance.source_plate is not None
                 else None
             )
-            queue = read_generation_queue(config)
+            queue = read_generation_queue(cast(AppConfig, config))
 
         self.assertTrue(result["preserved_correction_source"])
         self.assertEqual(result["source_run"], run.name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1514,6 +1514,14 @@ rotation_mode = "shuffle_bag"
                     }
                 )
             )
+            RetryStore(state_dir / "generation-retries.json").record_failure(
+                42,
+                GenerationError("temporary failure"),
+                now=datetime(2026, 8, 2, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+                species=BirdSpecies(42, "Old Bird Name", "Avis old", 0, "human-review"),
+            )
             config = controller_config(state_dir)
             output = io.StringIO()
 
@@ -1521,8 +1529,11 @@ rotation_mode = "shuffle_bag"
                 retry_command(Namespace(taxon_id=42))
 
             result = json.loads(output.getvalue())["data"]
+            queue = read_generation_queue(cast(AppConfig, config))
 
         self.assertTrue(result["queued_for_generation"])
+        self.assertEqual(queue[0].common_name, "Queued Bird")
+        self.assertEqual(queue[0].scientific_name, "Avis ordinata")
 
     def test_retry_prefers_current_identity_over_older_edit_source(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1919,6 +1919,29 @@ class ControllerTests(unittest.TestCase):
             config_path = Path(temporary) / "config.toml"
             config_path.write_text(CONFIG)
             config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            write_collection(
+                config.controller.state_dir,
+                [],
+                legacy_seed_queue_migrated_at="2026-08-05T12:00:00+00:00",
+            )
+            (config.controller.state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "species": [
+                            {
+                                "taxon_id": species.taxon_id,
+                                "common_name": "Old Cardinal Name",
+                                "scientific_name": "Cardinalis old",
+                                "observation_count": 0,
+                                "source": HUMAN_REVIEW_SOURCE,
+                                "sources": [HUMAN_REVIEW_SOURCE],
+                            }
+                        ],
+                    }
+                )
+            )
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",
@@ -1932,7 +1955,14 @@ class ControllerTests(unittest.TestCase):
             ):
                 run_controller_cycle(config)
 
-            self.assertEqual(list((config.controller.state_dir / "failed").glob("*")), [])
+            failures = list((config.controller.state_dir / "failed").glob("*"))
+            queue = read_generation_queue(config)
+
+        self.assertEqual(failures, [])
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0].common_name, species.common_name)
+        self.assertEqual(queue[0].scientific_name, species.scientific_name)
+        self.assertEqual(queue[0].source, HUMAN_REVIEW_SOURCE)
 
     def test_catalog_failure_is_terminal_for_species_without_aborting_cycle(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -41,6 +41,7 @@ from inky_bird_frame.controller import (
     collection_status,
     discover_species,
     enqueue_seed_species,
+    ensure_generation_retry,
     exclusive_cycle_lock,
     exclusive_refresh_lock,
     generate_candidate,
@@ -669,6 +670,45 @@ class ControllerTests(unittest.TestCase):
         if retry is not None:
             self.assertEqual(retry.common_name, observed.common_name)
             self.assertEqual(retry.scientific_name, observed.scientific_name)
+
+    def test_retry_marks_matching_observation_queue_as_human_review(self) -> None:
+        species = BirdSpecies(42, "Example Bird", "Avis exemplum", 1, "iNaturalist")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            (config.controller.state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "species": [
+                            {
+                                "taxon_id": species.taxon_id,
+                                "common_name": species.common_name,
+                                "scientific_name": species.scientific_name,
+                                "observation_count": species.observation_count,
+                                "source": species.source,
+                                "sources": [species.source],
+                            }
+                        ],
+                    }
+                )
+            )
+
+            ensure_generation_retry(
+                config,
+                species.taxon_id,
+                species.common_name,
+                species.scientific_name,
+                config.controller.state_dir / "failed/42-example-bird/profile.json",
+            )
+            queue = read_generation_queue(config)
+
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0].common_name, species.common_name)
+        self.assertEqual(queue[0].scientific_name, species.scientific_name)
+        self.assertEqual(queue[0].source, HUMAN_REVIEW_SOURCE)
 
     def test_expired_human_review_queue_generates_with_persisted_identity(self) -> None:
         species = BirdSpecies(42, "Current Bird Name", "Avis current", 0, HUMAN_REVIEW_SOURCE)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1030,6 +1030,82 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(generated_species.scientific_name, current.scientific_name)
         self.assertEqual(generated_species.source, queued.source)
 
+    def test_expired_retry_identity_survives_later_retry_state_write(self) -> None:
+        queued = BirdSpecies(42, "Current Bird Name", "Avis current", 0, HUMAN_REVIEW_SOURCE)
+        old = BirdSpecies(42, "Old Bird Name", "Avis old", 0, HUMAN_REVIEW_SOURCE)
+        observed = BirdSpecies(43, "Other Bird", "Avis other", 1, "eBird")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            write_collection(
+                config.controller.state_dir,
+                [],
+                legacy_seed_queue_migrated_at="2026-08-05T12:00:00+00:00",
+            )
+            (config.controller.state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "species": [
+                            {
+                                "taxon_id": queued.taxon_id,
+                                "common_name": queued.common_name,
+                                "scientific_name": queued.scientific_name,
+                                "observation_count": queued.observation_count,
+                                "source": queued.source,
+                                "sources": list(queued.sources),
+                            }
+                        ],
+                    }
+                )
+            )
+            (config.controller.state_dir / "discovery.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "refreshed_at": datetime.now(UTC).isoformat(),
+                        "place_name": "Exampleville",
+                        "state": "XY",
+                        "species": [
+                            {
+                                "taxon_id": observed.taxon_id,
+                                "common_name": observed.common_name,
+                                "scientific_name": observed.scientific_name,
+                                "observation_count": observed.observation_count,
+                                "source": observed.source,
+                                "sources": list(observed.sources),
+                            }
+                        ],
+                    }
+                )
+            )
+            RetryStore(config.controller.state_dir / "generation-retries.json").record_failure(
+                old.taxon_id,
+                DataSourceError("temporary failure"),
+                now=datetime.now(UTC),
+                initial_minutes=30,
+                maximum_minutes=60,
+                species=old,
+            )
+
+            with patch(
+                "inky_bird_frame.controller.generate_candidate",
+                side_effect=DataSourceError("other bird unavailable"),
+            ):
+                run_generation_cycle(config)
+
+            retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
+            retained = retry_store.get(queued.taxon_id)
+            later = retry_store.get(observed.taxon_id)
+
+        self.assertIsNotNone(retained)
+        if retained is not None:
+            self.assertEqual(retained.common_name, queued.common_name)
+            self.assertEqual(retained.scientific_name, queued.scientific_name)
+        self.assertIsNotNone(later)
+
     def test_approved_replacement_refreshes_research_only_when_requested(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 0, "test")
         with TemporaryDirectory() as temporary:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -655,17 +655,35 @@ class ControllerTests(unittest.TestCase):
                 maximum_minutes=60,
                 species=BirdSpecies(42, "Old Bird Name", "Avis old", 0, HUMAN_REVIEW_SOURCE),
             )
+            profile_cache = config.controller.state_dir / "profiles/42"
+            profile_cache.mkdir(parents=True)
+            (profile_cache / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Old Bird Name",
+                        "scientific_name": "Avis old",
+                    }
+                )
+            )
 
             queue = read_generation_queue(config)
             synchronize_generation_retry_identity(config, queue, observed)
             persisted_queue = read_generation_queue(config)
             retry = RetryStore(config.controller.state_dir / "generation-retries.json").get(42)
+            archived_profile = json.loads(
+                (config.controller.state_dir / "archive/42/profile.json").read_text()
+            )
+            profile_cache_exists = profile_cache.exists()
 
         self.assertEqual(len(queue), 1)
         self.assertEqual(queue[0].common_name, "Current Bird Name")
         self.assertEqual(queue[0].scientific_name, "Avis current")
         self.assertEqual(queue[0].source, HUMAN_REVIEW_SOURCE)
         self.assertEqual(persisted_queue, queue)
+        self.assertFalse(profile_cache_exists)
+        self.assertEqual(archived_profile["common_name"], "Old Bird Name")
+        self.assertEqual(archived_profile["scientific_name"], "Avis old")
         self.assertIsNotNone(retry)
         if retry is not None:
             self.assertEqual(retry.common_name, observed.common_name)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -768,6 +768,49 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(archived_profile["common_name"], old_species.common_name)
         self.assertFalse(profile_cache.exists())
 
+    def test_retry_identity_remains_old_when_queue_identity_write_fails(self) -> None:
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            old_species = BirdSpecies(42, "Old Bird Name", "Avis old", 0, HUMAN_REVIEW_SOURCE)
+            observed = BirdSpecies(42, "Current Bird Name", "Avis current", 3, "eBird")
+            ensure_generation_retry(
+                config,
+                old_species.taxon_id,
+                old_species.common_name,
+                old_species.scientific_name,
+                config.controller.state_dir / "test",
+            )
+            RetryStore(config.controller.state_dir / "generation-retries.json").record_failure(
+                42,
+                GenerationError("temporary failure"),
+                now=datetime(2026, 8, 5, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+                species=old_species,
+            )
+            queue = read_generation_queue(config)
+
+            with (
+                patch(
+                    "inky_bird_frame.controller._write_generation_queue",
+                    side_effect=OSError("interrupted"),
+                ),
+                self.assertRaisesRegex(OSError, "interrupted"),
+            ):
+                synchronize_generation_retry_identity(config, queue, observed)
+
+            persisted_queue = read_generation_queue(config)
+            retry = RetryStore(config.controller.state_dir / "generation-retries.json").get(42)
+
+        self.assertEqual(persisted_queue[0].common_name, old_species.common_name)
+        self.assertIsNotNone(retry)
+        if retry is not None:
+            self.assertEqual(retry.common_name, old_species.common_name)
+            self.assertEqual(retry.scientific_name, old_species.scientific_name)
+
     def test_expired_human_review_queue_generates_with_persisted_identity(self) -> None:
         species = BirdSpecies(42, "Current Bird Name", "Avis current", 0, HUMAN_REVIEW_SOURCE)
         approved = CatalogEntry(
@@ -2192,6 +2235,20 @@ class ControllerTests(unittest.TestCase):
             (profiles / "9083" / "profile.json").write_bytes(corrupt_payload)
             (profiles / "7513").mkdir(parents=True)
             (profiles / "7513" / "profile.json").write_text(json.dumps(wren_profile))
+            RetryStore(config.controller.state_dir / "generation-retries.json").record_failure(
+                corrupt.taxon_id,
+                GenerationError("temporary failure"),
+                now=datetime(2026, 8, 1, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+                species=BirdSpecies(
+                    corrupt.taxon_id,
+                    "Old Cardinal Name",
+                    "Cardinalis old",
+                    0,
+                    HUMAN_REVIEW_SOURCE,
+                ),
+            )
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -791,6 +791,17 @@ class ControllerTests(unittest.TestCase):
                 maximum_minutes=60,
                 species=old_species,
             )
+            profile_cache = config.controller.state_dir / "profiles/42"
+            profile_cache.mkdir(parents=True)
+            (profile_cache / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": old_species.common_name,
+                        "scientific_name": old_species.scientific_name,
+                    }
+                )
+            )
             queue = read_generation_queue(config)
 
             with (
@@ -804,12 +815,59 @@ class ControllerTests(unittest.TestCase):
 
             persisted_queue = read_generation_queue(config)
             retry = RetryStore(config.controller.state_dir / "generation-retries.json").get(42)
+            profile_cache_exists = profile_cache.exists()
 
         self.assertEqual(persisted_queue[0].common_name, old_species.common_name)
+        self.assertTrue(profile_cache_exists)
         self.assertIsNotNone(retry)
         if retry is not None:
             self.assertEqual(retry.common_name, old_species.common_name)
             self.assertEqual(retry.scientific_name, old_species.scientific_name)
+
+    def test_retry_profile_remains_when_identity_write_fails_without_queue(self) -> None:
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            old_species = BirdSpecies(42, "Old Bird Name", "Avis old", 1, "eBird")
+            observed = BirdSpecies(42, "Current Bird Name", "Avis current", 3, "eBird")
+            retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
+            retry_store.record_failure(
+                42,
+                GenerationError("temporary failure"),
+                now=datetime(2026, 8, 5, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+                species=old_species,
+            )
+            profile_cache = config.controller.state_dir / "profiles/42"
+            profile_cache.mkdir(parents=True)
+            (profile_cache / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": old_species.common_name,
+                        "scientific_name": old_species.scientific_name,
+                    }
+                )
+            )
+
+            with (
+                patch.object(retry_store, "set_identity", side_effect=OSError("interrupted")),
+                patch("inky_bird_frame.controller.RetryStore", return_value=retry_store),
+                self.assertRaisesRegex(OSError, "interrupted"),
+            ):
+                synchronize_generation_retry_identity(config, [], observed)
+
+            retained_retry = retry_store.get(42)
+            profile_cache_exists = profile_cache.exists()
+
+        self.assertTrue(profile_cache_exists)
+        self.assertIsNotNone(retained_retry)
+        if retained_retry is not None:
+            self.assertEqual(retained_retry.common_name, old_species.common_name)
+            self.assertEqual(retained_retry.scientific_name, old_species.scientific_name)
 
     def test_expired_human_review_queue_generates_with_persisted_identity(self) -> None:
         species = BirdSpecies(42, "Current Bird Name", "Avis current", 0, HUMAN_REVIEW_SOURCE)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -646,16 +646,29 @@ class ControllerTests(unittest.TestCase):
                 )
             )
             observed = BirdSpecies(42, "Current Bird Name", "Avis current", 3, "eBird")
+            RetryStore(config.controller.state_dir / "generation-retries.json").record_failure(
+                observed.taxon_id,
+                GenerationError("temporary failure"),
+                now=datetime(2026, 8, 5, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+                species=BirdSpecies(42, "Old Bird Name", "Avis old", 0, HUMAN_REVIEW_SOURCE),
+            )
 
             queue = read_generation_queue(config)
             synchronize_generation_retry_identity(config, queue, observed)
             persisted_queue = read_generation_queue(config)
+            retry = RetryStore(config.controller.state_dir / "generation-retries.json").get(42)
 
         self.assertEqual(len(queue), 1)
         self.assertEqual(queue[0].common_name, "Current Bird Name")
         self.assertEqual(queue[0].scientific_name, "Avis current")
         self.assertEqual(queue[0].source, HUMAN_REVIEW_SOURCE)
         self.assertEqual(persisted_queue, queue)
+        self.assertIsNotNone(retry)
+        if retry is not None:
+            self.assertEqual(retry.common_name, observed.common_name)
+            self.assertEqual(retry.scientific_name, observed.scientific_name)
 
     def test_expired_human_review_queue_generates_with_persisted_identity(self) -> None:
         species = BirdSpecies(42, "Current Bird Name", "Avis current", 0, HUMAN_REVIEW_SOURCE)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -547,7 +547,7 @@ class ControllerTests(unittest.TestCase):
                     return_value=[approved],
                 ),
                 patch(
-                    "inky_bird_frame.controller._current_discovery_species",
+                    "inky_bird_frame.controller.current_discovery_species",
                     return_value=[observed],
                 ),
                 patch("inky_bird_frame.controller._write_active_catalog", return_value=1),

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -648,12 +648,14 @@ class ControllerTests(unittest.TestCase):
             observed = BirdSpecies(42, "Current Bird Name", "Avis current", 3, "eBird")
 
             queue = read_generation_queue(config)
-            synchronize_generation_retry_identity(queue, observed)
+            synchronize_generation_retry_identity(config, queue, observed)
+            persisted_queue = read_generation_queue(config)
 
         self.assertEqual(len(queue), 1)
         self.assertEqual(queue[0].common_name, "Current Bird Name")
         self.assertEqual(queue[0].scientific_name, "Avis current")
         self.assertEqual(queue[0].source, HUMAN_REVIEW_SOURCE)
+        self.assertEqual(persisted_queue, queue)
 
     def test_approved_replacement_refreshes_research_only_when_requested(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 0, "test")
@@ -1602,6 +1604,60 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(len(queue), 1)
         self.assertEqual(queue[0].common_name, species.common_name)
         self.assertEqual(queue[0].scientific_name, species.scientific_name)
+        self.assertEqual(queue[0].source, HUMAN_REVIEW_SOURCE)
+
+    def test_transient_failure_persists_current_identity_before_later_abort(self) -> None:
+        renamed = BirdSpecies(42, "Current Bird Name", "Avis current", 2, "eBird")
+        fatal = BirdSpecies(43, "Fatal Bird", "Avis fatalis", 1, "eBird")
+        location = DiscoveryLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            write_collection(
+                config.controller.state_dir,
+                [],
+                legacy_seed_queue_migrated_at="2026-08-02T12:00:00+00:00",
+            )
+            (config.controller.state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "species": [
+                            {
+                                "taxon_id": renamed.taxon_id,
+                                "common_name": "Old Bird Name",
+                                "scientific_name": "Avis old",
+                                "observation_count": 0,
+                                "source": HUMAN_REVIEW_SOURCE,
+                                "sources": [HUMAN_REVIEW_SOURCE],
+                            }
+                        ],
+                    }
+                )
+            )
+            with (
+                patch(
+                    "inky_bird_frame.controller.discover_species",
+                    return_value=discovery_result(location, [renamed, fatal]),
+                ),
+                patch(
+                    "inky_bird_frame.controller.generate_candidate",
+                    side_effect=[
+                        InsufficientReferencesError("only 1 of 4 references"),
+                        CatalogError("catalog corrupt"),
+                    ],
+                ),
+                self.assertRaisesRegex(CatalogError, "catalog corrupt"),
+            ):
+                run_controller_cycle(config)
+
+            queue = read_generation_queue(config)
+
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0].common_name, renamed.common_name)
+        self.assertEqual(queue[0].scientific_name, renamed.scientific_name)
         self.assertEqual(queue[0].source, HUMAN_REVIEW_SOURCE)
 
     def test_failed_review_is_corrected_and_passing_attempt_is_staged(self) -> None:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -728,6 +728,46 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(queue[0].scientific_name, species.scientific_name)
         self.assertEqual(queue[0].source, HUMAN_REVIEW_SOURCE)
 
+    def test_live_observation_refreshes_deferred_identity_without_queue(self) -> None:
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            state_dir = config.controller.state_dir
+            config.controller.state_dir.mkdir(parents=True)
+            old_species = BirdSpecies(42, "Old Bird Name", "Avis old", 1, "eBird")
+            observed = BirdSpecies(42, "Current Bird Name", "Avis current", 3, "eBird")
+            RetryStore(state_dir / "generation-retries.json").record_failure(
+                42,
+                GenerationError("temporary failure"),
+                now=datetime(2026, 8, 5, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+                species=old_species,
+            )
+            profile_cache = state_dir / "profiles/42"
+            profile_cache.mkdir(parents=True)
+            (profile_cache / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": old_species.common_name,
+                        "scientific_name": old_species.scientific_name,
+                    }
+                )
+            )
+
+            synchronize_generation_retry_identity(config, [], observed)
+            retry = RetryStore(state_dir / "generation-retries.json").get(42)
+            archived_profile = json.loads((state_dir / "archive/42/profile.json").read_text())
+
+        self.assertIsNotNone(retry)
+        if retry is not None:
+            self.assertEqual(retry.common_name, observed.common_name)
+            self.assertEqual(retry.scientific_name, observed.scientific_name)
+        self.assertEqual(archived_profile["common_name"], old_species.common_name)
+        self.assertFalse(profile_cache.exists())
+
     def test_expired_human_review_queue_generates_with_persisted_identity(self) -> None:
         species = BirdSpecies(42, "Current Bird Name", "Avis current", 0, HUMAN_REVIEW_SOURCE)
         approved = CatalogEntry(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -933,6 +933,17 @@ class ControllerTests(unittest.TestCase):
                     }
                 )
             )
+            profile_cache = config.controller.state_dir / "profiles/42"
+            profile_cache.mkdir(parents=True)
+            (profile_cache / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": species.taxon_id,
+                        "common_name": "Old Bird Name",
+                        "scientific_name": "Avis old",
+                    }
+                )
+            )
             with (
                 patch("inky_bird_frame.controller.generate_candidate") as generate,
                 patch("inky_bird_frame.controller.approve_candidate", return_value=approved),
@@ -945,12 +956,18 @@ class ControllerTests(unittest.TestCase):
                 result = run_generation_cycle(config)
 
             queue = read_generation_queue(config)
+            archived_profile_exists = (
+                config.controller.state_dir / "archive/42/profile.json"
+            ).is_file()
+            profile_cache_exists = profile_cache.exists()
 
         generated_species = generate.call_args.args[1]
         self.assertEqual(generated_species.common_name, species.common_name)
         self.assertEqual(generated_species.scientific_name, species.scientific_name)
         self.assertEqual(len(cast(list[object], result["generated"])), 1)
         self.assertEqual(queue, [])
+        self.assertTrue(archived_profile_exists)
+        self.assertFalse(profile_cache_exists)
 
     def test_expired_seed_queue_generates_with_deferred_identity(self) -> None:
         queued = BirdSpecies(42, "Old Bird Name", "Avis old", 1, "eBird")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -757,10 +757,23 @@ class ControllerTests(unittest.TestCase):
                 )
             )
 
+            with (
+                patch("inky_bird_frame.controller.shutil.move", side_effect=OSError("interrupted")),
+                self.assertRaisesRegex(OSError, "interrupted"),
+            ):
+                synchronize_generation_retry_identity(config, [], observed)
+            interrupted_retry = RetryStore(state_dir / "generation-retries.json").get(42)
+            profile_exists_after_interruption = profile_cache.exists()
+
             synchronize_generation_retry_identity(config, [], observed)
             retry = RetryStore(state_dir / "generation-retries.json").get(42)
             archived_profile = json.loads((state_dir / "archive/42/profile.json").read_text())
 
+        self.assertIsNotNone(interrupted_retry)
+        if interrupted_retry is not None:
+            self.assertEqual(interrupted_retry.common_name, observed.common_name)
+            self.assertEqual(interrupted_retry.scientific_name, observed.scientific_name)
+        self.assertTrue(profile_exists_after_interruption)
         self.assertIsNotNone(retry)
         if retry is not None:
             self.assertEqual(retry.common_name, observed.common_name)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -952,6 +952,67 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(len(cast(list[object], result["generated"])), 1)
         self.assertEqual(queue, [])
 
+    def test_expired_seed_queue_generates_with_deferred_identity(self) -> None:
+        queued = BirdSpecies(42, "Old Bird Name", "Avis old", 1, "eBird")
+        current = BirdSpecies(42, "Current Bird Name", "Avis current", 1, "eBird")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            write_collection(
+                config.controller.state_dir,
+                [],
+                legacy_seed_queue_migrated_at="2026-08-05T12:00:00+00:00",
+            )
+            (config.controller.state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "species": [
+                            {
+                                "taxon_id": queued.taxon_id,
+                                "common_name": queued.common_name,
+                                "scientific_name": queued.scientific_name,
+                                "observation_count": queued.observation_count,
+                                "source": queued.source,
+                                "sources": list(queued.sources),
+                            }
+                        ],
+                    }
+                )
+            )
+            (config.controller.state_dir / "discovery.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "refreshed_at": datetime.now(UTC).isoformat(),
+                        "place_name": "Exampleville",
+                        "state": "XY",
+                        "species": [],
+                    }
+                )
+            )
+            RetryStore(config.controller.state_dir / "generation-retries.json").record_failure(
+                current.taxon_id,
+                DataSourceError("temporary failure"),
+                now=datetime(2026, 8, 1, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+                species=current,
+            )
+
+            with patch(
+                "inky_bird_frame.controller.generate_candidate",
+                side_effect=DataSourceError("still unavailable"),
+            ) as generate:
+                run_generation_cycle(config)
+
+        generated_species = generate.call_args.args[1]
+        self.assertEqual(generated_species.common_name, current.common_name)
+        self.assertEqual(generated_species.scientific_name, current.scientific_name)
+        self.assertEqual(generated_species.source, queued.source)
+
     def test_approved_replacement_refreshes_research_only_when_requested(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 0, "test")
         with TemporaryDirectory() as temporary:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -657,6 +657,76 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(queue[0].source, HUMAN_REVIEW_SOURCE)
         self.assertEqual(persisted_queue, queue)
 
+    def test_expired_human_review_queue_generates_with_persisted_identity(self) -> None:
+        species = BirdSpecies(42, "Current Bird Name", "Avis current", 0, HUMAN_REVIEW_SOURCE)
+        approved = CatalogEntry(
+            species.taxon_id,
+            species.common_name,
+            species.scientific_name,
+            "current-bird-name",
+            "species/42/portrait.png",
+            "a" * 64,
+            "species/42/display.png",
+            "b" * 64,
+            "2026-08-05T12:00:00+00:00",
+        )
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            write_collection(
+                config.controller.state_dir,
+                [],
+                legacy_seed_queue_migrated_at="2026-08-05T12:00:00+00:00",
+            )
+            (config.controller.state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "species": [
+                            {
+                                "taxon_id": species.taxon_id,
+                                "common_name": species.common_name,
+                                "scientific_name": species.scientific_name,
+                                "observation_count": species.observation_count,
+                                "source": species.source,
+                                "sources": [species.source],
+                            }
+                        ],
+                    }
+                )
+            )
+            (config.controller.state_dir / "discovery.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "refreshed_at": datetime.now(UTC).isoformat(),
+                        "place_name": "Exampleville",
+                        "state": "XY",
+                        "species": [],
+                    }
+                )
+            )
+            with (
+                patch("inky_bird_frame.controller.generate_candidate") as generate,
+                patch("inky_bird_frame.controller.approve_candidate", return_value=approved),
+                patch(
+                    "inky_bird_frame.controller.approved_taxon_ids",
+                    side_effect=[set(), {species.taxon_id}, {species.taxon_id}],
+                ),
+                patch("inky_bird_frame.controller._write_active_catalog", return_value=0),
+            ):
+                result = run_generation_cycle(config)
+
+            queue = read_generation_queue(config)
+
+        generated_species = generate.call_args.args[1]
+        self.assertEqual(generated_species.common_name, species.common_name)
+        self.assertEqual(generated_species.scientific_name, species.scientific_name)
+        self.assertEqual(len(cast(list[object], result["generated"])), 1)
+        self.assertEqual(queue, [])
+
     def test_approved_replacement_refreshes_research_only_when_requested(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 0, "test")
         with TemporaryDirectory() as temporary:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -54,6 +54,7 @@ from inky_bird_frame.controller import (
     run_controller_cycle,
     run_generation_cycle,
     run_refresh_cycle,
+    synchronize_generation_retry_identity,
 )
 from inky_bird_frame.errors import (
     CatalogError,
@@ -620,6 +621,39 @@ class ControllerTests(unittest.TestCase):
         self.assertFalse(result["cleared_cached_references"])
         self.assertTrue(profile_cache_exists)
         self.assertTrue(reference_cache_exists)
+
+    def test_live_observation_refreshes_human_review_queue_identity(self) -> None:
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            (config.controller.state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "species": [
+                            {
+                                "taxon_id": 42,
+                                "common_name": "Old Bird Name",
+                                "scientific_name": "Avis old",
+                                "observation_count": 0,
+                                "source": HUMAN_REVIEW_SOURCE,
+                                "sources": [HUMAN_REVIEW_SOURCE],
+                            }
+                        ],
+                    }
+                )
+            )
+            observed = BirdSpecies(42, "Current Bird Name", "Avis current", 3, "eBird")
+
+            synchronize_generation_retry_identity(config, observed)
+            queue = read_generation_queue(config)
+
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0].common_name, "Current Bird Name")
+        self.assertEqual(queue[0].scientific_name, "Avis current")
+        self.assertEqual(queue[0].source, HUMAN_REVIEW_SOURCE)
 
     def test_approved_replacement_refreshes_research_only_when_requested(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 0, "test")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -647,8 +647,8 @@ class ControllerTests(unittest.TestCase):
             )
             observed = BirdSpecies(42, "Current Bird Name", "Avis current", 3, "eBird")
 
-            synchronize_generation_retry_identity(config, observed)
             queue = read_generation_queue(config)
+            synchronize_generation_retry_identity(queue, observed)
 
         self.assertEqual(len(queue), 1)
         self.assertEqual(queue[0].common_name, "Current Bird Name")
@@ -1539,6 +1539,28 @@ class ControllerTests(unittest.TestCase):
             config_path.write_text(CONFIG)
             config = load_config(config_path)
             config.controller.state_dir.mkdir(parents=True)
+            write_collection(
+                config.controller.state_dir,
+                [],
+                legacy_seed_queue_migrated_at="2026-08-02T12:00:00+00:00",
+            )
+            (config.controller.state_dir / "generation-queue.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "species": [
+                            {
+                                "taxon_id": species.taxon_id,
+                                "common_name": "Old Cardinal Name",
+                                "scientific_name": "Cardinalis old",
+                                "observation_count": 0,
+                                "source": HUMAN_REVIEW_SOURCE,
+                                "sources": [HUMAN_REVIEW_SOURCE],
+                            }
+                        ],
+                    }
+                )
+            )
             RetryStore(
                 config.controller.state_dir / "generation-retries.json"
             ).set_quality_guidance(
@@ -1559,6 +1581,7 @@ class ControllerTests(unittest.TestCase):
             guidance = RetryStore(
                 config.controller.state_dir / "generation-retries.json"
             ).quality_guidance(species.taxon_id)
+            queue = read_generation_queue(config)
 
         self.assertEqual(terminal_failures, [])
         failures = result["failures"]
@@ -1576,6 +1599,10 @@ class ControllerTests(unittest.TestCase):
             generate.call_args.kwargs["invariant_correction_findings"],
             ("Keep the bill proportion accurate",),
         )
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(queue[0].common_name, species.common_name)
+        self.assertEqual(queue[0].scientific_name, species.scientific_name)
+        self.assertEqual(queue[0].source, HUMAN_REVIEW_SOURCE)
 
     def test_failed_review_is_corrected_and_passing_attempt_is_staged(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from inky_bird_frame.birds import BirdSpecies
 from inky_bird_frame.errors import CatalogError
 from inky_bird_frame.retry import RetryGuidance, RetryStore
 
@@ -15,12 +16,14 @@ class RetryStoreTests(unittest.TestCase):
         with TemporaryDirectory() as temporary:
             path = Path(temporary) / "retries.json"
             store = RetryStore(path)
+            species = BirdSpecies(42, "Example Bird", "Avis exemplum", 1, "eBird")
             first = store.record_failure(
                 42,
                 RuntimeError("temporary"),
                 now=now,
                 initial_minutes=30,
                 maximum_minutes=60,
+                species=species,
             )
             second = store.record_failure(
                 42,
@@ -34,6 +37,10 @@ class RetryStoreTests(unittest.TestCase):
         self.assertEqual(first.next_attempt_at, now + timedelta(minutes=30))
         self.assertEqual(second.next_attempt_at, now + timedelta(minutes=90))
         self.assertEqual(reloaded, second)
+        self.assertIsNotNone(reloaded)
+        if reloaded is not None:
+            self.assertEqual(reloaded.common_name, "Example Bird")
+            self.assertEqual(reloaded.scientific_name, "Avis exemplum")
 
     def test_fixed_delay_and_clear(self) -> None:
         now = datetime(2026, 7, 10, tzinfo=UTC)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -59,6 +59,28 @@ class RetryStoreTests(unittest.TestCase):
         self.assertEqual(record.next_attempt_at, now + timedelta(days=7))
         self.assertIsNone(store.get(42))
 
+    def test_identity_can_be_added_without_changing_backoff(self) -> None:
+        now = datetime(2026, 7, 10, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "retries.json"
+            store = RetryStore(path)
+            original = store.record_failure(
+                42,
+                RuntimeError("temporary"),
+                now=now,
+                initial_minutes=30,
+                maximum_minutes=60,
+            )
+
+            updated = store.set_identity(42, "Example Bird", "Avis exemplum")
+            reloaded = RetryStore(path).get(42)
+
+        self.assertEqual(updated.attempts, original.attempts)
+        self.assertEqual(updated.next_attempt_at, original.next_attempt_at)
+        self.assertEqual(updated.common_name, "Example Bird")
+        self.assertEqual(updated.scientific_name, "Avis exemplum")
+        self.assertEqual(reloaded, updated)
+
     def test_quality_guidance_is_durable_and_independent_from_backoff(self) -> None:
         now = datetime(2026, 7, 10, tzinfo=UTC)
         with TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary
- reconstruct a failed candidate's validated identity during retry
- keep retries in the durable generation queue after observation windows expire
- document the retry eligibility behavior and cover current and archived attempt paths

## Validation
- Ruff format check
- Ruff lint
- strict MyPy
- full Pytest suite
- package build