### PR TITLE
Refresh GitHub Actions runtime dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,14 @@ jobs:
           shellcheck deploy/*.sh
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: "false"
 
       - name: Install dependencies
         run: uv sync --extra dev --locked

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -100,20 +100,20 @@ jobs:
           echo "created=$(git show --no-patch --format=%cI "$SOURCE_SHA")" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Sign in to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
Closes #180.

Updates every stale external action to its current Node 24 release. This covers Python and uv setup plus the full Docker build/publish stack. Checkout, actionlint, and ShellCheck were already current.

The setup-uv upgrade would otherwise start caching automatically on GitHub-hosted runners. This keeps `enable-cache` disabled so the dependency refresh does not change storage behavior. No triggers, permissions, build inputs, release behavior, or application dependencies changed.

Adds a weekly grouped Dependabot check for GitHub Actions. Routine action drift will arrive as one maintenance PR; security updates remain separate.

Compatibility review:
- all updated actions require runner v2.327.1 or newer
- the self-hosted deployment runner is v2.336.0
- none of the removed major-version inputs or environment variables are used here

Validated locally:
- Ruff format and lint
- strict MyPy
- Pytest: 523 passed, 26 subtests passed
- catalog validation: 117 species
- workflow pinning, actionlint, and ShellCheck
- package sdist and wheel build
- Dependabot YAML parsing

Docker is not installed on the authoring Mac, so the hosted container build and smoke test remain the verification point for the container path.