### PR TITLE
Resolve scientific-name synonyms safely

### DIFF
--- a/src/inky_bird_frame/birds.py
+++ b/src/inky_bird_frame/birds.py
@@ -90,6 +90,7 @@ EBIRD_BACK_DAYS: Final = {
 }
 EBIRD_MAX_RADIUS_KM: Final = 50
 EBIRD_UNRESOLVED_RETRY_DAYS: Final = 7
+TAXONOMY_MATCH_STRATEGY: Final = "scientific-name-or-exact-synonym-v1"
 BIRDWEATHER_MAX_SPECIES: Final = 100
 
 
@@ -390,11 +391,14 @@ def parse_inaturalist_taxon_match(payload: object, scientific_name: str) -> Bird
         taxon_id = item.get("id")
         common_name = item.get("preferred_common_name")
         name = item.get("name")
+        matched_term = item.get("matched_term")
         if (
             item.get("rank") == "species"
             and item.get("is_active") is not False
             and item.get("iconic_taxon_name") == "Aves"
-            and name == scientific_name
+            and isinstance(name, str)
+            and name
+            and (name == scientific_name or matched_term == scientific_name)
             and isinstance(taxon_id, int)
             and not isinstance(taxon_id, bool)
             and isinstance(common_name, str)
@@ -477,22 +481,36 @@ def _resolve_external_species_locked(
 
     for observation in observations:
         cached = cache.get(observation.species_code)
-        if cached is not None and cached.get("scientific_name") == observation.scientific_name:
+        cached_source_name = (
+            cached.get("source_scientific_name", cached.get("scientific_name"))
+            if cached is not None
+            else None
+        )
+        if cached is not None and cached_source_name == observation.scientific_name:
             taxon_id = cached.get("taxon_id")
             common_name = cached.get("common_name")
-            if isinstance(taxon_id, int) and isinstance(common_name, str):
+            canonical_name = cached.get("scientific_name")
+            if (
+                isinstance(taxon_id, int)
+                and isinstance(common_name, str)
+                and isinstance(canonical_name, str)
+            ):
                 resolved.append(
                     BirdSpecies(
                         taxon_id=taxon_id,
                         common_name=common_name,
-                        scientific_name=observation.scientific_name,
+                        scientific_name=canonical_name,
                         observation_count=(counts or {}).get(observation.species_code, 1),
                         source=source,
                     )
                 )
                 continue
             retry_at = _parse_cache_datetime(cached.get("retry_at"))
-            if retry_at is not None and current < retry_at:
+            if (
+                cached.get("match_strategy") == TAXONOMY_MATCH_STRATEGY
+                and retry_at is not None
+                and current < retry_at
+            ):
                 unresolved.append(observation)
                 continue
 
@@ -502,18 +520,22 @@ def _resolve_external_species_locked(
             )
         except TaxonomyMatchError:
             cache[observation.species_code] = {
+                "match_strategy": TAXONOMY_MATCH_STRATEGY,
                 "scientific_name": observation.scientific_name,
                 "retry_at": (current + timedelta(days=EBIRD_UNRESOLVED_RETRY_DAYS)).isoformat(),
             }
             unresolved.append(observation)
             changed = True
             continue
-        cache[observation.species_code] = {
+        cache_entry: dict[str, object] = {
             "scientific_name": species.scientific_name,
             "common_name": species.common_name,
             "taxon_id": species.taxon_id,
             "resolved_at": current.isoformat(),
         }
+        if species.scientific_name != observation.scientific_name:
+            cache_entry["source_scientific_name"] = observation.scientific_name
+        cache[observation.species_code] = cache_entry
         resolved.append(
             BirdSpecies(
                 taxon_id=species.taxon_id,

--- a/tests/test_birds.py
+++ b/tests/test_birds.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import unittest
 from datetime import UTC, date, datetime
 from pathlib import Path
@@ -296,6 +297,44 @@ class EbirdTests(unittest.TestCase):
         self.assertEqual(species.taxon_id, 12942)
         self.assertEqual(species.sources, ("eBird",))
 
+    def test_taxon_match_accepts_one_exact_scientific_synonym(self) -> None:
+        payload = {
+            "results": [
+                {
+                    "id": 1579017,
+                    "preferred_common_name": "Cooper's Hawk",
+                    "name": "Astur cooperii",
+                    "matched_term": "Accipiter cooperii",
+                    "rank": "species",
+                    "is_active": True,
+                    "iconic_taxon_name": "Aves",
+                }
+            ]
+        }
+
+        species = parse_inaturalist_taxon_match(payload, "Accipiter cooperii")
+
+        self.assertEqual(species.taxon_id, 1579017)
+        self.assertEqual(species.scientific_name, "Astur cooperii")
+
+    def test_taxon_match_rejects_a_nonexact_search_result(self) -> None:
+        payload = {
+            "results": [
+                {
+                    "id": 1579017,
+                    "preferred_common_name": "Cooper's Hawk",
+                    "name": "Astur cooperii",
+                    "matched_term": "Cooper's Hawk",
+                    "rank": "species",
+                    "is_active": True,
+                    "iconic_taxon_name": "Aves",
+                }
+            ]
+        }
+
+        with self.assertRaisesRegex(TaxonomyMatchError, "found 0"):
+            parse_inaturalist_taxon_match(payload, "Accipiter cooperii")
+
     def test_resolution_uses_cached_exact_mapping(self) -> None:
         observation = EbirdSpecies(
             "easblu", "Eastern Bluebird", "Sialia sialis", "2026-07-12 08:15"
@@ -329,6 +368,36 @@ class EbirdTests(unittest.TestCase):
         self.assertEqual(fetch.call_count, 1)
         self.assertEqual(first.unresolved, [observation])
         self.assertEqual(second.unresolved, [observation])
+
+    def test_legacy_unresolved_mapping_is_retried_after_match_strategy_upgrade(self) -> None:
+        observation = EbirdSpecies("coohaw", "Cooper's Hawk", "Accipiter cooperii", "2026-08-07")
+        species = BirdSpecies(1579017, "Cooper's Hawk", "Astur cooperii", 1, "eBird")
+        now = datetime(2026, 8, 7, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            cache = Path(temporary) / "crosswalk.json"
+            cache.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "entries": {
+                            "coohaw": {
+                                "scientific_name": "Accipiter cooperii",
+                                "retry_at": "2026-08-12T00:00:00+00:00",
+                            }
+                        },
+                    }
+                )
+            )
+            with patch(
+                "inky_bird_frame.birds.fetch_inaturalist_taxon_match",
+                return_value=species,
+            ) as fetch:
+                result = resolve_ebird_species([observation], cache, now=now)
+
+        fetch.assert_called_once_with("Accipiter cooperii", timeout_seconds=10.0)
+        self.assertEqual(result.unresolved, [])
+        self.assertEqual(result.species[0].taxon_id, 1579017)
+        self.assertEqual(result.species[0].scientific_name, "Astur cooperii")
 
     def test_non_persistent_resolution_does_not_create_cache_state(self) -> None:
         observation = EbirdSpecies("easblu", "Eastern Bluebird", "Sialia sialis", "2026-07-12")
@@ -453,6 +522,40 @@ class BirdWeatherTests(unittest.TestCase):
         self.assertEqual(species[0].observation_count, 7)
         self.assertEqual(species[0].sources, ("BirdWeather",))
         self.assertEqual(species[0].latest_detection_at, detection.latest_detection_at)
+
+    def test_resolution_caches_source_and_canonical_scientific_names(self) -> None:
+        detection = BirdWeatherSpecies(
+            344,
+            "Cooper's Hawk",
+            "Accipiter cooperii",
+            7,
+            "2026-08-07T08:15:00-04:00",
+        )
+        match = BirdSpecies(1579017, "Cooper's Hawk", "Astur cooperii", 1, "eBird")
+        with TemporaryDirectory() as temporary:
+            cache = Path(temporary) / "crosswalk.json"
+            with patch(
+                "inky_bird_frame.birds.fetch_inaturalist_taxon_match", return_value=match
+            ) as fetch:
+                first, first_unresolved = resolve_birdweather_species([detection], cache)
+                second, second_unresolved = resolve_birdweather_species([detection], cache)
+            cached = json.loads(cache.read_text())
+
+        self.assertEqual(fetch.call_count, 1)
+        self.assertEqual(first_unresolved, [])
+        self.assertEqual(second_unresolved, [])
+        self.assertEqual(first[0].scientific_name, "Astur cooperii")
+        self.assertEqual(second[0].scientific_name, "Astur cooperii")
+        self.assertEqual(
+            cached["entries"]["344"],
+            {
+                "common_name": "Cooper's Hawk",
+                "resolved_at": cached["entries"]["344"]["resolved_at"],
+                "scientific_name": "Astur cooperii",
+                "source_scientific_name": "Accipiter cooperii",
+                "taxon_id": 1579017,
+            },
+        )
 
 
 class BirdBuddyTaxonomyTests(unittest.TestCase):


### PR DESCRIPTION
## What changed

- accept an iNaturalist taxon only when the provider name exactly matches either the canonical scientific name or iNaturalist’s exact matched synonym
- retain both the source and canonical scientific names in the taxonomy cache
- version unresolved cache entries so a resolver improvement retries legacy negative results once

## Why

BirdWeather reported Cooper’s Hawk as `Accipiter cooperii`, while iNaturalist now uses `Astur cooperii`. The previous exact-canonical-name check rejected that otherwise unique active bird species and repeatedly deferred the detection.

The resolver remains fail-closed: fuzzy, ambiguous, inactive, non-bird, and non-species results are rejected. No provider-specific alias is hardcoded.

## Validation

- `ruff format --check .`
- `ruff check .`
- strict MyPy: 52 source files
- full Pytest: 523 passed, 26 subtests passed
- actionlint and shellcheck
- workflow action pinning: 6 files
- catalog validation: 115 species
- package build: sdist and wheel
- live iNaturalist contract check: `Accipiter cooperii` resolved to taxon 1579017, canonical `Astur cooperii`
