### PR TITLE
Update actions/checkout to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -44,7 +44,7 @@ jobs:
       version: ${{ steps.image.outputs.version }}
     steps:
       - name: Checkout trusted main revision
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
           persist-credentials: false
@@ -133,7 +133,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout released revision
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout trusted main revision
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -73,7 +73,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0


### PR DESCRIPTION
## Summary

- update every workflow checkout step from v4.3.1 to v7.0.1
- keep the action pinned to immutable commit `3d3c42e5aac5ba805825da76410c181273ba90b1`
- remove the Node 20 deprecation annotation from checkout jobs

Checkout v7 runs on Node 24, improves credential storage, and refuses unsafe fork pull-request checkouts in trusted workflow contexts by default. Existing workflow triggers, permissions, inputs, and credential settings are unchanged.

The self-hosted runner reports v2.336.0. That is newer than checkout v7’s v2.329.0 requirement for authenticated Git commands from container actions and its v2.327.1 Node 24 baseline.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest`: 523 passed, 26 subtests passed
- `uv run inky-bird-frame catalog validate --catalog catalog`: 117 species
- workflow action pinning check
- actionlint with ShellCheck
- shellcheck `deploy/*.sh`
- `git diff --check`

The hosted quality job remains the authoritative proof that checkout v7 runs correctly before the repository’s Compose validation and container build.

Closes #178.
