### PR TITLE
Pace iNaturalist taxonomy lookups

### DIFF
--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -158,6 +158,10 @@ the imported date range.
 Every scientific name must still resolve exactly to one active iNaturalist bird
 species. Hybrids, `sp.` aggregates, domestic groups, and ambiguous or unmatched
 labels remain private unresolved diagnostics and cannot trigger generation.
+First-time taxonomy resolution is paced to iNaturalist's official guidance of
+about one API request per second; large archives can therefore take a few
+minutes to seed. Completed matches are cached atomically, so a transient error
+or rate limit preserves progress for the next run.
 Because the export supplies calendar dates rather than event instants, archive
 observations do not claim latest-detection rotation priority. Re-export and
 reimport periodically to include newly published eBird checklists; no eBird

--- a/src/inky_bird_frame/birds.py
+++ b/src/inky_bird_frame/birds.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, replace
 from datetime import UTC, date, datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
+from time import sleep
 from typing import Final
 from urllib.parse import quote, urlencode
 
@@ -114,6 +115,9 @@ EBIRD_MAX_RADIUS_KM: Final = 50
 EBIRD_UNRESOLVED_RETRY_DAYS: Final = 7
 TAXONOMY_MATCH_STRATEGY: Final = "scientific-name-or-exact-synonym-v1"
 BIRDWEATHER_MAX_SPECIES: Final = 100
+# iNaturalist asks API clients to stay near one request per second. Taxonomy
+# lookups cannot be batched because every source name needs an exact-match check.
+INATURALIST_TAXONOMY_REQUEST_DELAY_SECONDS: Final = 1.0
 
 
 @dataclass(frozen=True)
@@ -520,6 +524,7 @@ def fetch_inaturalist_taxon_match(
             "per_page": "20",
         }
     )
+    sleep(INATURALIST_TAXONOMY_REQUEST_DELAY_SECONDS)
     payload = get_json(f"https://api.inaturalist.org/v1/taxa?{params}", timeout_seconds)
     return parse_inaturalist_taxon_match(payload, scientific_name)
 

--- a/tests/test_birds.py
+++ b/tests/test_birds.py
@@ -22,6 +22,7 @@ from inky_bird_frame.birds import (
     fetch_birdweather_species,
     fetch_ebird_observations,
     fetch_inaturalist_birds,
+    fetch_inaturalist_taxon_match,
     fetch_taxon_context,
     parse_birdnet_go_species,
     parse_birdnet_taxon,
@@ -302,6 +303,30 @@ class EbirdTests(unittest.TestCase):
 
         self.assertEqual(species.taxon_id, 12942)
         self.assertEqual(species.sources, ("eBird",))
+
+    @patch("inky_bird_frame.birds.sleep")
+    @patch("inky_bird_frame.birds.get_json")
+    def test_taxon_match_paces_inaturalist_requests(
+        self, get_json: MagicMock, sleep: MagicMock
+    ) -> None:
+        get_json.return_value = {
+            "results": [
+                {
+                    "id": 12942,
+                    "preferred_common_name": "Eastern Bluebird",
+                    "name": "Sialia sialis",
+                    "rank": "species",
+                    "is_active": True,
+                    "iconic_taxon_name": "Aves",
+                }
+            ]
+        }
+
+        species = fetch_inaturalist_taxon_match("Sialia sialis")
+
+        self.assertEqual(species.taxon_id, 12942)
+        sleep.assert_called_once_with(1.0)
+        self.assertIn("/v1/taxa?", get_json.call_args.args[0])
 
     def test_taxon_match_accepts_one_exact_scientific_synonym(self) -> None:
         payload = {


### PR DESCRIPTION
## Summary

- pace uncached iNaturalist taxonomy lookups at one request per second
- preserve the existing atomic progress cache and fail-closed provider behavior
- document why a first all-history seed can take a few minutes

## Root cause

The new eBird archive bootstrap can require dozens of exact scientific-name lookups. The resolver preserved completed progress on failure, but it issued uncached requests faster than iNaturalist's documented guidance and a real 96-label import received HTTP 429.

## Validation

- added a focused request-pacing regression test
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q`
- `uv build`
- `git diff --check`
