### PR TITLE
Release version 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.3.0"
+version = "0.3.1"
 description = "Generate and display reusable bird field-journal plates"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/inky_bird_frame/__init__.py
+++ b/src/inky_bird_frame/__init__.py
@@ -1,3 +1,3 @@
 """Local bird field-journal plates for Pimoroni Inky displays."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary

- bump the package and runtime version to 0.3.1
- release the observation-retry and scientific-name synonym fixes merged since 0.3.0
- include six reviewed catalog additions, the Northern Rough-winged Swallow correction, and its catalog migration history
- include the Bird Buddy architecture-diagram update

No configuration migration is required.

## Live validation

The catalog migration and taxonomy fixes were deployed from merged `main` before this version bump. A live refresh completed successfully across iNaturalist, eBird, BirdWeather, and Bird Buddy. BirdWeather resolved Cooper’s Hawk from the former `Accipiter cooperii` name to the current `Astur cooperii` taxon, all providers reported zero unresolved species, and the notification and generation-retry queues drained cleanly.

## Validation

- `uv sync --extra dev --locked`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest`: 523 passed, 26 subtests passed
- `uv run inky-bird-frame catalog validate --catalog catalog`: 115 species
- workflow action pinning check
- actionlint
- shellcheck `deploy/*.sh`
- package and runtime version consistency
- source distribution and wheel build
- `git diff --check`

Docker is unavailable on the local release host. The required hosted quality job will run the Compose validation, controller image build, and container smoke tests before merge.

## Release scope

This PR changes version metadata only. Every functional and catalog change was reviewed and merged separately.
