### PR TITLE
Improve generation quality convergence

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -50,6 +50,9 @@ catalog_dir = "catalog"
 state_dir = "var/controller"
 # Use an absolute path when a service manager does not inherit your shell PATH.
 codex_path = "codex"
+# Optional: pin profile research, image generation, and review to a tested Codex
+# model instead of inheriting the machine-wide Codex default.
+# codex_model = "gpt-5.6-sol"
 bind_host = "0.0.0.0"
 port = 8793
 references_per_species = 4
@@ -70,7 +73,7 @@ insufficient_references_retry_minutes = 10080
 # for one recovery. Raise it deliberately when generation_minutes is reduced or after seeding.
 enabled = true
 max_searches_per_day = 5
-# Two allows one normal profile attempt and one bounded recovery for the same species.
+# Two allows one normal profile attempt and one bounded conflict refresh for the same species.
 max_searches_per_species = 2
 allowed_domains = [
     "allaboutbirds.org",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -274,7 +274,11 @@ downloads, and display rotation.
 Codex handles factual synthesis, image generation, and independent factual and
 visual review. Those steps are bounded by structured schemas, attached
 references, sourced verification, versioned prompts, configurable attempts,
-and a terminal failure state. Human approval is not required for normal flow.
+and a terminal failure state. A structured profile conflict can trigger one
+fresh research pass, but reviewer prose is never written into the canonical
+profile directly. Corrections that disappear are carried forward as
+non-regression constraints within the bounded run. Human approval is not
+required for normal flow.
 
 Application code and documentation continue through protected pull requests.
 Generated species are content artifacts: after runtime review and deterministic

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -276,9 +276,11 @@ visual review. Those steps are bounded by structured schemas, attached
 references, sourced verification, versioned prompts, configurable attempts,
 and a terminal failure state. A structured profile conflict can trigger one
 fresh research pass, but reviewer prose is never written into the canonical
-profile directly. Corrections that disappear are carried forward as
-non-regression constraints within the bounded run. Human approval is not
-required for normal flow.
+profile directly. Earlier corrections are carried forward as non-regression
+constraints only when the reviewer explicitly marks the exact
+earlier request as resolved; reversed or refined corrections remain actionable
+instead of becoming contradictory invariants. Human approval is not required
+for normal flow.
 
 Application code and documentation continue through protected pull requests.
 Generated species are content artifacts: after runtime review and deterministic

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -125,6 +125,10 @@ At minimum, set:
 - one discovery location from `zip_code`, `postal_code` plus `country_code`, or
   `latitude` plus `longitude` when iNaturalist or eBird is enabled;
 - `controller.codex_path` to the output of `command -v codex`;
+- optionally, `controller.codex_model` to a model you have validated for
+  source-backed profile research, image generation, and review (omit it to use
+  Codex's configured default, and run one foreground generation after changing
+  the pin);
 - `display_node.controller_url` to a name or address the Pi can reach, such as
   `http://bird-controller.local:8793`; and
 - any paths that should live outside the configuration directory.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -30,7 +30,11 @@ The controller's `workspace_dir` must be writable because the Codex image tool
 copies its final image there. Keep it separate from configuration, catalog, and
 state; the example uses a dedicated `workspace` directory. `catalog_dir` and
 `state_dir` must persist across deployments. `codex_path` must point to a Codex
-CLI whose `login status` reports a ChatGPT-authenticated session.
+CLI whose `login status` reports a ChatGPT-authenticated session. Set the
+optional `codex_model` only after validating that model for profile research,
+generation, and review; otherwise the controller inherits the machine-wide
+Codex default. Each private run record states the requested value explicitly,
+including `null` when the default was inherited.
 
 Bird Buddy uses controller-private authentication state rather than configured
 credentials. Obtain Bird Buddy's permission first, run `birdbuddy login`, and
@@ -112,6 +116,22 @@ by configured domains, per-species attempts, and a daily total. A validated
 profile is cached, so image retries do not repeat profile research. Independent
 quality review may revisit configured source domains to verify the rendered
 facts rather than trusting the profile's citations.
+
+When that review finds a material disagreement with the cached profile, it
+must identify the supported profile field and cite two independent allowed
+sources. The reviewer cannot write canonical facts directly. Instead, the
+controller permits one fresh source-backed profile research pass within the
+same generation limit and research budget. A repeated conflict becomes
+terminal. Private `runs/*/profile-before-refresh.json` and
+`profile-after-refresh.json` files preserve the adjudication evidence.
+
+`state_dir/runs/*/attempt-history.json` is a private, schema-versioned record of
+every started image attempt. It includes prompt version, requested model,
+generation and review latency, score-axis failures, correction regressions,
+profile conflicts, and sanitized process-error types. Terminal failures also
+retain a copy with their private failed artifacts. These files can contain
+source-backed species facts and review diagnostics; back them up with
+controller state, never publish them into the reusable catalog.
 
 `rotation_mode` is configured under `[display_node]`:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -124,14 +124,35 @@ controller permits one fresh source-backed profile research pass within the
 same generation limit and research budget. A repeated conflict becomes
 terminal. Private `runs/*/profile-before-refresh.json` and
 `profile-after-refresh.json` files preserve the adjudication evidence.
+Conflict output is accepted only when `profile_value` matches the exact current
+profile field. A reviewer must also explicitly identify earlier image
+corrections that the current attempt resolves; disappearance alone never turns
+a correction into a non-regression invariant.
 
 `state_dir/runs/*/attempt-history.json` is a private, schema-versioned record of
 every started image attempt. It includes prompt version, requested model,
 generation and review latency, score-axis failures, correction regressions,
-profile conflicts, and sanitized process-error types. Terminal failures also
-retain a copy with their private failed artifacts. These files can contain
-source-backed species facts and review diagnostics; back them up with
-controller state, never publish them into the reusable catalog.
+explicitly resolved corrections, profile conflicts, and sanitized process-error
+types. Terminal failures also retain a copy with their private failed artifacts.
+These files can contain source-backed species facts and review diagnostics;
+back them up with controller state, never publish them into the reusable catalog.
+
+An explicit `retry TAXON_ID` preserves a terminal structured profile conflict
+in private retry state, even when the review has no image correction. The next
+run supplies that conflict to independent review until the current profile is
+verified or the source-backed conflict is adjudicated; a generic image failure
+message never replaces it. `generation-retries.json` contains the same private
+source-backed facts while a conflict is outstanding, so protect and back it up
+with the rest of controller state and never publish it.
+Stored conflict sources are revalidated against the current research-domain
+allowlist before reuse. If the allowlist has narrowed, that taxon is deferred
+with an actionable error rather than placing an unauthorized source into a
+search-enabled review prompt.
+Use `retry TAXON_ID --refresh-research` when the authorized domains have changed
+or the stored conflict should be adjudicated from scratch. This explicitly
+discards outstanding conflict provenance and clears the cached profile and
+references so the next run researches them under the current allowlist; any
+independent image-correction guidance is preserved.
 
 `rotation_mode` is configured under `[display_node]`:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -194,6 +194,22 @@ not block later queue entries. Terminal factual or visual failures require an
 explicit `retry TAXON_ID` after investigation. See
 [`operations.md`](operations.md#failure-recovery).
 
+For a specific run, inspect its private structured history before reading the
+larger Codex logs:
+
+```bash
+jq . /path/to/state/runs/TAXON-TIMESTAMP/attempt-history.json
+```
+
+`outcome` separates generation-process errors, review-process errors, ordinary
+image corrections, source-backed profile conflicts, and passing attempts.
+`regressed_findings` and `regressed_axes` show a correction that returned or a
+score that fell below the quality threshold. A profile conflict may perform
+one bounded refresh; compare `profile-before-refresh.json` and
+`profile-after-refresh.json`. Do not edit the cached profile to copy a
+reviewer's claim. If a validated model is pinned with `controller.codex_model`,
+confirm that the deployed Codex CLI still accepts it.
+
 ### Catalog publication fails
 
 Inspect the structured command result first. On macOS it is written to the

--- a/src/inky_bird_frame/catalog.py
+++ b/src/inky_bird_frame/catalog.py
@@ -379,6 +379,7 @@ def has_passing_sourced_review(review: object) -> bool:
     if not isinstance(review, dict):
         return False
     correction_findings = review.get("correction_findings", [])
+    profile_conflicts = review.get("profile_conflicts", [])
     score_fields = (
         "species_accuracy",
         "anatomy_accuracy",
@@ -390,6 +391,8 @@ def has_passing_sourced_review(review: object) -> bool:
         or review.get("location_free") is not True
         or not isinstance(correction_findings, list)
         or bool(correction_findings)
+        or not isinstance(profile_conflicts, list)
+        or bool(profile_conflicts)
         or any(
             not isinstance(review.get(field), int)
             or isinstance(review.get(field), bool)

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -800,6 +800,8 @@ def retry_command(args: argparse.Namespace) -> int:
             existing_profile_conflicts = ()
         if refresh_research:
             profile_conflicts = ()
+            if existing_guidance is not None and not quality_findings:
+                quality_findings = existing_guidance.findings
         selected_profile_conflicts = profile_conflicts
         reuse_existing_guidance = (
             not refresh_research
@@ -956,6 +958,13 @@ def retry_command(args: argparse.Namespace) -> int:
             correction_source,
         )
         archived_correction_source = retained_correction_source or planned_correction_source
+        guidance_source_plate = (
+            archived_correction_source.relative_to(config.controller.state_dir).as_posix()
+            if archived_correction_source is not None
+            else existing_guidance.source_plate
+            if existing_guidance is not None
+            else None
+        )
         final_guidance = None if refresh_research else existing_guidance
         if refresh_research and existing_guidance is not None:
             retry_store.clear_quality_guidance(args.taxon_id)
@@ -963,11 +972,7 @@ def retry_command(args: argparse.Namespace) -> int:
             final_guidance = retry_store.set_quality_guidance(
                 args.taxon_id,
                 quality_findings,
-                source_plate=(
-                    archived_correction_source.relative_to(config.controller.state_dir).as_posix()
-                    if archived_correction_source is not None
-                    else None
-                ),
+                source_plate=guidance_source_plate,
                 invariant_findings=(
                     existing_guidance.invariant_findings if existing_guidance is not None else ()
                 ),

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -66,6 +66,7 @@ from .ebird_archive import import_ebird_archive, read_ebird_archive_history
 from .errors import CatalogError, DataSourceError, InkyBirdFrameError, SpeciesStateError
 from .images import prepare_uploaded_image
 from .installation import InstallationRole, doctor, setup
+from .models import ProfileConflict
 from .notifications import (
     check_display_heartbeat,
     dispatch_notifications,
@@ -84,7 +85,7 @@ from .publisher import (
     validate_catalog_additions,
     validate_public_catalog,
 )
-from .retry import RetryStore
+from .retry import RetryStore, parse_retry_profile_conflicts
 from .scheduler import ScheduledJob, SubprocessCommandRunner, run_scheduler
 from .server import serve_catalog
 
@@ -421,11 +422,12 @@ def reject_command(args: argparse.Namespace) -> int:
 def _retry_quality_guidance(
     failed_directories: list[Path],
     source_attempt: int | None,
-) -> tuple[tuple[str, ...], Path | None]:
+    allowed_domains: tuple[str, ...] | None,
+) -> tuple[tuple[str, ...], Path | None, tuple[ProfileConflict, ...]]:
     if not failed_directories:
         if source_attempt is not None:
             raise ValueError("--source-attempt requires retained failed generation attempts")
-        return (), None
+        return (), None, ()
     attempts: list[tuple[int, Path]] = []
     for attempt_path in failed_directories[-1].glob("attempt-*"):
         try:
@@ -438,7 +440,7 @@ def _retry_quality_guidance(
     if not attempts:
         if source_attempt is not None:
             raise ValueError("--source-attempt requires retained failed generation attempts")
-        return (), None
+        return (), None, ()
     attempts_by_number = dict(attempts)
     if source_attempt is None:
         selected_attempt, attempt_path = max(attempts, key=lambda item: item[0])
@@ -468,6 +470,25 @@ def _retry_quality_guidance(
         not isinstance(finding, str) or not finding.strip() for finding in findings
     ):
         raise SpeciesStateError(f"Invalid quality review findings: {review_path}")
+    try:
+        profile_conflicts = parse_retry_profile_conflicts(
+            review.get("profile_conflicts", []),
+            review_path,
+        )
+    except CatalogError as exc:
+        raise SpeciesStateError(f"Invalid quality review profile conflicts: {review_path}") from exc
+    if allowed_domains is not None:
+        try:
+            profile_conflicts = parse_retry_profile_conflicts(
+                list(profile_conflicts),
+                review_path,
+                allowed_domains=allowed_domains,
+            )
+        except CatalogError as exc:
+            raise SpeciesStateError(
+                "Retained profile conflict sources are outside the current research "
+                "allowlist; restore the authorized domains or retry with --refresh-research"
+            ) from exc
     source_plate = None
     if source_attempt is not None:
         source_plate = attempt_path / "portrait.png"
@@ -475,7 +496,10 @@ def _retry_quality_guidance(
             raise SpeciesStateError(
                 f"Generation attempt {selected_attempt} has no portrait: {attempt_path}"
             )
-    return tuple(findings) or (REVIEW_FAILURE_FALLBACK,), source_plate
+    quality_findings = tuple(findings)
+    if not quality_findings and not profile_conflicts:
+        quality_findings = (REVIEW_FAILURE_FALLBACK,)
+    return quality_findings, source_plate, profile_conflicts
 
 
 def _retry_archived_quality_guidance(
@@ -483,7 +507,8 @@ def _retry_archived_quality_guidance(
     taxon_id: int,
     source_run: str,
     source_attempt: int,
-) -> tuple[tuple[str, ...], Path]:
+    allowed_domains: tuple[str, ...] | None,
+) -> tuple[tuple[str, ...], Path, tuple[ProfileConflict, ...]]:
     run_name = source_run.strip()
     if (
         not run_name
@@ -526,17 +551,21 @@ def _retry_archived_quality_guidance(
                 raise SpeciesStateError(
                     f"Retained generation artifact escapes its attempt: {artifact_path}"
                 )
-    findings, source_plate = _retry_quality_guidance([run], source_attempt)
+    findings, source_plate, profile_conflicts = _retry_quality_guidance(
+        [run],
+        source_attempt,
+        allowed_domains,
+    )
     if source_plate is None:
         raise SpeciesStateError(f"Retained generation attempt is unavailable: {run_name}")
-    return findings, source_plate
+    return findings, source_plate, profile_conflicts
 
 
 def _retry_candidate_guidance(
     state_dir: Path,
     taxon_id: int,
     source_candidate: str,
-) -> tuple[tuple[str, ...], Path]:
+) -> tuple[tuple[str, ...], Path, tuple[ProfileConflict, ...]]:
     candidate_name = source_candidate.strip()
     if (
         not candidate_name
@@ -583,7 +612,7 @@ def _retry_candidate_guidance(
         raise SpeciesStateError(f"Retained candidate has no portrait: {candidate}")
     if sha256_file(portrait) != portrait_asset["sha256"]:
         raise SpeciesStateError(f"Retained candidate portrait checksum mismatch: {portrait}")
-    return (rejection_reason.strip(),), portrait
+    return (rejection_reason.strip(),), portrait, ()
 
 
 def _retry_species_identity(
@@ -722,20 +751,25 @@ def retry_command(args: argparse.Namespace) -> int:
         )
         quality_findings: tuple[str, ...]
         correction_source: Path | None
+        profile_conflicts: tuple[ProfileConflict, ...]
         if source_run is not None and source_attempt is not None:
-            quality_findings, correction_source = _retry_archived_quality_guidance(
-                config.controller.state_dir,
-                args.taxon_id,
-                source_run,
-                source_attempt,
+            quality_findings, correction_source, profile_conflicts = (
+                _retry_archived_quality_guidance(
+                    config.controller.state_dir,
+                    args.taxon_id,
+                    source_run,
+                    source_attempt,
+                    None if refresh_research else config.research.allowed_domains,
+                )
             )
         elif source_candidate is None:
-            quality_findings, correction_source = _retry_quality_guidance(
+            quality_findings, correction_source, profile_conflicts = _retry_quality_guidance(
                 failed_directories,
                 source_attempt,
+                None if refresh_research else config.research.allowed_domains,
             )
         else:
-            quality_findings, correction_source = _retry_candidate_guidance(
+            quality_findings, correction_source, profile_conflicts = _retry_candidate_guidance(
                 config.controller.state_dir,
                 args.taxon_id,
                 source_candidate,
@@ -750,6 +784,41 @@ def retry_command(args: argparse.Namespace) -> int:
         terminal_sources = list(sources)
         retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
         existing_guidance = retry_store.quality_guidance(args.taxon_id)
+        if existing_guidance is not None and not refresh_research:
+            try:
+                existing_profile_conflicts = parse_retry_profile_conflicts(
+                    list(existing_guidance.profile_conflicts),
+                    retry_store.path,
+                    allowed_domains=config.research.allowed_domains,
+                )
+            except CatalogError as exc:
+                raise SpeciesStateError(
+                    "Stored profile conflict sources are outside the current research "
+                    "allowlist; restore the authorized domains or retry with --refresh-research"
+                ) from exc
+        else:
+            existing_profile_conflicts = ()
+        if refresh_research:
+            profile_conflicts = ()
+        selected_profile_conflicts = profile_conflicts
+        reuse_existing_guidance = (
+            not refresh_research
+            and not quality_findings
+            and not selected_profile_conflicts
+            and existing_guidance is not None
+        )
+        if reuse_existing_guidance:
+            assert existing_guidance is not None
+            quality_findings = existing_guidance.findings
+        conflicts_by_field = {
+            conflict["field"]: conflict
+            for conflicts in (
+                existing_profile_conflicts,
+                profile_conflicts,
+            )
+            for conflict in conflicts
+        }
+        profile_conflicts = tuple(conflicts_by_field.values())
         retry_record = retry_store.get(args.taxon_id)
         deferred = retry_record is not None
         if not sources and not deferred and source_candidate is None and source_run is None:
@@ -887,8 +956,10 @@ def retry_command(args: argparse.Namespace) -> int:
             correction_source,
         )
         archived_correction_source = retained_correction_source or planned_correction_source
-        final_guidance = existing_guidance
-        if quality_findings:
+        final_guidance = None if refresh_research else existing_guidance
+        if refresh_research and existing_guidance is not None:
+            retry_store.clear_quality_guidance(args.taxon_id)
+        if (quality_findings or profile_conflicts) and not reuse_existing_guidance:
             final_guidance = retry_store.set_quality_guidance(
                 args.taxon_id,
                 quality_findings,
@@ -900,6 +971,7 @@ def retry_command(args: argparse.Namespace) -> int:
                 invariant_findings=(
                     existing_guidance.invariant_findings if existing_guidance is not None else ()
                 ),
+                profile_conflicts=profile_conflicts,
             )
         terminal_source_set = set(terminal_sources)
         cache_moves = [move for move in archive_plan if move[0] not in terminal_source_set]
@@ -940,6 +1012,9 @@ def retry_command(args: argparse.Namespace) -> int:
             "cleared_cached_references": cleared_cached_references,
             "preserved_quality_findings_count": (
                 len(final_guidance.findings) if final_guidance is not None else 0
+            ),
+            "preserved_profile_conflicts_count": (
+                len(final_guidance.profile_conflicts) if final_guidance is not None else 0
             ),
             "replaced_approved": False,
             "source_attempt": source_attempt,

--- a/src/inky_bird_frame/codex_runner.py
+++ b/src/inky_bird_frame/codex_runner.py
@@ -11,18 +11,15 @@ from urllib.parse import urlsplit
 
 from .birds import BirdSpecies, TaxonContext
 from .errors import GenerationError
-from .models import ProfileConflict, QualityReview, ReferencePhoto, SourceLink, SpeciesProfileData
-from .prompts import plate_prompt, profile_prompt, review_prompt
-
-PROFILE_CONFLICT_FIELDS: Final[tuple[str, ...]] = (
-    "family",
-    "measurements.length",
-    "measurements.wingspan",
-    "measurements.weight",
-    "field_marks",
-    "habitat",
-    "behavior",
+from .models import (
+    PROFILE_CONFLICT_FIELDS,
+    ProfileConflict,
+    QualityReview,
+    ReferencePhoto,
+    SourceLink,
+    SpeciesProfileData,
 )
+from .prompts import plate_prompt, profile_prompt, review_prompt
 
 PROFILE_SCHEMA: Final[dict[str, object]] = {
     "type": "object",
@@ -81,6 +78,7 @@ REVIEW_SCHEMA: Final[dict[str, object]] = {
         "location_free": {"type": "boolean"},
         "findings": {"type": "array", "items": {"type": "string"}},
         "correction_findings": {"type": "array", "items": {"type": "string"}},
+        "resolved_corrections": {"type": "array", "items": {"type": "string"}},
         "profile_conflicts": {
             "type": "array",
             "items": {
@@ -125,6 +123,7 @@ REVIEW_SCHEMA: Final[dict[str, object]] = {
         "location_free",
         "findings",
         "correction_findings",
+        "resolved_corrections",
         "profile_conflicts",
         "verification_sources",
     ],
@@ -320,7 +319,12 @@ class CodexRunner:
             log_path,
             search=True,
         )
-        return _parse_review(raw, allowed_domains)
+        return _parse_review(
+            raw,
+            profile,
+            allowed_domains,
+            prior_corrections=prior_corrections,
+        )
 
 
 def _non_empty_string(value: object, field: str) -> str:
@@ -420,6 +424,7 @@ def _score(raw: dict[str, object], field: str) -> int:
 
 def _parse_profile_conflicts(
     value: object,
+    current_profile: SpeciesProfileData,
     allowed_domains: tuple[str, ...] | None,
 ) -> tuple[ProfileConflict, ...]:
     if value is None:
@@ -440,6 +445,40 @@ def _parse_profile_conflicts(
         profile_value = _non_empty_string(
             raw_conflict.get("profile_value"), "profile_conflicts.profile_value"
         )
+        expected_profile_value: str
+        if field == "measurements.length":
+            expected_profile_value = current_profile["measurements"]["length"]
+        elif field == "measurements.wingspan":
+            expected_profile_value = current_profile["measurements"]["wingspan"]
+        elif field == "measurements.weight":
+            expected_profile_value = current_profile["measurements"]["weight"]
+        elif field == "field_marks":
+            expected_profile_value = json.dumps(
+                current_profile["field_marks"],
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        elif field == "family":
+            expected_profile_value = current_profile["family"]
+        elif field == "habitat":
+            expected_profile_value = current_profile["habitat"]
+        elif field == "behavior":
+            expected_profile_value = current_profile["behavior"]
+        else:
+            raise GenerationError(f"Unsupported profile conflict field: {field}")
+        matches_current_profile = profile_value == expected_profile_value
+        if field == "field_marks":
+            try:
+                matches_current_profile = (
+                    json.loads(profile_value) == current_profile["field_marks"]
+                )
+            except json.JSONDecodeError:
+                matches_current_profile = False
+        if not matches_current_profile:
+            raise GenerationError(
+                f"Codex profile conflict does not match the current profile field: {field}"
+            )
+        profile_value = expected_profile_value
         observed_value = _non_empty_string(
             raw_conflict.get("observed_value"), "profile_conflicts.observed_value"
         )
@@ -490,7 +529,38 @@ def _parse_profile_conflicts(
     return tuple(conflicts)
 
 
-def _parse_review(raw: object, allowed_domains: tuple[str, ...] | None = None) -> QualityReview:
+def _parse_resolved_corrections(
+    value: object,
+    prior_corrections: tuple[str, ...],
+    current_corrections: tuple[str, ...],
+) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    items = _string_list(value, "resolved_corrections", 0)
+    prior_by_key = {" ".join(item.split()).casefold(): item for item in prior_corrections}
+    current_keys = {" ".join(item.split()).casefold() for item in current_corrections}
+    resolved: list[str] = []
+    resolved_keys: set[str] = set()
+    for item in items:
+        key = " ".join(item.split()).casefold()
+        if key not in prior_by_key:
+            raise GenerationError("Codex resolved correction was not present in review history")
+        if key in current_keys:
+            raise GenerationError("Codex correction cannot be both resolved and actionable")
+        if key in resolved_keys:
+            raise GenerationError("Codex resolved correction is duplicated")
+        resolved_keys.add(key)
+        resolved.append(prior_by_key[key])
+    return tuple(resolved)
+
+
+def _parse_review(
+    raw: object,
+    current_profile: SpeciesProfileData,
+    allowed_domains: tuple[str, ...] | None = None,
+    *,
+    prior_corrections: tuple[str, ...] = (),
+) -> QualityReview:
     if not isinstance(raw, dict):
         raise GenerationError("Codex review output must be an object")
     reported_pass = raw.get("passed") is True
@@ -503,7 +573,16 @@ def _parse_review(raw: object, allowed_domains: tuple[str, ...] | None = None) -
     correction_findings = tuple(
         _string_list(raw.get("correction_findings"), "correction_findings", 0)
     )
-    profile_conflicts = _parse_profile_conflicts(raw.get("profile_conflicts"), allowed_domains)
+    resolved_corrections = _parse_resolved_corrections(
+        raw.get("resolved_corrections"),
+        prior_corrections,
+        correction_findings,
+    )
+    profile_conflicts = _parse_profile_conflicts(
+        raw.get("profile_conflicts"),
+        current_profile,
+        allowed_domains,
+    )
     sources = raw.get("verification_sources")
     if not isinstance(sources, list):
         raise GenerationError("Codex review verification_sources must be a list")
@@ -566,4 +645,5 @@ def _parse_review(raw: object, allowed_domains: tuple[str, ...] | None = None) -
         verification_sources=tuple(verification_sources),
         correction_findings=correction_findings,
         profile_conflicts=profile_conflicts,
+        resolved_corrections=resolved_corrections,
     )

--- a/src/inky_bird_frame/codex_runner.py
+++ b/src/inky_bird_frame/codex_runner.py
@@ -11,8 +11,18 @@ from urllib.parse import urlsplit
 
 from .birds import BirdSpecies, TaxonContext
 from .errors import GenerationError
-from .models import QualityReview, ReferencePhoto, SourceLink, SpeciesProfileData
+from .models import ProfileConflict, QualityReview, ReferencePhoto, SourceLink, SpeciesProfileData
 from .prompts import plate_prompt, profile_prompt, review_prompt
+
+PROFILE_CONFLICT_FIELDS: Final[tuple[str, ...]] = (
+    "family",
+    "measurements.length",
+    "measurements.wingspan",
+    "measurements.weight",
+    "field_marks",
+    "habitat",
+    "behavior",
+)
 
 PROFILE_SCHEMA: Final[dict[str, object]] = {
     "type": "object",
@@ -71,6 +81,31 @@ REVIEW_SCHEMA: Final[dict[str, object]] = {
         "location_free": {"type": "boolean"},
         "findings": {"type": "array", "items": {"type": "string"}},
         "correction_findings": {"type": "array", "items": {"type": "string"}},
+        "profile_conflicts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "field": {"type": "string", "enum": list(PROFILE_CONFLICT_FIELDS)},
+                    "profile_value": {"type": "string"},
+                    "observed_value": {"type": "string"},
+                    "sources": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "title": {"type": "string"},
+                                "url": {"type": "string"},
+                            },
+                            "required": ["title", "url"],
+                            "additionalProperties": False,
+                        },
+                    },
+                },
+                "required": ["field", "profile_value", "observed_value", "sources"],
+                "additionalProperties": False,
+            },
+        },
         "verification_sources": {
             "type": "array",
             "items": {
@@ -90,6 +125,7 @@ REVIEW_SCHEMA: Final[dict[str, object]] = {
         "location_free",
         "findings",
         "correction_findings",
+        "profile_conflicts",
         "verification_sources",
     ],
     "additionalProperties": False,
@@ -97,10 +133,18 @@ REVIEW_SCHEMA: Final[dict[str, object]] = {
 
 
 class CodexRunner:
-    def __init__(self, executable: Path, workspace: Path, timeout_seconds: int = 1200) -> None:
+    def __init__(
+        self,
+        executable: Path,
+        workspace: Path,
+        timeout_seconds: int = 1200,
+        *,
+        model: str | None = None,
+    ) -> None:
         self.executable = executable
         self.workspace = workspace.resolve()
         self.timeout_seconds = timeout_seconds
+        self.model = model
         if not self.executable.is_file():
             raise GenerationError(f"Codex executable not found: {self.executable}")
 
@@ -117,6 +161,8 @@ class CodexRunner:
                 "workspace-write" if writable else "read-only",
             ]
         )
+        if self.model is not None:
+            command.extend(["--model", self.model])
         return command
 
     def _run(
@@ -181,9 +227,18 @@ class CodexRunner:
         log_path: Path,
         *,
         allowed_domains: tuple[str, ...],
+        prior_profile: SpeciesProfileData | None = None,
+        profile_conflicts: tuple[ProfileConflict, ...] = (),
     ) -> SpeciesProfileData:
         raw = self._structured(
-            profile_prompt(species, context, references, allowed_domains),
+            profile_prompt(
+                species,
+                context,
+                references,
+                allowed_domains,
+                prior_profile=prior_profile,
+                profile_conflicts=profile_conflicts,
+            ),
             PROFILE_SCHEMA,
             reference_paths,
             output_path,
@@ -247,9 +302,18 @@ class CodexRunner:
         log_path: Path,
         *,
         allowed_domains: tuple[str, ...],
+        prior_corrections: tuple[str, ...] = (),
+        prior_profile_conflicts: tuple[ProfileConflict, ...] = (),
     ) -> QualityReview:
         raw = self._structured(
-            review_prompt(species, profile, references, allowed_domains),
+            review_prompt(
+                species,
+                profile,
+                references,
+                allowed_domains,
+                prior_corrections=prior_corrections,
+                prior_profile_conflicts=prior_profile_conflicts,
+            ),
             REVIEW_SCHEMA,
             [plate_path, *reference_paths],
             output_path,
@@ -354,6 +418,78 @@ def _score(raw: dict[str, object], field: str) -> int:
     return value
 
 
+def _parse_profile_conflicts(
+    value: object,
+    allowed_domains: tuple[str, ...] | None,
+) -> tuple[ProfileConflict, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise GenerationError("Codex review field profile_conflicts must be a list")
+    conflicts: list[ProfileConflict] = []
+    fields: set[str] = set()
+    for raw_conflict in value:
+        if not isinstance(raw_conflict, dict):
+            raise GenerationError("Codex profile conflict must be an object")
+        field = _non_empty_string(raw_conflict.get("field"), "profile_conflicts.field")
+        if field not in PROFILE_CONFLICT_FIELDS:
+            raise GenerationError(f"Codex profile conflict field is not supported: {field}")
+        if field in fields:
+            raise GenerationError(f"Codex profile conflict field is duplicated: {field}")
+        fields.add(field)
+        profile_value = _non_empty_string(
+            raw_conflict.get("profile_value"), "profile_conflicts.profile_value"
+        )
+        observed_value = _non_empty_string(
+            raw_conflict.get("observed_value"), "profile_conflicts.observed_value"
+        )
+        if profile_value == observed_value:
+            raise GenerationError("Codex profile conflict values must disagree")
+        raw_sources = raw_conflict.get("sources")
+        if not isinstance(raw_sources, list):
+            raise GenerationError("Codex profile conflict sources must be a list")
+        sources: list[SourceLink] = []
+        urls: set[str] = set()
+        domains: set[str] = set()
+        for raw_source in raw_sources:
+            if not isinstance(raw_source, dict):
+                raise GenerationError("Codex profile conflict source must be an object")
+            url = _non_empty_string(raw_source.get("url"), "profile_conflicts.sources.url")
+            if not url.startswith("https://"):
+                raise GenerationError("Codex profile conflict source URLs must use HTTPS")
+            if not _allowed_source(url, allowed_domains):
+                raise GenerationError(
+                    "Codex profile conflict cited a source outside the configured allowlist"
+                )
+            if url in urls:
+                continue
+            urls.add(url)
+            identity = _source_identity(url, allowed_domains)
+            if identity is not None:
+                domains.add(identity)
+            sources.append(
+                SourceLink(
+                    title=_non_empty_string(
+                        raw_source.get("title"), "profile_conflicts.sources.title"
+                    ),
+                    url=url,
+                )
+            )
+        if len(sources) < 2 or len(domains) < 2:
+            raise GenerationError(
+                "Codex profile conflicts must cite two independent verification sources"
+            )
+        conflicts.append(
+            ProfileConflict(
+                field=field,
+                profile_value=profile_value,
+                observed_value=observed_value,
+                sources=sources,
+            )
+        )
+    return tuple(conflicts)
+
+
 def _parse_review(raw: object, allowed_domains: tuple[str, ...] | None = None) -> QualityReview:
     if not isinstance(raw, dict):
         raise GenerationError("Codex review output must be an object")
@@ -367,6 +503,7 @@ def _parse_review(raw: object, allowed_domains: tuple[str, ...] | None = None) -
     correction_findings = tuple(
         _string_list(raw.get("correction_findings"), "correction_findings", 0)
     )
+    profile_conflicts = _parse_profile_conflicts(raw.get("profile_conflicts"), allowed_domains)
     sources = raw.get("verification_sources")
     if not isinstance(sources, list):
         raise GenerationError("Codex review verification_sources must be a list")
@@ -410,10 +547,14 @@ def _parse_review(raw: object, allowed_domains: tuple[str, ...] | None = None) -
         )
         >= 4
     )
-    if requires_correction and not correction_findings:
-        raise GenerationError("Failed Codex reviews must include correction_findings")
-    if not requires_correction and correction_findings:
-        raise GenerationError("Passing Codex reviews must not include correction_findings")
+    if requires_correction and not (correction_findings or profile_conflicts):
+        raise GenerationError(
+            "Failed Codex reviews must include correction_findings or profile_conflicts"
+        )
+    if not requires_correction and (correction_findings or profile_conflicts):
+        raise GenerationError(
+            "Passing Codex reviews must not include correction_findings or profile_conflicts"
+        )
     return QualityReview(
         passed=not requires_correction,
         species_accuracy=species_accuracy,
@@ -424,4 +565,5 @@ def _parse_review(raw: object, allowed_domains: tuple[str, ...] | None = None) -
         findings=findings,
         verification_sources=tuple(verification_sources),
         correction_findings=correction_findings,
+        profile_conflicts=profile_conflicts,
     )

--- a/src/inky_bird_frame/codex_runner.py
+++ b/src/inky_bird_frame/codex_runner.py
@@ -489,11 +489,15 @@ def _parse_profile_conflicts(
                 raise GenerationError(
                     "Codex field_marks conflict observed_value must be a JSON array"
                 ) from exc
-            if not isinstance(observed_field_marks, list) or any(
-                not isinstance(mark, str) or not mark.strip() for mark in observed_field_marks
+            if (
+                not isinstance(observed_field_marks, list)
+                or len(observed_field_marks) < 4
+                or any(
+                    not isinstance(mark, str) or not mark.strip() for mark in observed_field_marks
+                )
             ):
                 raise GenerationError(
-                    "Codex field_marks conflict observed_value must be a JSON array of strings"
+                    "Codex field_marks conflict observed_value must contain at least four strings"
                 )
             if observed_field_marks == current_profile["field_marks"]:
                 raise GenerationError("Codex profile conflict values must disagree")

--- a/src/inky_bird_frame/codex_runner.py
+++ b/src/inky_bird_frame/codex_runner.py
@@ -482,6 +482,26 @@ def _parse_profile_conflicts(
         observed_value = _non_empty_string(
             raw_conflict.get("observed_value"), "profile_conflicts.observed_value"
         )
+        if field == "field_marks":
+            try:
+                observed_field_marks = json.loads(observed_value)
+            except json.JSONDecodeError as exc:
+                raise GenerationError(
+                    "Codex field_marks conflict observed_value must be a JSON array"
+                ) from exc
+            if not isinstance(observed_field_marks, list) or any(
+                not isinstance(mark, str) or not mark.strip() for mark in observed_field_marks
+            ):
+                raise GenerationError(
+                    "Codex field_marks conflict observed_value must be a JSON array of strings"
+                )
+            if observed_field_marks == current_profile["field_marks"]:
+                raise GenerationError("Codex profile conflict values must disagree")
+            observed_value = json.dumps(
+                observed_field_marks,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
         if profile_value == observed_value:
             raise GenerationError("Codex profile conflict values must disagree")
         raw_sources = raw_conflict.get("sources")

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -112,6 +112,7 @@ class ControllerConfig:
     catalog_dir: Path
     state_dir: Path
     codex_path: Path
+    codex_model: str | None
     bind_host: str
     port: int
     references_per_species: int
@@ -638,6 +639,7 @@ def load_config(path: Path, *, load_secrets: bool = True) -> AppConfig:
             catalog_dir=_path(_string(controller, "catalog_dir"), base_dir),
             state_dir=_path(_string(controller, "state_dir"), base_dir),
             codex_path=_executable_path(_string(controller, "codex_path"), base_dir),
+            codex_model=_optional_string(controller, "codex_model", default="") or None,
             bind_host=_string(controller, "bind_host"),
             port=_integer(controller, "port", maximum=65535),
             references_per_species=_integer(controller, "references_per_species"),

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -88,7 +88,7 @@ from .models import ProfileConflict, ReferencePhoto, SpeciesProfileData
 from .prompts import PROMPT_VERSION
 from .references import download_references, fetch_reference_candidates
 from .research import ResearchBudget
-from .retry import RetryStore
+from .retry import RetryStore, parse_retry_profile_conflicts
 from .timeutil import parse_utc_timestamp
 
 REVIEW_FAILURE_FALLBACK = "The previous attempt did not meet every automated review threshold."
@@ -1749,6 +1749,7 @@ def generate_candidate(
     initial_correction_findings: tuple[str, ...] = (),
     initial_correction_source: Path | None = None,
     invariant_correction_findings: tuple[str, ...] = (),
+    initial_profile_conflicts: tuple[ProfileConflict, ...] = (),
 ) -> Path:
     state_dir = config.controller.state_dir
     if species.taxon_id in approved_taxon_ids(config.controller.catalog_dir):
@@ -1794,7 +1795,7 @@ def generate_candidate(
         correction_source = initial_correction_source
         resolved_corrections: tuple[str, ...] = ()
         prior_review_corrections: tuple[str, ...] = ()
-        prior_profile_conflicts: tuple[ProfileConflict, ...] = ()
+        prior_profile_conflicts = initial_profile_conflicts
         previous_scores: dict[str, int] | None = None
         profile_refresh_used = False
         terminal_detail: str | None = None
@@ -1849,6 +1850,14 @@ def generate_candidate(
             history_entry["generation_seconds"] = round(monotonic() - generation_started, 3)
 
             review_started = monotonic()
+            reviewed_corrections = _deduplicate_findings(
+                prior_review_corrections,
+                tuple(
+                    finding
+                    for finding in correction_findings
+                    if finding not in {PROFILE_REFRESH_CORRECTION, REVIEW_FAILURE_FALLBACK}
+                ),
+            )
             try:
                 review = runner.review_plate(
                     species,
@@ -1859,7 +1868,7 @@ def generate_candidate(
                     attempt_dir / "quality-review.json",
                     logs / f"03-quality-review-attempt-{attempt:02d}.log",
                     allowed_domains=config.research.allowed_domains,
-                    prior_corrections=prior_review_corrections,
+                    prior_corrections=reviewed_corrections,
                     prior_profile_conflicts=prior_profile_conflicts,
                 )
             except Exception as exc:
@@ -1891,13 +1900,12 @@ def generate_candidate(
                 axis for axis, score in current_scores.items() if score < 4
             ] + ([] if review.location_free else ["location_free"])
             new_correction_keys = {_finding_key(finding) for finding in review.correction_findings}
-            newly_resolved = tuple(
-                finding
-                for finding in correction_findings
-                if finding not in {PROFILE_REFRESH_CORRECTION, REVIEW_FAILURE_FALLBACK}
-                if _finding_key(finding) not in new_correction_keys
+            resolved_candidates = _deduplicate_findings(
+                resolved_corrections,
+                review.resolved_corrections,
             )
-            resolved_keys = {_finding_key(finding) for finding in resolved_corrections}
+            resolved_keys = {_finding_key(finding) for finding in resolved_candidates}
+            history_entry["newly_resolved_findings"] = list(review.resolved_corrections)
             history_entry["regressed_findings"] = [
                 finding
                 for finding in review.correction_findings
@@ -1945,12 +1953,13 @@ def generate_candidate(
                 shutil.copytree(attempt_dir, destination)
                 return destination
 
-            resolved_corrections = _deduplicate_findings(
-                resolved_corrections,
-                newly_resolved,
+            resolved_corrections = tuple(
+                finding
+                for finding in resolved_candidates
+                if _finding_key(finding) not in new_correction_keys
             )
             prior_review_corrections = _deduplicate_findings(
-                prior_review_corrections,
+                reviewed_corrections,
                 review.correction_findings,
             )
             prior_profile_conflicts = _deduplicate_profile_conflicts(
@@ -1995,6 +2004,12 @@ def generate_candidate(
                     _write_attempt_history(logs, work, history)
                     raise
                 profile_refresh_used = True
+                refreshed_fields = {conflict["field"] for conflict in review.profile_conflicts}
+                prior_profile_conflicts = tuple(
+                    conflict
+                    for conflict in prior_profile_conflicts
+                    if conflict["field"] not in refreshed_fields
+                )
                 history_entry["profile_refresh"] = "completed"
                 history_entry["profile_changed"] = before_refresh != profile
                 _write_attempt_history(logs, work, history)
@@ -2196,16 +2211,28 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                     generate_candidate(config, species, config.controller.workspace_dir)
                 else:
                     try:
+                        profile_conflicts = parse_retry_profile_conflicts(
+                            list(guidance.profile_conflicts),
+                            retry_store.path,
+                            allowed_domains=config.research.allowed_domains,
+                        )
+                    except CatalogError as exc:
+                        raise DataSourceError(
+                            "Stored profile conflict sources are outside the current "
+                            "research allowlist"
+                        ) from exc
+                    try:
                         correction_source = _retry_source_plate(
                             config.controller.state_dir,
                             guidance.source_plate,
                         )
                     except SpeciesStateError:
-                        if guidance.invariant_findings:
+                        if guidance.invariant_findings or guidance.profile_conflicts:
                             retry_store.set_quality_guidance(
                                 species.taxon_id,
                                 guidance.invariant_findings,
                                 invariant_findings=guidance.invariant_findings,
+                                profile_conflicts=guidance.profile_conflicts,
                             )
                         else:
                             retry_store.clear_quality_guidance(species.taxon_id)
@@ -2223,6 +2250,7 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                         initial_correction_findings=current_findings,
                         initial_correction_source=correction_source,
                         invariant_correction_findings=guidance.invariant_findings,
+                        initial_profile_conflicts=profile_conflicts,
                     )
                 with catalog_state_lock(config.controller.state_dir):
                     entry = approve_candidate(
@@ -2278,11 +2306,14 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 )
             except QualityReviewError as exc:
                 retry_store.clear(species.taxon_id)
-                if guidance is not None and guidance.invariant_findings:
+                if guidance is not None and (
+                    guidance.invariant_findings or guidance.profile_conflicts
+                ):
                     retry_store.set_quality_guidance(
                         species.taxon_id,
                         guidance.invariant_findings,
                         invariant_findings=guidance.invariant_findings,
+                        profile_conflicts=guidance.profile_conflicts,
                     )
                 else:
                     retry_store.clear_quality_guidance(species.taxon_id)

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -8,10 +8,12 @@ import os
 import shutil
 from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from time import monotonic
 from typing import cast
 
 from .birdbuddy import sync_birdbuddy_detections
@@ -82,7 +84,7 @@ from .errors import (
 from .geo import DiscoveryLocation, resolve_discovery_location
 from .http import write_json_atomic
 from .images import prepare_generated_plate
-from .models import ReferencePhoto, SpeciesProfileData
+from .models import ProfileConflict, ReferencePhoto, SpeciesProfileData
 from .prompts import PROMPT_VERSION
 from .references import download_references, fetch_reference_candidates
 from .research import ResearchBudget
@@ -90,6 +92,9 @@ from .retry import RetryStore
 from .timeutil import parse_utc_timestamp
 
 REVIEW_FAILURE_FALLBACK = "The previous attempt did not meet every automated review threshold."
+PROFILE_REFRESH_CORRECTION = (
+    "Update every visible factual note to match the refreshed source-backed profile exactly."
+)
 HUMAN_REVIEW_SOURCE = "human-review"
 
 
@@ -1638,6 +1643,104 @@ def load_or_create_profile(
     return profile, output_path
 
 
+def _refresh_profile_after_conflict(
+    config: AppConfig,
+    species: BirdSpecies,
+    references: list[ReferencePhoto],
+    reference_paths: list[Path],
+    runner: CodexRunner,
+    prior_profile: SpeciesProfileData,
+    profile_conflicts: tuple[ProfileConflict, ...],
+    output_path: Path,
+    log_path: Path,
+) -> SpeciesProfileData:
+    if not config.research.enabled:
+        raise GenerationError("Profile conflict requires research, but research is disabled")
+    context = fetch_taxon_context(species.taxon_id)
+    ResearchBudget(
+        config.controller.state_dir / "research-budget.json",
+        daily_limit=config.research.max_searches_per_day,
+        species_limit=config.research.max_searches_per_species,
+    ).consume(species.taxon_id)
+    write_json_atomic(log_path.parent / "profile-before-refresh.json", prior_profile)
+    researched_profile = runner.create_profile(
+        species,
+        context,
+        references,
+        reference_paths,
+        output_path,
+        log_path,
+        allowed_domains=config.research.allowed_domains,
+        prior_profile=prior_profile,
+        profile_conflicts=profile_conflicts,
+    )
+    profile = _merge_refreshed_profile(prior_profile, researched_profile, profile_conflicts)
+    cache_path = config.controller.state_dir / "profiles" / str(species.taxon_id) / "profile.json"
+    write_json_atomic(output_path, profile)
+    write_json_atomic(cache_path, profile)
+    write_json_atomic(log_path.parent / "profile-after-refresh.json", profile)
+    return profile
+
+
+def _merge_refreshed_profile(
+    prior_profile: SpeciesProfileData,
+    researched_profile: SpeciesProfileData,
+    profile_conflicts: tuple[ProfileConflict, ...],
+) -> SpeciesProfileData:
+    merged = deepcopy(prior_profile)
+    for conflict in profile_conflicts:
+        field = conflict["field"]
+        if field.startswith("measurements."):
+            measurement = field.removeprefix("measurements.")
+            if measurement == "length":
+                merged["measurements"]["length"] = researched_profile["measurements"]["length"]
+            elif measurement == "wingspan":
+                merged["measurements"]["wingspan"] = researched_profile["measurements"]["wingspan"]
+            else:
+                merged["measurements"]["weight"] = researched_profile["measurements"]["weight"]
+        elif field == "family":
+            merged["family"] = researched_profile["family"]
+        elif field == "field_marks":
+            merged["field_marks"] = researched_profile["field_marks"]
+        elif field == "habitat":
+            merged["habitat"] = researched_profile["habitat"]
+        elif field == "behavior":
+            merged["behavior"] = researched_profile["behavior"]
+        else:
+            raise GenerationError(f"Unsupported profile conflict field: {field}")
+    merged["sources"] = researched_profile["sources"]
+    # The research pass returns a complete profile, so its citations cover both
+    # refreshed and preserved fields without growing the cached source list on retries.
+    return merged
+
+
+def _deduplicate_findings(*groups: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(finding for group in groups for finding in group))
+
+
+def _finding_key(finding: str) -> str:
+    return " ".join(finding.split()).casefold()
+
+
+def _deduplicate_profile_conflicts(
+    *groups: tuple[ProfileConflict, ...],
+) -> tuple[ProfileConflict, ...]:
+    conflicts: dict[str, ProfileConflict] = {}
+    for conflict in (item for group in groups for item in group):
+        conflicts[json.dumps(conflict, sort_keys=True)] = conflict
+    return tuple(conflicts.values())
+
+
+def _write_attempt_history(
+    logs: Path,
+    work: Path,
+    history: list[dict[str, object]],
+) -> None:
+    payload = {"schema_version": 1, "attempts": history}
+    write_json_atomic(logs / "attempt-history.json", payload)
+    write_json_atomic(work / "attempt-history.json", payload)
+
+
 def generate_candidate(
     config: AppConfig,
     species: BirdSpecies,
@@ -1656,7 +1759,15 @@ def generate_candidate(
     references = load_or_fetch_references(config, species)
     reference_root = state_dir / "references" / str(species.taxon_id)
     reference_paths = [reference_root / reference.filename for reference in references]
-    runner = CodexRunner(config.controller.codex_path, workspace)
+    runner = (
+        CodexRunner(config.controller.codex_path, workspace)
+        if config.controller.codex_model is None
+        else CodexRunner(
+            config.controller.codex_path,
+            workspace,
+            model=config.controller.codex_model,
+        )
+    )
     work_parent = state_dir / "work"
     work_parent.mkdir(parents=True, exist_ok=True)
     # The image tool copies its bitmap from inside Codex, so that one output
@@ -1681,54 +1792,140 @@ def generate_candidate(
         )
         correction_findings = initial_correction_findings
         correction_source = initial_correction_source
+        resolved_corrections: tuple[str, ...] = ()
+        prior_review_corrections: tuple[str, ...] = ()
+        prior_profile_conflicts: tuple[ProfileConflict, ...] = ()
+        previous_scores: dict[str, int] | None = None
+        profile_refresh_used = False
+        terminal_detail: str | None = None
         history: list[dict[str, object]] = []
         for attempt in range(1, config.controller.max_generation_attempts + 1):
             attempt_dir = work / f"attempt-{attempt:02d}"
             attempt_dir.mkdir()
             portrait_path = attempt_dir / "portrait.png"
             display_path = attempt_dir / "display.png"
-            with TemporaryDirectory(
-                prefix=f"{species.taxon_id}-attempt-{attempt:02d}-",
-                dir=generation_parent,
-            ) as generation_temporary:
-                generated_path = Path(generation_temporary) / "generated.png"
-                correction_source_sha256 = (
-                    sha256_file(correction_source) if correction_source is not None else None
-                )
-                runner.generate_plate(
+            carried_invariants = _deduplicate_findings(
+                invariant_correction_findings,
+                resolved_corrections,
+            )
+            history_entry: dict[str, object] = {
+                "attempt": attempt,
+                "started_at": utc_now(),
+                "prompt_version": PROMPT_VERSION,
+                "generator": "Codex subscription / built-in gpt-image-2",
+                "requested_model": config.controller.codex_model,
+                "has_correction_source": correction_source is not None,
+                "carried_invariant_count": len(carried_invariants),
+            }
+            generation_started = monotonic()
+            try:
+                with TemporaryDirectory(
+                    prefix=f"{species.taxon_id}-attempt-{attempt:02d}-",
+                    dir=generation_parent,
+                ) as generation_temporary:
+                    generated_path = Path(generation_temporary) / "generated.png"
+                    correction_source_sha256 = (
+                        sha256_file(correction_source) if correction_source is not None else None
+                    )
+                    runner.generate_plate(
+                        species,
+                        profile,
+                        references,
+                        reference_paths,
+                        generated_path,
+                        logs / f"02-generation-attempt-{attempt:02d}.log",
+                        correction_findings,
+                        correction_source_path=correction_source,
+                        invariant_findings=carried_invariants,
+                    )
+                    prepare_generated_plate(generated_path, portrait_path, display_path)
+            except Exception as exc:
+                history_entry["generation_seconds"] = round(monotonic() - generation_started, 3)
+                history_entry["outcome"] = "generation_error"
+                history_entry["error_type"] = type(exc).__name__
+                history.append(history_entry)
+                _write_attempt_history(logs, work, history)
+                raise
+            history_entry["generation_seconds"] = round(monotonic() - generation_started, 3)
+
+            review_started = monotonic()
+            try:
+                review = runner.review_plate(
                     species,
                     profile,
                     references,
+                    portrait_path,
                     reference_paths,
-                    generated_path,
-                    logs / f"02-generation-attempt-{attempt:02d}.log",
-                    correction_findings,
-                    correction_source_path=correction_source,
-                    invariant_findings=invariant_correction_findings,
+                    attempt_dir / "quality-review.json",
+                    logs / f"03-quality-review-attempt-{attempt:02d}.log",
+                    allowed_domains=config.research.allowed_domains,
+                    prior_corrections=prior_review_corrections,
+                    prior_profile_conflicts=prior_profile_conflicts,
                 )
-                prepare_generated_plate(generated_path, portrait_path, display_path)
-
-            review = runner.review_plate(
-                species,
-                profile,
-                references,
-                portrait_path,
-                reference_paths,
-                attempt_dir / "quality-review.json",
-                logs / f"03-quality-review-attempt-{attempt:02d}.log",
-                allowed_domains=config.research.allowed_domains,
-            )
+            except Exception as exc:
+                history_entry["review_seconds"] = round(monotonic() - review_started, 3)
+                history_entry["outcome"] = "review_error"
+                history_entry["error_type"] = type(exc).__name__
+                history.append(history_entry)
+                _write_attempt_history(logs, work, history)
+                raise
+            history_entry["review_seconds"] = round(monotonic() - review_started, 3)
             write_json_atomic(attempt_dir / "quality-review.json", review.as_dict())
-            history_entry: dict[str, object] = {
-                "attempt": attempt,
-                "quality_review": review.as_dict(),
-            }
+            history_entry["quality_review"] = review.as_dict()
+            history_entry["outcome"] = (
+                "passed"
+                if review.passed
+                else "profile_conflict"
+                if review.profile_conflicts
+                else "correction_required"
+            )
             if correction_source_sha256 is not None:
                 history_entry["correction_source_sha256"] = correction_source_sha256
+            current_scores = {
+                "species_accuracy": review.species_accuracy,
+                "anatomy_accuracy": review.anatomy_accuracy,
+                "text_accuracy": review.text_accuracy,
+                "composition_quality": review.composition_quality,
+            }
+            history_entry["failed_axes"] = [
+                axis for axis, score in current_scores.items() if score < 4
+            ] + ([] if review.location_free else ["location_free"])
+            new_correction_keys = {_finding_key(finding) for finding in review.correction_findings}
+            newly_resolved = tuple(
+                finding
+                for finding in correction_findings
+                if finding not in {PROFILE_REFRESH_CORRECTION, REVIEW_FAILURE_FALLBACK}
+                if _finding_key(finding) not in new_correction_keys
+            )
+            resolved_keys = {_finding_key(finding) for finding in resolved_corrections}
+            history_entry["regressed_findings"] = [
+                finding
+                for finding in review.correction_findings
+                if _finding_key(finding) in resolved_keys
+            ]
+            history_entry["regressed_axes"] = (
+                [
+                    axis
+                    for axis, score in current_scores.items()
+                    if previous_scores is not None and previous_scores[axis] >= 4 and score < 4
+                ]
+                if previous_scores is not None
+                else []
+            )
+            prior_conflict_values = {
+                conflict["field"]: conflict["observed_value"]
+                for conflict in prior_profile_conflicts
+            }
+            history_entry["profile_reversals"] = [
+                conflict["field"]
+                for conflict in review.profile_conflicts
+                if conflict["field"] in prior_conflict_values
+                and prior_conflict_values[conflict["field"]] != conflict["observed_value"]
+            ]
             history.append(history_entry)
+            _write_attempt_history(logs, work, history)
             if review.passed:
                 shutil.copy2(profile_path, attempt_dir / "profile.json")
-                write_json_atomic(logs / "attempt-history.json", history)
                 write_candidate_manifest(
                     attempt_dir,
                     species,
@@ -1747,15 +1944,76 @@ def generate_candidate(
                     raise CatalogError(f"Pending destination already exists: {destination}")
                 shutil.copytree(attempt_dir, destination)
                 return destination
-            correction_findings = review.correction_findings or (REVIEW_FAILURE_FALLBACK,)
+
+            resolved_corrections = _deduplicate_findings(
+                resolved_corrections,
+                newly_resolved,
+            )
+            prior_review_corrections = _deduplicate_findings(
+                prior_review_corrections,
+                review.correction_findings,
+            )
+            prior_profile_conflicts = _deduplicate_profile_conflicts(
+                prior_profile_conflicts,
+                review.profile_conflicts,
+            )
+            previous_scores = current_scores
+            if review.profile_conflicts:
+                if not config.research.enabled:
+                    terminal_detail = (
+                        "a profile conflict requires research, but research is disabled"
+                    )
+                    history_entry["profile_refresh"] = "disabled"
+                    _write_attempt_history(logs, work, history)
+                    break
+                if profile_refresh_used:
+                    terminal_detail = "a profile conflict remained after one source-backed refresh"
+                    history_entry["profile_refresh"] = "conflict_remained"
+                    _write_attempt_history(logs, work, history)
+                    break
+                if attempt == config.controller.max_generation_attempts:
+                    terminal_detail = "a profile conflict was found on the final attempt"
+                    history_entry["profile_refresh"] = "not_run_no_attempt_remaining"
+                    _write_attempt_history(logs, work, history)
+                    break
+                before_refresh = profile
+                try:
+                    profile = _refresh_profile_after_conflict(
+                        config,
+                        species,
+                        references,
+                        reference_paths,
+                        runner,
+                        profile,
+                        review.profile_conflicts,
+                        profile_output_path,
+                        logs / f"04-profile-refresh-attempt-{attempt:02d}.log",
+                    )
+                except Exception as exc:
+                    history_entry["profile_refresh"] = "failed"
+                    history_entry["profile_refresh_error_type"] = type(exc).__name__
+                    _write_attempt_history(logs, work, history)
+                    raise
+                profile_refresh_used = True
+                history_entry["profile_refresh"] = "completed"
+                history_entry["profile_changed"] = before_refresh != profile
+                _write_attempt_history(logs, work, history)
+            correction_findings = _deduplicate_findings(
+                review.correction_findings,
+                (PROFILE_REFRESH_CORRECTION,) if review.profile_conflicts else (),
+            ) or (REVIEW_FAILURE_FALLBACK,)
             correction_source = portrait_path
 
         failed = state_dir / "failed" / f"{species.taxon_id}-{_timestamp()}"
         failed.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(work, failed)
+        reason = terminal_detail or (
+            "the configured maximum of "
+            f"{config.controller.max_generation_attempts} attempts was exhausted"
+        )
         raise QualityReviewError(
-            "Generated plate failed automated quality review after "
-            f"{config.controller.max_generation_attempts} attempts; artifacts retained at {failed}"
+            f"Generated plate failed automated quality review because {reason}; "
+            f"artifacts retained at {failed}"
         )
 
 

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -1702,6 +1702,7 @@ def _merge_refreshed_profile(
             merged["family"] = researched_profile["family"]
         elif field == "field_marks":
             merged["field_marks"] = researched_profile["field_marks"]
+            merged["palette"] = researched_profile["palette"]
         elif field == "habitat":
             merged["habitat"] = researched_profile["habitat"]
         elif field == "behavior":
@@ -1720,15 +1721,6 @@ def _deduplicate_findings(*groups: tuple[str, ...]) -> tuple[str, ...]:
 
 def _finding_key(finding: str) -> str:
     return " ".join(finding.split()).casefold()
-
-
-def _deduplicate_profile_conflicts(
-    *groups: tuple[ProfileConflict, ...],
-) -> tuple[ProfileConflict, ...]:
-    conflicts: dict[str, ProfileConflict] = {}
-    for conflict in (item for group in groups for item in group):
-        conflicts[conflict["field"]] = conflict
-    return tuple(conflicts.values())
 
 
 def _write_attempt_history(
@@ -1962,10 +1954,7 @@ def generate_candidate(
                 reviewed_corrections,
                 review.correction_findings,
             )
-            prior_profile_conflicts = _deduplicate_profile_conflicts(
-                prior_profile_conflicts,
-                review.profile_conflicts,
-            )
+            prior_profile_conflicts = review.profile_conflicts
             previous_scores = current_scores
             if review.profile_conflicts:
                 if not config.research.enabled:

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -93,7 +93,9 @@ from .timeutil import parse_utc_timestamp
 
 REVIEW_FAILURE_FALLBACK = "The previous attempt did not meet every automated review threshold."
 PROFILE_REFRESH_CORRECTION = (
-    "Update every visible factual note to match the refreshed source-backed profile exactly."
+    "Update the primary bird, every supplementary study, and every visible factual note to "
+    "match the refreshed source-backed profile exactly, including its field marks, palette, "
+    "measurements, and anatomy."
 )
 HUMAN_REVIEW_SOURCE = "human-review"
 

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -2028,7 +2028,8 @@ def generate_candidate(
         )
         raise QualityReviewError(
             f"Generated plate failed automated quality review because {reason}; "
-            f"artifacts retained at {failed}"
+            f"artifacts retained at {failed}",
+            profile_conflicts=prior_profile_conflicts,
         )
 
 
@@ -2306,14 +2307,19 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 )
             except QualityReviewError as exc:
                 retry_store.clear(species.taxon_id)
+                remaining_profile_conflicts = (
+                    guidance.profile_conflicts
+                    if guidance is not None and exc.profile_conflicts is None
+                    else exc.profile_conflicts or ()
+                )
                 if guidance is not None and (
-                    guidance.invariant_findings or guidance.profile_conflicts
+                    guidance.invariant_findings or remaining_profile_conflicts
                 ):
                     retry_store.set_quality_guidance(
                         species.taxon_id,
                         guidance.invariant_findings,
                         invariant_findings=guidance.invariant_findings,
-                        profile_conflicts=guidance.profile_conflicts,
+                        profile_conflicts=remaining_profile_conflicts,
                     )
                 else:
                     retry_store.clear_quality_guidance(species.taxon_id)

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -1727,7 +1727,7 @@ def _deduplicate_profile_conflicts(
 ) -> tuple[ProfileConflict, ...]:
     conflicts: dict[str, ProfileConflict] = {}
     for conflict in (item for group in groups for item in group):
-        conflicts[json.dumps(conflict, sort_keys=True)] = conflict
+        conflicts[conflict["field"]] = conflict
     return tuple(conflicts.values())
 
 

--- a/src/inky_bird_frame/errors.py
+++ b/src/inky_bird_frame/errors.py
@@ -1,5 +1,12 @@
 """Project-specific exceptions."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .models import ProfileConflict
+
 
 class InkyBirdFrameError(Exception):
     """Base exception for expected application failures."""
@@ -51,3 +58,12 @@ class GenerationError(InkyBirdFrameError):
 
 class QualityReviewError(GenerationError):
     """Raised when a species exhausts its automated visual-review attempts."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        profile_conflicts: tuple[ProfileConflict, ...] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.profile_conflicts = profile_conflicts

--- a/src/inky_bird_frame/models.py
+++ b/src/inky_bird_frame/models.py
@@ -3,7 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TypedDict
+from typing import Final, TypedDict
+
+PROFILE_CONFLICT_FIELDS: Final[tuple[str, ...]] = (
+    "family",
+    "measurements.length",
+    "measurements.wingspan",
+    "measurements.weight",
+    "field_marks",
+    "habitat",
+    "behavior",
+)
 
 
 class SourceLink(TypedDict):
@@ -79,8 +89,11 @@ class QualityReview:
     verification_sources: tuple[SourceLink, ...] = ()
     correction_findings: tuple[str, ...] = ()
     profile_conflicts: tuple[ProfileConflict, ...] = ()
+    resolved_corrections: tuple[str, ...] = ()
 
     def as_dict(self) -> dict[str, object]:
+        # Resolution claims are private within-run control state. Public quality
+        # artifacts retain only the final actionable corrections and conflicts.
         result: dict[str, object] = {
             "passed": self.passed,
             "species_accuracy": self.species_accuracy,

--- a/src/inky_bird_frame/models.py
+++ b/src/inky_bird_frame/models.py
@@ -30,6 +30,13 @@ class SpeciesProfileData(TypedDict):
     sources: list[SourceLink]
 
 
+class ProfileConflict(TypedDict):
+    field: str
+    profile_value: str
+    observed_value: str
+    sources: list[SourceLink]
+
+
 @dataclass(frozen=True)
 class ReferencePhoto:
     photo_id: int
@@ -71,9 +78,10 @@ class QualityReview:
     findings: tuple[str, ...]
     verification_sources: tuple[SourceLink, ...] = ()
     correction_findings: tuple[str, ...] = ()
+    profile_conflicts: tuple[ProfileConflict, ...] = ()
 
     def as_dict(self) -> dict[str, object]:
-        return {
+        result: dict[str, object] = {
             "passed": self.passed,
             "species_accuracy": self.species_accuracy,
             "anatomy_accuracy": self.anatomy_accuracy,
@@ -84,3 +92,6 @@ class QualityReview:
             "verification_sources": list(self.verification_sources),
             "correction_findings": list(self.correction_findings),
         }
+        if self.profile_conflicts:
+            result["profile_conflicts"] = list(self.profile_conflicts)
+        return result

--- a/src/inky_bird_frame/prompts.py
+++ b/src/inky_bird_frame/prompts.py
@@ -7,9 +7,9 @@ from html.parser import HTMLParser
 from pathlib import Path
 
 from .birds import BirdSpecies, TaxonContext
-from .models import ReferencePhoto, SpeciesProfileData
+from .models import ProfileConflict, ReferencePhoto, SpeciesProfileData
 
-PROMPT_VERSION = "field-journal-v4"
+PROMPT_VERSION = "field-journal-v5"
 
 
 class _TextExtractor(HTMLParser):
@@ -42,7 +42,26 @@ def profile_prompt(
     context: TaxonContext,
     references: list[ReferencePhoto],
     allowed_domains: tuple[str, ...],
+    *,
+    prior_profile: SpeciesProfileData | None = None,
+    profile_conflicts: tuple[ProfileConflict, ...] = (),
 ) -> str:
+    conflict_review = ""
+    if prior_profile is not None and profile_conflicts:
+        conflicts = json.dumps(profile_conflicts, indent=2, sort_keys=True)
+        conflict_review = f"""
+This is one bounded re-adjudication of a cached profile after an independent plate review reported
+the following source conflicts:
+{conflicts}
+
+Prior profile:
+{json.dumps(prior_profile, indent=2, sort_keys=True)}
+
+Research each disputed fact from direct source pages. Do not assume either the prior profile or the
+review claim is correct, and do not copy a review claim into the profile without source support.
+Return a complete profile, preserving prior facts that remain supported and replacing only facts
+that the direct sources establish are wrong or incomplete.
+"""
     return f"""Create a factual, location-neutral species profile for a scientific
 field-journal plate.
 
@@ -63,10 +82,15 @@ facts still needed for the schema. Restrict browsing to these domains:
 Use at least two independent sources from that list and do not rely on search snippets. Use the
 attached images to verify plumage colors, proportions, bill, eye, legs, wings, and tail. Return
 only the requested JSON.
+{conflict_review}
 
 Requirements:
 - Preserve the exact taxon ID and names supplied above.
-- Measurements must include units and a compact range suitable for a field note.
+- Measurements must include units and faithfully represent one compatible published measurement
+  set. Preserve source qualifiers such as sex, age, or season when they materially explain
+  different values. Never synthesize a new range by combining endpoints from incompatible sources.
+- Never invent or infer a measurement. Use a source-supported single value or a range whose
+  endpoints come from one compatible published measurement set.
 - Provide 4 to 6 concise, visible field marks.
 - Provide 3 to 5 plain-language palette colors tied to the species.
 - Source URLs must be direct HTTPS pages used for the facts.
@@ -108,7 +132,7 @@ empty space to make room for corrections.
 Current actionable corrections required after an independent review:
 {issues}
 
-Non-regression constraints from earlier human review:
+Non-regression constraints from earlier accepted reviews:
 {invariants}
 
 Use the supplied current profile as the authority for visible facts, including any text that the
@@ -186,21 +210,25 @@ Style and composition:
 - Bottom margin contains a small wing-pattern study, a bill/head study, and color swatches.
 - Right edge contains a thin, self-contained vertical schematic range ruler representing exactly
   the published body length "{measurements["length"]}". For a range, the ruler itself spans only
-  the published endpoints, with the minimum at the bottom and maximum at the top, plus exactly
-  four evenly spaced unlabeled interior ticks creating five equal proportional segments. Those
-  ticks are subdivisions, not one-unit increments. For a single value, use one dimension line
-  labeled with that value. Use explicit units. Do not draw a zero-based or wider full-range axis,
-  and do not add a separate range bracket whose endpoints could disagree with the ruler. Label it
+  the published endpoints, with the minimum at the bottom and maximum at the top. Include a small
+  number of roughly even, unlabeled interior ticks as visual subdivisions; their count and spacing
+  do not encode measurement units. For a single value, use one dimension line labeled with that
+  value. Use explicit units. Do not draw a zero-based or wider full-range axis, and do not add a
+  separate range bracket whose endpoints could disagree with the ruler. Label it
   "BODY LENGTH: {measurements["length"]}" and "SCHEMATIC — NOT TO SCALE". Keep it separate from
   the bird; never imply that it measures the printed illustration.
 - It should look like a carefully scanned scientific field-journal page, not Audubon, not a
   decorative poster, not a collage, and not photorealistic.
 - Quiet margins. No scenery, map, location, ZIP code, coordinates, date, logo, or watermark.
 - Preserve the exact 3:4 portrait aspect ratio and keep all text inside safe page margins.
-- Exactly one complete primary bird specimen, with one head, one beak, two wings, two legs, and
-  one tail. The detached bottom-margin wing and bill/head studies are supplementary anatomical
+- Exactly one complete primary bird specimen, with one head, one beak, one anatomically complete
+  pair of wings, one anatomically complete pair of legs, and one tail. In a natural side-on or
+  overlapping pose, the far-side wing or leg may be partly or fully occluded when the visible body
+  geometry clearly supports its natural attachment; do not add a duplicated limb merely to make
+  the count visible. Every visible limb, joint, foot, wing, eye, and tail must remain complete and
+  plausible. The detached bottom-margin wing and bill/head studies are supplementary anatomical
   details, not additional birds; keep them spatially separate from the primary specimen and make
-  each anatomically accurate. Do not depict a second complete bird. Feet must be plausible.
+  each anatomically accurate. Do not depict a second complete bird.
 - Render the primary bird's tail as a distinct anatomical structure matching the supplied field
   mark; do not let folded wing tips obscure or impersonate it.
 - When a supplied field mark calls an eye dark and inconspicuous while specifying its pupil shape,
@@ -227,13 +255,39 @@ def review_prompt(
     profile: SpeciesProfileData,
     references: list[ReferencePhoto],
     allowed_domains: tuple[str, ...],
+    *,
+    prior_corrections: tuple[str, ...] = (),
+    prior_profile_conflicts: tuple[ProfileConflict, ...] = (),
 ) -> str:
+    prior_review = ""
+    if prior_corrections or prior_profile_conflicts:
+        corrections = "\n".join(f"- {item}" for item in prior_corrections) or "- None"
+        conflicts = (
+            json.dumps(prior_profile_conflicts, indent=2, sort_keys=True)
+            if prior_profile_conflicts
+            else "- None"
+        )
+        prior_review = f"""
+Earlier review history for convergence checking:
+Image corrections already requested:
+{corrections}
+Profile conflicts already reported:
+{conflicts}
+
+Check that earlier corrected image defects did not regress. Do not reverse an earlier correction
+without naming the concrete visible regression or direct-source conflict that justifies doing so.
+Repeated or contradictory profile conflicts must remain in profile_conflicts, not be converted into
+an unsupported image edit. Re-evaluate every earlier conflict against the current profile; never
+repeat a stale profile_value from history, and drop a conflict that the current direct sources no
+longer support.
+"""
     return f"""Review Image 1 as a candidate scientific field-journal plate for
 {species.common_name} ({species.scientific_name}). Images 2 onward are licensed field-reference
 photos of the same species.
 
 Facts proposed by the research pass:
 {json.dumps(profile, indent=2, sort_keys=True)}
+{prior_review}
 
 Independently verify the species identity, measurements, and field marks against live source pages
 and the attached references. Do not assume the proposed facts are correct. Restrict browsing to
@@ -243,12 +297,13 @@ against the attached field-reference photos. Compare every visible factual claim
 independently verified facts. Do not infer a seasonal-plumage correction from one image or an
 unstated assumption; require explicit agreement from at least two direct allowed source pages
 before requesting a seasonal qualifier or color-pattern rewrite. Inspect every ruler, scale, and
-measurement diagram for internal
-consistency: values must increase from bottom to top, its endpoints, ticks, and units must match the
-published value or range, no separate marker may disagree with it, and it must be clearly
-schematic rather than presented as the printed bird's size. A range ruler must contain exactly
-four evenly spaced unlabeled interior ticks; treat them as five proportional segments, not
-one-unit increments. Treat any mismatch as a material text error with a specific correction.
+measurement diagram for internal consistency: values must increase from bottom to top, its labeled
+endpoints and units must match the published value or range, no separate marker may disagree with
+it, and it must be clearly schematic rather than presented as the printed bird's size. Unlabeled
+interior ticks are visual subdivisions, not unit increments: their exact count or minor spacing
+variation is not a factual error and must not lower a score below 4 by itself. Missing or reversed
+endpoints, wrong values or units, a contradictory marker, or a ruler presented as the printed
+bird's scale remains a material text error with a specific correction.
 Read every visible text line in full rather than summarizing it. Compare its spelling, numbers,
 and word order to the proposed facts; treat duplicated, omitted, substituted, or nonsensical words
 as material text errors and give the exact replacement. When unequal mandibles are a field mark,
@@ -259,18 +314,28 @@ reversed rendering, an exaggerated or materially understated projection, a trunc
 upper mandible, or inconsistent proportions between heads—even when the lower mandible is
 technically longer. Confirm that no place name, ZIP code, coordinates, map, or local-observation
 detail appears. Use findings for the complete review record, including verified strengths and
-concrete issues. Put only required, actionable changes in correction_findings; do not repeat
-positive observations, source confirmations, or already-correct traits there. Return at least two
-direct HTTPS source URLs from distinct configured domains used for verification.
+concrete issues. Put only visible, required image changes in correction_findings; do not repeat
+positive observations, source confirmations, or already-correct traits there. Put disagreements
+between the proposed profile and independently verified direct-source facts in profile_conflicts
+instead—state the supported profile field, proposed value, independently observed value, and at
+least two direct HTTPS sources from distinct configured domains. Do not instruct the image
+generator to apply the reviewer claim directly. profile_value must quote the current proposed
+field, not an earlier review history entry. Identity fields are not adjudicable profile conflicts.
+Return at least two direct HTTPS source URLs from distinct configured domains used for overall
+verification.
 
 Set passed=true only when all four scores are at least 4, location_free is true, the bird has
-exactly one complete primary specimen with one head, one beak, two wings, two legs, and one tail,
+exactly one complete primary specimen with one head, one beak, an anatomically complete pair of
+wings, an anatomically complete pair of legs, and one tail,
 and there are no material species or text errors. Clearly detached wing and bill/head studies are
 intentional supplementary anatomy, not duplicate parts or additional birds; do not fail them for
 their presence, but validate each study independently and fail malformed anatomy or a study that
-appears attached to the primary specimen. When passed=false, correction_findings must contain at
-least one specific change.
-When passed=true, correction_findings must be empty. Return only the requested JSON.
+appears attached to the primary specimen. A naturally occluded far-side wing or leg is acceptable
+when pose and visible attachment geometry are anatomically convincing; never excuse a malformed,
+detached, duplicated, or implausibly attached visible structure, a missing visible eye, or broken
+feet as occlusion. When passed=false, at least one of correction_findings or profile_conflicts must
+be nonempty. When passed=true, correction_findings and profile_conflicts must both be empty. Return
+only the requested JSON.
 
 Reference provenance:
 {reference_list(references)}

--- a/src/inky_bird_frame/prompts.py
+++ b/src/inky_bird_frame/prompts.py
@@ -323,8 +323,8 @@ between the proposed profile and independently verified direct-source facts in p
 instead—state the supported profile field, proposed value, independently observed value, and at
 least two direct HTTPS sources from distinct configured domains. Do not instruct the image
 generator to apply the reviewer claim directly. profile_value must quote the current proposed
-field, not an earlier review history entry. For field_marks, encode the current list as a compact
-JSON array. Identity fields are not adjudicable profile conflicts.
+field, not an earlier review history entry. For field_marks, encode both profile_value and
+observed_value as compact JSON arrays. Identity fields are not adjudicable profile conflicts.
 Return at least two direct HTTPS source URLs from distinct configured domains used for overall
 verification.
 

--- a/src/inky_bird_frame/prompts.py
+++ b/src/inky_bird_frame/prompts.py
@@ -276,6 +276,9 @@ Profile conflicts already reported:
 
 Check that earlier corrected image defects did not regress. Do not reverse an earlier correction
 without naming the concrete visible regression or direct-source conflict that justifies doing so.
+Copy an earlier correction into resolved_corrections only when the current image visibly satisfies
+that exact request. Do not mark a correction resolved when a new correction reverses, refines, or
+otherwise supersedes it. Every resolved_corrections entry must exactly match one earlier correction.
 Repeated or contradictory profile conflicts must remain in profile_conflicts, not be converted into
 an unsupported image edit. Re-evaluate every earlier conflict against the current profile; never
 repeat a stale profile_value from history, and drop a conflict that the current direct sources no
@@ -320,7 +323,8 @@ between the proposed profile and independently verified direct-source facts in p
 instead—state the supported profile field, proposed value, independently observed value, and at
 least two direct HTTPS sources from distinct configured domains. Do not instruct the image
 generator to apply the reviewer claim directly. profile_value must quote the current proposed
-field, not an earlier review history entry. Identity fields are not adjudicable profile conflicts.
+field, not an earlier review history entry. For field_marks, encode the current list as a compact
+JSON array. Identity fields are not adjudicable profile conflicts.
 Return at least two direct HTTPS source URLs from distinct configured domains used for overall
 verification.
 
@@ -334,7 +338,8 @@ appears attached to the primary specimen. A naturally occluded far-side wing or 
 when pose and visible attachment geometry are anatomically convincing; never excuse a malformed,
 detached, duplicated, or implausibly attached visible structure, a missing visible eye, or broken
 feet as occlusion. When passed=false, at least one of correction_findings or profile_conflicts must
-be nonempty. When passed=true, correction_findings and profile_conflicts must both be empty. Return
+be nonempty. When passed=true, correction_findings and profile_conflicts must both be empty.
+resolved_corrections may contain only exact earlier requests that this image now satisfies. Return
 only the requested JSON.
 
 Reference provenance:

--- a/src/inky_bird_frame/retry.py
+++ b/src/inky_bird_frame/retry.py
@@ -7,11 +7,13 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timedelta
 from pathlib import Path, PurePosixPath
 from typing import cast
+from urllib.parse import urlsplit
 
 from .birds import BirdSpecies
 from .catalog import utc_now
 from .errors import CatalogError
 from .http import write_json_atomic
+from .models import PROFILE_CONFLICT_FIELDS, ProfileConflict, SourceLink
 from .timeutil import parse_utc_timestamp
 
 
@@ -49,6 +51,7 @@ class RetryGuidance:
     findings: tuple[str, ...]
     source_plate: str | None = None
     invariant_findings: tuple[str, ...] = ()
+    profile_conflicts: tuple[ProfileConflict, ...] = ()
 
     def as_dict(self) -> dict[str, object]:
         value: dict[str, object] = {
@@ -59,6 +62,8 @@ class RetryGuidance:
             value["source_plate"] = self.source_plate
         if self.invariant_findings:
             value["invariant_findings"] = list(self.invariant_findings)
+        if self.profile_conflicts:
+            value["profile_conflicts"] = list(self.profile_conflicts)
         return value
 
 
@@ -182,6 +187,7 @@ class RetryStore:
         *,
         source_plate: str | None = None,
         invariant_findings: tuple[str, ...] = (),
+        profile_conflicts: tuple[ProfileConflict, ...] = (),
     ) -> RetryGuidance:
         guidance = _parse_guidance(
             {
@@ -189,6 +195,7 @@ class RetryStore:
                 "findings": list(findings),
                 "source_plate": source_plate,
                 "invariant_findings": list(invariant_findings),
+                "profile_conflicts": list(profile_conflicts),
             },
             self.path,
         )
@@ -291,6 +298,91 @@ def _parse_record(raw: object, source: Path) -> RetryRecord:
     )
 
 
+def parse_retry_profile_conflicts(
+    raw: object,
+    source: Path,
+    *,
+    allowed_domains: tuple[str, ...] | None = None,
+) -> tuple[ProfileConflict, ...]:
+    if not isinstance(raw, list):
+        raise CatalogError(f"Invalid retry quality guidance: {source}")
+    conflicts: list[ProfileConflict] = []
+    fields: set[str] = set()
+    for item in raw:
+        if not isinstance(item, dict) or set(item) != {
+            "field",
+            "profile_value",
+            "observed_value",
+            "sources",
+        }:
+            raise CatalogError(f"Invalid retry quality guidance: {source}")
+        field = item.get("field")
+        profile_value = item.get("profile_value")
+        observed_value = item.get("observed_value")
+        raw_sources = item.get("sources")
+        if (
+            not isinstance(field, str)
+            or field not in PROFILE_CONFLICT_FIELDS
+            or field in fields
+            or not isinstance(profile_value, str)
+            or not profile_value.strip()
+            or not isinstance(observed_value, str)
+            or not observed_value.strip()
+            or profile_value.strip() == observed_value.strip()
+            or not isinstance(raw_sources, list)
+        ):
+            raise CatalogError(f"Invalid retry quality guidance: {source}")
+        parsed_sources: list[SourceLink] = []
+        urls: set[str] = set()
+        domains: set[str] = set()
+        for raw_source in raw_sources:
+            if not isinstance(raw_source, dict) or set(raw_source) != {"title", "url"}:
+                raise CatalogError(f"Invalid retry quality guidance: {source}")
+            title = raw_source.get("title")
+            url = raw_source.get("url")
+            if (
+                not isinstance(title, str)
+                or not title.strip()
+                or not isinstance(url, str)
+                or not url.startswith("https://")
+            ):
+                raise CatalogError(f"Invalid retry quality guidance: {source}")
+            hostname = urlsplit(url).hostname
+            if hostname is None or (
+                allowed_domains is not None
+                and not any(
+                    hostname == domain or hostname.endswith(f".{domain}")
+                    for domain in allowed_domains
+                )
+            ):
+                raise CatalogError(f"Invalid retry quality guidance: {source}")
+            if url in urls:
+                continue
+            urls.add(url)
+            source_identity = next(
+                (
+                    domain
+                    for domain in allowed_domains or ()
+                    if hostname == domain or hostname.endswith(f".{domain}")
+                ),
+                hostname.casefold(),
+            )
+            domains.add(source_identity)
+            parsed_sources.append(SourceLink(title=title.strip(), url=url))
+        if len(parsed_sources) < 2 or len(domains) < 2:
+            raise CatalogError(f"Invalid retry quality guidance: {source}")
+        fields.add(field)
+        conflicts.append(
+            ProfileConflict(
+                field=field,
+                profile_value=profile_value.strip(),
+                observed_value=observed_value.strip(),
+                sources=parsed_sources,
+            )
+        )
+    return tuple(conflicts)
+
+
 def _parse_guidance(raw: object, source: Path) -> RetryGuidance:
     if not isinstance(raw, dict):
         raise CatalogError(f"Invalid retry quality guidance: {source}")
@@ -298,12 +390,16 @@ def _parse_guidance(raw: object, source: Path) -> RetryGuidance:
     findings = raw.get("findings")
     source_plate = raw.get("source_plate")
     invariant_findings = raw.get("invariant_findings", [])
+    profile_conflicts = parse_retry_profile_conflicts(
+        raw.get("profile_conflicts", []),
+        source,
+    )
     if (
         not isinstance(taxon_id, int)
         or isinstance(taxon_id, bool)
         or taxon_id <= 0
         or not isinstance(findings, list)
-        or not findings
+        or (not findings and not profile_conflicts)
         or any(not isinstance(finding, str) or not finding.strip() for finding in findings)
         or not isinstance(invariant_findings, list)
         or any(
@@ -332,4 +428,5 @@ def _parse_guidance(raw: object, source: Path) -> RetryGuidance:
         findings=merged_findings,
         source_plate=source_plate,
         invariant_findings=tuple(cast(list[str], invariant_findings)),
+        profile_conflicts=profile_conflicts,
     )

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -16,6 +16,7 @@ from inky_bird_frame.catalog import (
     approve_candidate,
     archive_invalid_approved_candidate,
     candidate_directory,
+    has_passing_sourced_review,
     has_valid_approved_candidate,
     read_catalog_entries,
     read_collection,
@@ -66,6 +67,33 @@ def make_candidate(state: Path, species: BirdSpecies, review: QualityReview) -> 
 
 
 class CatalogTests(unittest.TestCase):
+    def test_passing_review_gate_rejects_profile_conflicts(self) -> None:
+        review = QualityReview(
+            True,
+            5,
+            5,
+            5,
+            5,
+            True,
+            (),
+            (
+                {"title": "One", "url": "https://one.example/bird"},
+                {"title": "Two", "url": "https://two.example/bird"},
+            ),
+        ).as_dict()
+        review["profile_conflicts"] = [
+            {
+                "field": "measurements.length",
+                "profile_value": "10 cm",
+                "observed_value": "12 cm",
+                "sources": [],
+            }
+        ]
+
+        self.assertFalse(has_passing_sourced_review(review))
+        review["profile_conflicts"] = "invalid"
+        self.assertFalse(has_passing_sourced_review(review))
+
     def test_atomic_json_writes_support_concurrent_health_requests(self) -> None:
         with TemporaryDirectory() as temporary:
             path = Path(temporary) / "index.json"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,7 @@ from inky_bird_frame.errors import (
     GenerationError,
     SpeciesStateError,
 )
+from inky_bird_frame.models import ProfileConflict
 from inky_bird_frame.retry import RetryStore
 
 
@@ -63,7 +64,15 @@ def controller_config(state_dir: Path, catalog_dir: Path | None = None) -> Simpl
         controller=SimpleNamespace(
             state_dir=state_dir,
             catalog_dir=catalog_dir if catalog_dir is not None else state_dir / "catalog",
-        )
+        ),
+        research=SimpleNamespace(
+            allowed_domains=(
+                "allaboutbirds.org",
+                "audubon.org",
+                "birds.example",
+                "field.example",
+            )
+        ),
     )
 
 
@@ -1018,6 +1027,23 @@ rotation_mode = "shuffle_bag"
                 ("Keep the visible eye correction.",),
                 source_plate="archive/42-source/portrait.png",
                 invariant_findings=("Keep the visible eye correction.",),
+                profile_conflicts=(
+                    {
+                        "field": "measurements.length",
+                        "profile_value": "10-20 cm",
+                        "observed_value": "12-15 cm",
+                        "sources": [
+                            {
+                                "title": "Birds",
+                                "url": "https://birds.example/length",
+                            },
+                            {
+                                "title": "Field",
+                                "url": "https://field.example/length",
+                            },
+                        ],
+                    },
+                ),
             )
             config = controller_config(state_dir)
             output = io.StringIO()
@@ -1033,6 +1059,7 @@ rotation_mode = "shuffle_bag"
         self.assertIsNone(retry)
         self.assertEqual(guidance, expected)
         self.assertEqual(result["preserved_quality_findings_count"], 1)
+        self.assertEqual(result["preserved_profile_conflicts_count"], 1)
         self.assertTrue(result["preserved_correction_source"])
 
     def test_retry_reads_findings_from_legacy_null_correction_field(self) -> None:
@@ -1240,6 +1267,262 @@ rotation_mode = "shuffle_bag"
         self.assertEqual(queue[0].source, "human-review")
         self.assertEqual(collection["taxa"], [])
         self.assertIsNotNone(collection["legacy_seed_queue_migrated_at"])
+
+    def test_retry_preserves_a_terminal_profile_conflict(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-example-bird"
+            attempt = failed / "attempt-01"
+            attempt.mkdir(parents=True)
+            (attempt / "quality-review.json").write_text(
+                json.dumps(
+                    {
+                        "passed": False,
+                        "findings": ["The cached length conflicts with direct sources"],
+                        "correction_findings": [],
+                        "profile_conflicts": [
+                            {
+                                "field": "measurements.length",
+                                "profile_value": "10-20 cm",
+                                "observed_value": "12-15 cm",
+                                "sources": [
+                                    {
+                                        "title": "Birds",
+                                        "url": "https://birds.example/length",
+                                    },
+                                    {
+                                        "title": "Field",
+                                        "url": "https://field.example/length",
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                )
+            )
+            (failed / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Example Bird",
+                        "scientific_name": "Avis exemplum",
+                    }
+                )
+            )
+            config = controller_config(state_dir)
+            output = io.StringIO()
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(output),
+            ):
+                retry_command(Namespace(taxon_id=42))
+
+            guidance = RetryStore(state_dir / "generation-retries.json").quality_guidance(42)
+            result = json.loads(output.getvalue())["data"]
+
+        self.assertIsNotNone(guidance)
+        self.assertEqual(result["preserved_profile_conflicts_count"], 1)
+        if guidance is not None:
+            self.assertEqual(guidance.findings, ())
+            self.assertEqual(len(guidance.profile_conflicts), 1)
+            self.assertEqual(guidance.profile_conflicts[0]["field"], "measurements.length")
+
+    def test_retry_keeps_existing_conflict_with_new_image_guidance(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-example-bird"
+            attempt = failed / "attempt-01"
+            attempt.mkdir(parents=True)
+            (attempt / "quality-review.json").write_text(
+                json.dumps(
+                    {
+                        "passed": False,
+                        "findings": ["The visible wing is malformed"],
+                        "correction_findings": ["Repair the visible wing"],
+                    }
+                )
+            )
+            (failed / "profile.json").write_text(
+                json.dumps(
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Example Bird",
+                        "scientific_name": "Avis exemplum",
+                    }
+                )
+            )
+            conflict = {
+                "field": "measurements.length",
+                "profile_value": "10-20 cm",
+                "observed_value": "12-15 cm",
+                "sources": [
+                    {"title": "Birds", "url": "https://birds.example/length"},
+                    {"title": "Field", "url": "https://field.example/length"},
+                ],
+            }
+            config = controller_config(state_dir)
+            RetryStore(state_dir / "generation-retries.json").set_quality_guidance(
+                42,
+                (),
+                profile_conflicts=(cast(ProfileConflict, conflict),),
+            )
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(io.StringIO()),
+            ):
+                retry_command(Namespace(taxon_id=42))
+
+            guidance = RetryStore(state_dir / "generation-retries.json").quality_guidance(42)
+
+        self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(guidance.findings, ("Repair the visible wing",))
+            self.assertEqual(guidance.profile_conflicts, (conflict,))
+
+    def test_retry_rejects_conflict_sources_outside_the_allowlist(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-example-bird"
+            attempt = failed / "attempt-01"
+            attempt.mkdir(parents=True)
+            (attempt / "quality-review.json").write_text(
+                json.dumps(
+                    {
+                        "passed": False,
+                        "findings": ["Length conflict"],
+                        "correction_findings": [],
+                        "profile_conflicts": [
+                            {
+                                "field": "measurements.length",
+                                "profile_value": "10-20 cm",
+                                "observed_value": "12-15 cm",
+                                "sources": [
+                                    {
+                                        "title": "Outside",
+                                        "url": "https://outside.example/length",
+                                    },
+                                    {
+                                        "title": "Other",
+                                        "url": "https://other.example/length",
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                )
+            )
+            write_test_species_identity(failed)
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(
+                    SpeciesStateError,
+                    "outside the current research allowlist",
+                ),
+            ):
+                retry_command(Namespace(taxon_id=42))
+
+    def test_retry_refresh_research_discards_stale_profile_conflict(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            store = RetryStore(state_dir / "generation-retries.json")
+            store.record_failure(
+                42,
+                GenerationError("profile conflict remained"),
+                now=datetime(2026, 8, 2, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+                species=BirdSpecies(42, "Example Bird", "Avis exemplum", 1, "test"),
+            )
+            store.set_quality_guidance(
+                42,
+                (),
+                profile_conflicts=(
+                    cast(
+                        ProfileConflict,
+                        {
+                            "field": "measurements.length",
+                            "profile_value": "10-20 cm",
+                            "observed_value": "12-15 cm",
+                            "sources": [
+                                {
+                                    "title": "Outside",
+                                    "url": "https://outside.example/length",
+                                },
+                                {
+                                    "title": "Other",
+                                    "url": "https://other.example/length",
+                                },
+                            ],
+                        },
+                    ),
+                ),
+            )
+            config = controller_config(state_dir)
+            output = io.StringIO()
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(output),
+            ):
+                retry_command(Namespace(taxon_id=42, refresh_research=True))
+
+            guidance = RetryStore(state_dir / "generation-retries.json").quality_guidance(42)
+            result = json.loads(output.getvalue())["data"]
+
+        self.assertIsNone(guidance)
+        self.assertEqual(result["preserved_profile_conflicts_count"], 0)
+        self.assertTrue(result["queued_for_generation"])
+
+    def test_retry_rejects_stored_conflict_outside_the_allowlist(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            store = RetryStore(state_dir / "generation-retries.json")
+            store.record_failure(
+                42,
+                GenerationError("profile conflict remained"),
+                now=datetime(2026, 8, 2, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+                species=BirdSpecies(42, "Example Bird", "Avis exemplum", 1, "test"),
+            )
+            store.set_quality_guidance(
+                42,
+                (),
+                profile_conflicts=(
+                    cast(
+                        ProfileConflict,
+                        {
+                            "field": "measurements.length",
+                            "profile_value": "10-20 cm",
+                            "observed_value": "12-15 cm",
+                            "sources": [
+                                {
+                                    "title": "Outside",
+                                    "url": "https://outside.example/length",
+                                },
+                                {
+                                    "title": "Other",
+                                    "url": "https://other.example/length",
+                                },
+                            ],
+                        },
+                    ),
+                ),
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(
+                    SpeciesStateError,
+                    "Stored profile conflict sources are outside the current research allowlist",
+                ),
+            ):
+                retry_command(Namespace(taxon_id=42))
 
     def test_retry_refreshes_stale_queued_identity(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1477,6 +1477,65 @@ rotation_mode = "shuffle_bag"
         self.assertEqual(result["preserved_profile_conflicts_count"], 0)
         self.assertTrue(result["queued_for_generation"])
 
+    def test_retry_refresh_research_preserves_non_conflict_guidance(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            source_plate = state_dir / "archive/42-human/portrait.png"
+            source_plate.parent.mkdir(parents=True)
+            source_plate.write_bytes(b"human-reviewed source")
+            store = RetryStore(state_dir / "generation-retries.json")
+            store.record_failure(
+                42,
+                GenerationError("profile conflict remained"),
+                now=datetime(2026, 8, 2, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+                species=BirdSpecies(42, "Example Bird", "Avis exemplum", 1, "test"),
+            )
+            correction = "Keep the human-reviewed eye and bill proportions"
+            store.set_quality_guidance(
+                42,
+                (correction,),
+                source_plate="archive/42-human/portrait.png",
+                invariant_findings=(correction,),
+                profile_conflicts=(
+                    cast(
+                        ProfileConflict,
+                        {
+                            "field": "measurements.length",
+                            "profile_value": "10-20 cm",
+                            "observed_value": "12-15 cm",
+                            "sources": [
+                                {
+                                    "title": "Outside",
+                                    "url": "https://outside.example/length",
+                                },
+                                {
+                                    "title": "Other",
+                                    "url": "https://other.example/length",
+                                },
+                            ],
+                        },
+                    ),
+                ),
+            )
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                redirect_stdout(io.StringIO()),
+            ):
+                retry_command(Namespace(taxon_id=42, refresh_research=True))
+
+            guidance = RetryStore(state_dir / "generation-retries.json").quality_guidance(42)
+
+        self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(guidance.findings, (correction,))
+            self.assertEqual(guidance.invariant_findings, (correction,))
+            self.assertEqual(guidance.source_plate, "archive/42-human/portrait.png")
+            self.assertEqual(guidance.profile_conflicts, ())
+
     def test_retry_rejects_stored_conflict_outside_the_allowlist(self) -> None:
         with TemporaryDirectory() as temporary:
             state_dir = Path(temporary)

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -618,6 +618,41 @@ class CodexRunnerTests(unittest.TestCase):
             review.profile_conflicts[0]["profile_value"],
             '["one","two","three","four"]',
         )
+        self.assertEqual(
+            review.profile_conflicts[0]["observed_value"],
+            '["one","two","three","different"]',
+        )
+
+    def test_field_mark_conflict_rejects_semantically_equal_observed_value(self) -> None:
+        with self.assertRaisesRegex(GenerationError, "values must disagree"):
+            _parse_review(
+                {
+                    "passed": False,
+                    "species_accuracy": 3,
+                    "anatomy_accuracy": 5,
+                    "text_accuracy": 5,
+                    "composition_quality": 5,
+                    "location_free": True,
+                    "findings": ["The proposed field marks conflict with direct sources"],
+                    "correction_findings": [],
+                    "profile_conflicts": [
+                        {
+                            "field": "field_marks",
+                            "profile_value": '["one","two","three","four"]',
+                            "observed_value": '["one", "two", "three", "four"]',
+                            "sources": [
+                                {"title": "Birds", "url": "https://birds.example/marks"},
+                                {"title": "Field", "url": "https://field.example/marks"},
+                            ],
+                        }
+                    ],
+                    "verification_sources": [
+                        {"title": "Birds", "url": "https://birds.example/marks"},
+                        {"title": "Field", "url": "https://field.example/marks"},
+                    ],
+                },
+                ("birds.example", "field.example"),
+            )
 
     def test_review_accepts_only_explicit_resolutions_from_history(self) -> None:
         review = _parse_review(

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -654,6 +654,37 @@ class CodexRunnerTests(unittest.TestCase):
                 ("birds.example", "field.example"),
             )
 
+    def test_field_mark_conflict_rejects_empty_observed_value(self) -> None:
+        with self.assertRaisesRegex(GenerationError, "at least four strings"):
+            _parse_review(
+                {
+                    "passed": False,
+                    "species_accuracy": 3,
+                    "anatomy_accuracy": 5,
+                    "text_accuracy": 5,
+                    "composition_quality": 5,
+                    "location_free": True,
+                    "findings": ["The proposed field marks conflict with direct sources"],
+                    "correction_findings": [],
+                    "profile_conflicts": [
+                        {
+                            "field": "field_marks",
+                            "profile_value": '["one","two","three","four"]',
+                            "observed_value": "[]",
+                            "sources": [
+                                {"title": "Birds", "url": "https://birds.example/marks"},
+                                {"title": "Field", "url": "https://field.example/marks"},
+                            ],
+                        }
+                    ],
+                    "verification_sources": [
+                        {"title": "Birds", "url": "https://birds.example/marks"},
+                        {"title": "Field", "url": "https://field.example/marks"},
+                    ],
+                },
+                ("birds.example", "field.example"),
+            )
+
     def test_review_accepts_only_explicit_resolutions_from_history(self) -> None:
         review = _parse_review(
             {

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 from inky_bird_frame.birds import BirdSpecies, TaxonContext
 from inky_bird_frame.codex_runner import CodexRunner, _parse_review, parse_species_profile
 from inky_bird_frame.errors import GenerationError
-from inky_bird_frame.models import SpeciesProfileData
+from inky_bird_frame.models import QualityReview, SpeciesProfileData
 
 _CAPTURE_OUTPUT_ARGUMENT = """\
 out=""
@@ -225,6 +225,17 @@ class CodexRunnerSubprocessTests(unittest.TestCase):
 
 
 class CodexRunnerTests(unittest.TestCase):
+    def test_configured_model_is_forwarded_to_exec(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            executable = root / "codex"
+            executable.touch()
+            command = CodexRunner(executable, root, model="tested-model")._base_command(
+                writable=False
+            )
+
+        self.assertEqual(command[command.index("--model") + 1], "tested-model")
+
     def test_review_uses_bounded_live_source_verification(self) -> None:
         species = BirdSpecies(1, "Test Bird", "Avis test", 1, "test")
         profile = SpeciesProfileData(
@@ -426,6 +437,106 @@ class CodexRunnerTests(unittest.TestCase):
                     ],
                 }
             )
+
+    def test_review_parses_source_backed_profile_conflict(self) -> None:
+        review = _parse_review(
+            {
+                "passed": False,
+                "species_accuracy": 5,
+                "anatomy_accuracy": 5,
+                "text_accuracy": 3,
+                "composition_quality": 5,
+                "location_free": True,
+                "findings": ["The cached length conflicts with both sources"],
+                "correction_findings": [],
+                "profile_conflicts": [
+                    {
+                        "field": "measurements.length",
+                        "profile_value": "10-20 cm",
+                        "observed_value": "12-15 cm",
+                        "sources": [
+                            {"title": "Birds", "url": "https://birds.example/length"},
+                            {"title": "Field", "url": "https://field.example/length"},
+                        ],
+                    }
+                ],
+                "verification_sources": [
+                    {"title": "Birds", "url": "https://birds.example/length"},
+                    {"title": "Field", "url": "https://field.example/length"},
+                ],
+            },
+            ("birds.example", "field.example"),
+        )
+
+        self.assertFalse(review.passed)
+        self.assertEqual(review.profile_conflicts[0]["field"], "measurements.length")
+
+    def test_profile_conflict_rejects_identity_field(self) -> None:
+        with self.assertRaisesRegex(GenerationError, "field is not supported"):
+            _parse_review(
+                {
+                    "passed": False,
+                    "species_accuracy": 3,
+                    "anatomy_accuracy": 5,
+                    "text_accuracy": 5,
+                    "composition_quality": 5,
+                    "location_free": True,
+                    "findings": ["Identity conflict"],
+                    "correction_findings": [],
+                    "profile_conflicts": [
+                        {
+                            "field": "scientific_name",
+                            "profile_value": "Avis one",
+                            "observed_value": "Avis two",
+                            "sources": [
+                                {"title": "Birds", "url": "https://birds.example/name"},
+                                {"title": "Field", "url": "https://field.example/name"},
+                            ],
+                        }
+                    ],
+                    "verification_sources": [
+                        {"title": "Birds", "url": "https://birds.example/name"},
+                        {"title": "Field", "url": "https://field.example/name"},
+                    ],
+                },
+                ("birds.example", "field.example"),
+            )
+
+    def test_profile_conflict_requires_independent_sources(self) -> None:
+        with self.assertRaisesRegex(GenerationError, "two independent verification sources"):
+            _parse_review(
+                {
+                    "passed": False,
+                    "species_accuracy": 5,
+                    "anatomy_accuracy": 5,
+                    "text_accuracy": 3,
+                    "composition_quality": 5,
+                    "location_free": True,
+                    "findings": ["Length conflict"],
+                    "correction_findings": [],
+                    "profile_conflicts": [
+                        {
+                            "field": "measurements.length",
+                            "profile_value": "10-20 cm",
+                            "observed_value": "12-15 cm",
+                            "sources": [
+                                {"title": "One", "url": "https://birds.example/one"},
+                                {"title": "Two", "url": "https://birds.example/two"},
+                            ],
+                        }
+                    ],
+                    "verification_sources": [
+                        {"title": "Birds", "url": "https://birds.example/length"},
+                        {"title": "Field", "url": "https://field.example/length"},
+                    ],
+                },
+                ("birds.example", "field.example"),
+            )
+
+    def test_passing_review_shape_omits_empty_profile_conflicts(self) -> None:
+        review = QualityReview(True, 5, 5, 5, 5, True, ())
+
+        self.assertNotIn("profile_conflicts", review.as_dict())
 
 
 if __name__ == "__main__":

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -7,7 +7,13 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from inky_bird_frame.birds import BirdSpecies, TaxonContext
-from inky_bird_frame.codex_runner import CodexRunner, _parse_review, parse_species_profile
+from inky_bird_frame.codex_runner import (
+    CodexRunner,
+    parse_species_profile,
+)
+from inky_bird_frame.codex_runner import (
+    _parse_review as _parse_review_impl,
+)
 from inky_bird_frame.errors import GenerationError
 from inky_bird_frame.models import QualityReview, SpeciesProfileData
 
@@ -60,6 +66,20 @@ def _profile() -> SpeciesProfileData:
             {"title": "One", "url": "https://birds.example/one"},
             {"title": "Two", "url": "https://field.example/two"},
         ],
+    )
+
+
+def _parse_review(
+    raw: object,
+    allowed_domains: tuple[str, ...] | None = None,
+    *,
+    prior_corrections: tuple[str, ...] = (),
+) -> QualityReview:
+    return _parse_review_impl(
+        raw,
+        _profile(),
+        allowed_domains,
+        prior_corrections=prior_corrections,
     )
 
 
@@ -452,7 +472,7 @@ class CodexRunnerTests(unittest.TestCase):
                 "profile_conflicts": [
                     {
                         "field": "measurements.length",
-                        "profile_value": "10-20 cm",
+                        "profile_value": "1 in",
                         "observed_value": "12-15 cm",
                         "sources": [
                             {"title": "Birds", "url": "https://birds.example/length"},
@@ -517,7 +537,7 @@ class CodexRunnerTests(unittest.TestCase):
                     "profile_conflicts": [
                         {
                             "field": "measurements.length",
-                            "profile_value": "10-20 cm",
+                            "profile_value": "1 in",
                             "observed_value": "12-15 cm",
                             "sources": [
                                 {"title": "One", "url": "https://birds.example/one"},
@@ -531,6 +551,137 @@ class CodexRunnerTests(unittest.TestCase):
                     ],
                 },
                 ("birds.example", "field.example"),
+            )
+
+    def test_profile_conflict_must_quote_the_current_profile(self) -> None:
+        with self.assertRaisesRegex(GenerationError, "does not match the current profile"):
+            _parse_review(
+                {
+                    "passed": False,
+                    "species_accuracy": 5,
+                    "anatomy_accuracy": 5,
+                    "text_accuracy": 3,
+                    "composition_quality": 5,
+                    "location_free": True,
+                    "findings": ["A stale length conflict"],
+                    "correction_findings": [],
+                    "profile_conflicts": [
+                        {
+                            "field": "measurements.length",
+                            "profile_value": "10-20 cm",
+                            "observed_value": "12-15 cm",
+                            "sources": [
+                                {"title": "Birds", "url": "https://birds.example/length"},
+                                {"title": "Field", "url": "https://field.example/length"},
+                            ],
+                        }
+                    ],
+                    "verification_sources": [
+                        {"title": "Birds", "url": "https://birds.example/length"},
+                        {"title": "Field", "url": "https://field.example/length"},
+                    ],
+                },
+                ("birds.example", "field.example"),
+            )
+
+    def test_field_mark_conflict_accepts_equivalent_json_and_canonicalizes_it(self) -> None:
+        review = _parse_review(
+            {
+                "passed": False,
+                "species_accuracy": 3,
+                "anatomy_accuracy": 5,
+                "text_accuracy": 5,
+                "composition_quality": 5,
+                "location_free": True,
+                "findings": ["The proposed field marks conflict with direct sources"],
+                "correction_findings": [],
+                "profile_conflicts": [
+                    {
+                        "field": "field_marks",
+                        "profile_value": json.dumps(_profile()["field_marks"]),
+                        "observed_value": '["one","two","three","different"]',
+                        "sources": [
+                            {"title": "Birds", "url": "https://birds.example/marks"},
+                            {"title": "Field", "url": "https://field.example/marks"},
+                        ],
+                    }
+                ],
+                "verification_sources": [
+                    {"title": "Birds", "url": "https://birds.example/marks"},
+                    {"title": "Field", "url": "https://field.example/marks"},
+                ],
+            },
+            ("birds.example", "field.example"),
+        )
+
+        self.assertEqual(
+            review.profile_conflicts[0]["profile_value"],
+            '["one","two","three","four"]',
+        )
+
+    def test_review_accepts_only_explicit_resolutions_from_history(self) -> None:
+        review = _parse_review(
+            {
+                "passed": True,
+                "species_accuracy": 5,
+                "anatomy_accuracy": 5,
+                "text_accuracy": 5,
+                "composition_quality": 5,
+                "location_free": True,
+                "findings": ["The bill correction is now satisfied"],
+                "correction_findings": [],
+                "resolved_corrections": ["Shorten the bill"],
+                "verification_sources": [
+                    {"title": "Birds", "url": "https://birds.example/bill"},
+                    {"title": "Field", "url": "https://field.example/bill"},
+                ],
+            },
+            ("birds.example", "field.example"),
+            prior_corrections=("Shorten the bill",),
+        )
+
+        self.assertEqual(review.resolved_corrections, ("Shorten the bill",))
+
+        with self.assertRaisesRegex(GenerationError, "was not present in review history"):
+            _parse_review(
+                {
+                    "passed": True,
+                    "species_accuracy": 5,
+                    "anatomy_accuracy": 5,
+                    "text_accuracy": 5,
+                    "composition_quality": 5,
+                    "location_free": True,
+                    "findings": [],
+                    "correction_findings": [],
+                    "resolved_corrections": ["Shorten the bill"],
+                    "verification_sources": [
+                        {"title": "Birds", "url": "https://birds.example/bill"},
+                        {"title": "Field", "url": "https://field.example/bill"},
+                    ],
+                },
+                ("birds.example", "field.example"),
+            )
+
+    def test_review_rejects_a_correction_as_resolved_and_actionable(self) -> None:
+        with self.assertRaisesRegex(GenerationError, "both resolved and actionable"):
+            _parse_review(
+                {
+                    "passed": False,
+                    "species_accuracy": 3,
+                    "anatomy_accuracy": 5,
+                    "text_accuracy": 5,
+                    "composition_quality": 5,
+                    "location_free": True,
+                    "findings": ["The bill remains too long"],
+                    "correction_findings": ["Shorten the bill"],
+                    "resolved_corrections": ["Shorten the bill"],
+                    "verification_sources": [
+                        {"title": "Birds", "url": "https://birds.example/bill"},
+                        {"title": "Field", "url": "https://field.example/bill"},
+                    ],
+                },
+                ("birds.example", "field.example"),
+                prior_corrections=("Shorten the bill",),
             )
 
     def test_passing_review_shape_omits_empty_profile_conflicts(self) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,6 +65,7 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(config.discovery.radius_km, 16)
         self.assertEqual(config.controller.catalog_dir, (Path(temporary) / "catalog").resolve())
         self.assertEqual(config.controller.max_generation_attempts, 3)
+        self.assertIsNone(config.controller.codex_model)
         self.assertEqual(config.display_node.controller_url, "http://controller.test:8793")
         self.assertEqual(config.display_node.rotation_mode, RotationMode.WEIGHTED)
         self.assertTrue(config.display_node.prioritize_latest_detection)
@@ -85,6 +86,35 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(config.schedule.rotation_jitter_seconds, 7)
         self.assertEqual(config.schedule.display_startup_delay_seconds, 30)
         self.assertEqual(config.schedule.catalog_publish_minutes, 4)
+
+    def test_loads_optional_codex_model_pin(self) -> None:
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(
+                CONFIG.replace(
+                    'codex_path = "/Applications/Codex.app/Contents/Resources/codex"',
+                    'codex_path = "/Applications/Codex.app/Contents/Resources/codex"\n'
+                    'codex_model = "tested-model"',
+                )
+            )
+
+            config = load_config(path)
+
+        self.assertEqual(config.controller.codex_model, "tested-model")
+
+    def test_rejects_blank_codex_model_pin(self) -> None:
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(
+                CONFIG.replace(
+                    'codex_path = "/Applications/Codex.app/Contents/Resources/codex"',
+                    'codex_path = "/Applications/Codex.app/Contents/Resources/codex"\n'
+                    'codex_model = "  "',
+                )
+            )
+
+            with self.assertRaisesRegex(ConfigurationError, "codex_model must be a non-empty"):
+                load_config(path)
 
     def test_ebird_source_requires_a_key(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3357,6 +3357,51 @@ class ControllerTests(unittest.TestCase):
             (conflict,),
         )
 
+    def test_exhausted_quality_review_clears_adjudicated_profile_conflict(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        location = DiscoveryLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        conflict = ProfileConflict(
+            field="measurements.length",
+            profile_value="20.9-23.5 cm",
+            observed_value="21-23 cm",
+            sources=[
+                {"title": "Cornell", "url": "https://www.allaboutbirds.org/example"},
+                {"title": "Audubon", "url": "https://www.audubon.org/example"},
+            ],
+        )
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            RetryStore(
+                config.controller.state_dir / "generation-retries.json"
+            ).set_quality_guidance(
+                species.taxon_id,
+                (),
+                profile_conflicts=(conflict,),
+            )
+            with (
+                patch(
+                    "inky_bird_frame.controller.discover_species",
+                    return_value=discovery_result(location, [species]),
+                ),
+                patch(
+                    "inky_bird_frame.controller.generate_candidate",
+                    side_effect=QualityReviewError(
+                        "image quality remained below threshold",
+                        profile_conflicts=(),
+                    ),
+                ),
+            ):
+                run_controller_cycle(config)
+
+            guidance = RetryStore(
+                config.controller.state_dir / "generation-retries.json"
+            ).quality_guidance(species.taxon_id)
+
+        self.assertIsNone(guidance)
+
     def test_retry_conflict_outside_current_allowlist_is_deferred(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
         location = DiscoveryLocation("12345", "Exampleville", "XY", 1.0, 2.0)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2697,8 +2697,29 @@ class ControllerTests(unittest.TestCase):
                 },
             ),
         )
+        refined_conflict = ProfileConflict(
+            field="measurements.length",
+            profile_value=PROFILE["measurements"]["length"],
+            observed_value="21-22 cm",
+            sources=[
+                {"title": "Cornell", "url": "https://www.allaboutbirds.org/refined"},
+                {"title": "Audubon", "url": "https://www.audubon.org/refined"},
+            ],
+        )
+        refined_conflict_review = QualityReview(
+            False,
+            5,
+            5,
+            3,
+            5,
+            True,
+            ("Length remains disputed with refined evidence",),
+            profile_conflicts=(refined_conflict,),
+        )
 
         class FakeRunner:
+            reviews = iter((conflict_review, refined_conflict_review))
+
             def __init__(self, _executable: Path, _workspace: Path) -> None:
                 pass
 
@@ -2709,7 +2730,7 @@ class ControllerTests(unittest.TestCase):
                 return output_path
 
             def review_plate(self, *_args: object, **_kwargs: object) -> QualityReview:
-                return conflict_review
+                return next(self.reviews)
 
         def prepare(_source: Path, portrait: Path, display: Path) -> None:
             portrait.write_bytes(b"portrait")
@@ -2732,7 +2753,7 @@ class ControllerTests(unittest.TestCase):
                     "inky_bird_frame.controller._refresh_profile_after_conflict",
                     return_value=cached_profile,
                 ) as refresh,
-                self.assertRaisesRegex(QualityReviewError, "remained after one"),
+                self.assertRaisesRegex(QualityReviewError, "remained after one") as raised,
             ):
                 generate_candidate(config, species, config.controller.workspace_dir)
             failed_history_path = next(
@@ -2741,6 +2762,7 @@ class ControllerTests(unittest.TestCase):
             history = json.loads(failed_history_path.read_text())
 
         refresh.assert_called_once()
+        self.assertEqual(raised.exception.profile_conflicts, (refined_conflict,))
         self.assertEqual(len(history["attempts"]), 2)
         self.assertEqual(history["attempts"][1]["profile_refresh"], "conflict_remained")
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -41,6 +41,7 @@ from inky_bird_frame.controller import (
     DiscoverySnapshot,
     ProviderStatus,
     _merge_provider_species,
+    _merge_refreshed_profile,
     add_collection_member,
     collection_status,
     discover_species,
@@ -2582,6 +2583,32 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(before_refresh, PROFILE)
         self.assertEqual(after_refresh, expected_profile)
 
+    def test_field_mark_refresh_also_replaces_the_palette(self) -> None:
+        researched_profile = SpeciesProfileData(
+            **{
+                **PROFILE,
+                "field_marks": ["crest", "blue plumage", "black mask", "orange bill"],
+                "palette": ["blue", "black", "orange"],
+            }
+        )
+        conflict = ProfileConflict(
+            field="field_marks",
+            profile_value=json.dumps(PROFILE["field_marks"], separators=(",", ":")),
+            observed_value=json.dumps(
+                researched_profile["field_marks"],
+                separators=(",", ":"),
+            ),
+            sources=[
+                {"title": "Cornell", "url": "https://www.allaboutbirds.org/example"},
+                {"title": "Audubon", "url": "https://www.audubon.org/example"},
+            ],
+        )
+
+        merged = _merge_refreshed_profile(PROFILE, researched_profile, (conflict,))
+
+        self.assertEqual(merged["field_marks"], researched_profile["field_marks"])
+        self.assertEqual(merged["palette"], researched_profile["palette"])
+
     def test_profile_conflict_is_terminal_when_research_is_disabled(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
         cached_profile = SpeciesProfileData(
@@ -2768,6 +2795,15 @@ class ControllerTests(unittest.TestCase):
 
     def test_terminal_review_failure_retains_versioned_attempt_history(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        initial_conflict = ProfileConflict(
+            field="measurements.length",
+            profile_value=PROFILE["measurements"]["length"],
+            observed_value="21-23 cm",
+            sources=[
+                {"title": "Cornell", "url": "https://www.allaboutbirds.org/example"},
+                {"title": "Audubon", "url": "https://www.audubon.org/example"},
+            ],
+        )
         failed_reviews = iter(
             (
                 QualityReview(
@@ -2836,9 +2872,14 @@ class ControllerTests(unittest.TestCase):
                 patch("inky_bird_frame.controller.fetch_taxon_context"),
                 patch("inky_bird_frame.controller.CodexRunner", FakeRunner),
                 patch("inky_bird_frame.controller.prepare_generated_plate", side_effect=prepare),
-                self.assertRaises(QualityReviewError),
+                self.assertRaises(QualityReviewError) as raised,
             ):
-                generate_candidate(config, species, config.controller.workspace_dir)
+                generate_candidate(
+                    config,
+                    species,
+                    config.controller.workspace_dir,
+                    initial_profile_conflicts=(initial_conflict,),
+                )
             run_history_path = next(
                 (config.controller.state_dir / "runs").glob("*/attempt-history.json")
             )
@@ -2849,6 +2890,7 @@ class ControllerTests(unittest.TestCase):
             failed_history = json.loads(failed_history_path.read_text())
 
         self.assertEqual(run_history, failed_history)
+        self.assertEqual(raised.exception.profile_conflicts, ())
         self.assertEqual(run_history["schema_version"], 1)
         self.assertEqual(len(run_history["attempts"]), 3)
         self.assertEqual(run_history["attempts"][0]["failed_axes"], ["species_accuracy"])

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2346,7 +2346,10 @@ class ControllerTests(unittest.TestCase):
             FakeRunner.invariants,
             [
                 ("Render clearly visible natural eyes",),
-                ("Render clearly visible natural eyes",),
+                (
+                    "Render clearly visible natural eyes",
+                    "Preserve the previous scale correction",
+                ),
             ],
         )
         self.assertEqual(len(FakeRunner.generated_paths), 2)
@@ -2361,6 +2364,475 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(manifest["status"], "pending")
         self.assertFalse((candidate / "attempt-history.json").exists())
         self.assertEqual(len(private_histories), 1)
+
+    def test_profile_conflict_triggers_one_source_backed_refresh(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        researched_profile = SpeciesProfileData(
+            **{
+                **PROFILE,
+                "measurements": {
+                    **PROFILE["measurements"],
+                    "length": "21-23 cm",
+                    "wingspan": "30 cm average",
+                },
+                "sources": [
+                    {"title": "Refreshed one", "url": "https://one.example/refreshed"},
+                    {"title": "Refreshed two", "url": "https://two.example/refreshed"},
+                ],
+            }
+        )
+        expected_profile = SpeciesProfileData(
+            **{
+                **PROFILE,
+                "measurements": {
+                    **PROFILE["measurements"],
+                    "length": "21-23 cm",
+                },
+                "sources": researched_profile["sources"],
+            }
+        )
+        conflict_review = QualityReview(
+            False,
+            5,
+            5,
+            3,
+            5,
+            True,
+            ("The cached length conflicts with direct sources",),
+            verification_sources=(
+                {"title": "Cornell", "url": "https://www.allaboutbirds.org/example"},
+                {"title": "Audubon", "url": "https://www.audubon.org/example"},
+            ),
+            profile_conflicts=(
+                {
+                    "field": "measurements.length",
+                    "profile_value": PROFILE["measurements"]["length"],
+                    "observed_value": "21-23 cm",
+                    "sources": [
+                        {
+                            "title": "Cornell",
+                            "url": "https://www.allaboutbirds.org/example",
+                        },
+                        {"title": "Audubon", "url": "https://www.audubon.org/example"},
+                    ],
+                },
+            ),
+        )
+        passed_review = QualityReview(
+            True,
+            5,
+            5,
+            5,
+            5,
+            True,
+            (),
+            (
+                {"title": "Cornell", "url": "https://www.allaboutbirds.org/example"},
+                {"title": "Audubon", "url": "https://www.audubon.org/example"},
+            ),
+        )
+        correction_review = QualityReview(
+            False,
+            5,
+            3,
+            5,
+            5,
+            True,
+            ("The visible leg is malformed",),
+            correction_findings=("Repair the visible leg",),
+        )
+
+        class FakeRunner:
+            profile_results = iter((PROFILE, researched_profile))
+            generated_profiles: list[SpeciesProfileData] = []
+            corrections: list[tuple[str, ...]] = []
+            invariants: list[tuple[str, ...]] = []
+            profile_calls: list[dict[str, object]] = []
+            review_kwargs: list[dict[str, object]] = []
+            reviews = iter((conflict_review, correction_review, passed_review))
+
+            def __init__(self, _executable: Path, workspace: Path) -> None:
+                self.workspace = workspace.resolve()
+
+            def create_profile(self, *_args: object, **kwargs: object) -> SpeciesProfileData:
+                output_path = _args[-2]
+                assert isinstance(output_path, Path)
+                profile = next(self.profile_results)
+                output_path.write_text(json.dumps(profile))
+                self.profile_calls.append(kwargs)
+                return profile
+
+            def generate_plate(self, *_args: object, **_kwargs: object) -> Path:
+                profile = cast(SpeciesProfileData, _args[1])
+                output_path = _args[-3]
+                correction = _args[-1]
+                assert isinstance(output_path, Path)
+                assert isinstance(correction, tuple)
+                self.generated_profiles.append(profile)
+                self.corrections.append(correction)
+                invariants = _kwargs.get("invariant_findings")
+                assert isinstance(invariants, tuple)
+                self.invariants.append(invariants)
+                output_path.write_bytes(b"generated")
+                return output_path
+
+            def review_plate(self, *_args: object, **kwargs: object) -> QualityReview:
+                self.review_kwargs.append(kwargs)
+                return next(self.reviews)
+
+        def prepare(_source: Path, portrait: Path, display: Path) -> None:
+            portrait.write_bytes(b"portrait")
+            display.write_bytes(b"display")
+
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            with (
+                patch("inky_bird_frame.controller.load_or_fetch_references", return_value=[]),
+                patch("inky_bird_frame.controller.fetch_taxon_context"),
+                patch("inky_bird_frame.controller.CodexRunner", FakeRunner),
+                patch("inky_bird_frame.controller.prepare_generated_plate", side_effect=prepare),
+            ):
+                candidate = generate_candidate(config, species, config.controller.workspace_dir)
+            history_path = next(
+                (config.controller.state_dir / "runs").glob("*/attempt-history.json")
+            )
+            history = json.loads(history_path.read_text())
+            before_refresh = json.loads(
+                (history_path.parent / "profile-before-refresh.json").read_text()
+            )
+            after_refresh = json.loads(
+                (history_path.parent / "profile-after-refresh.json").read_text()
+            )
+            cached_profile = json.loads(
+                (
+                    config.controller.state_dir
+                    / "profiles"
+                    / str(species.taxon_id)
+                    / "profile.json"
+                ).read_text()
+            )
+            candidate_profile = json.loads((candidate / "profile.json").read_text())
+
+        self.assertEqual(len(FakeRunner.profile_calls), 2)
+        self.assertNotIn("prior_profile", FakeRunner.profile_calls[0])
+        self.assertEqual(FakeRunner.profile_calls[1]["prior_profile"], PROFILE)
+        self.assertEqual(
+            FakeRunner.generated_profiles,
+            [PROFILE, expected_profile, expected_profile],
+        )
+        self.assertEqual(
+            FakeRunner.corrections[1],
+            (
+                "Update every visible factual note to match the refreshed source-backed "
+                "profile exactly.",
+            ),
+        )
+        self.assertEqual(FakeRunner.corrections[2], ("Repair the visible leg",))
+        self.assertEqual(FakeRunner.invariants, [(), (), ()])
+        self.assertEqual(
+            FakeRunner.review_kwargs[1]["prior_profile_conflicts"],
+            conflict_review.profile_conflicts,
+        )
+        self.assertEqual(
+            FakeRunner.review_kwargs[2]["prior_corrections"],
+            correction_review.correction_findings,
+        )
+        self.assertEqual(cached_profile, expected_profile)
+        self.assertEqual(candidate_profile, expected_profile)
+        self.assertEqual(history["schema_version"], 1)
+        self.assertEqual(history["attempts"][0]["profile_refresh"], "completed")
+        self.assertTrue(history["attempts"][0]["profile_changed"])
+        self.assertEqual(before_refresh, PROFILE)
+        self.assertEqual(after_refresh, expected_profile)
+
+    def test_profile_conflict_is_terminal_when_research_is_disabled(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        cached_profile = SpeciesProfileData(
+            **{
+                **PROFILE,
+                "sources": [
+                    {
+                        "title": "Cornell",
+                        "url": "https://www.allaboutbirds.org/example",
+                    },
+                    {"title": "Audubon", "url": "https://www.audubon.org/example"},
+                ],
+            }
+        )
+        conflict_review = QualityReview(
+            False,
+            5,
+            5,
+            3,
+            5,
+            True,
+            ("The cached length conflicts with direct sources",),
+            profile_conflicts=(
+                {
+                    "field": "measurements.length",
+                    "profile_value": PROFILE["measurements"]["length"],
+                    "observed_value": "21-23 cm",
+                    "sources": [
+                        {
+                            "title": "Cornell",
+                            "url": "https://www.allaboutbirds.org/example",
+                        },
+                        {"title": "Audubon", "url": "https://www.audubon.org/example"},
+                    ],
+                },
+            ),
+        )
+
+        class FakeRunner:
+            def __init__(self, _executable: Path, _workspace: Path) -> None:
+                pass
+
+            def generate_plate(self, *_args: object, **_kwargs: object) -> Path:
+                output_path = _args[-3]
+                assert isinstance(output_path, Path)
+                output_path.write_bytes(b"generated")
+                return output_path
+
+            def review_plate(self, *_args: object, **_kwargs: object) -> QualityReview:
+                return conflict_review
+
+        def prepare(_source: Path, portrait: Path, display: Path) -> None:
+            portrait.write_bytes(b"portrait")
+            display.write_bytes(b"display")
+
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(f"{CONFIG}\n[research]\nenabled = false\n")
+            config = load_config(config_path)
+            cache = (
+                config.controller.state_dir / "profiles" / str(species.taxon_id) / "profile.json"
+            )
+            cache.parent.mkdir(parents=True)
+            cache.write_text(json.dumps(cached_profile))
+            with (
+                patch("inky_bird_frame.controller.load_or_fetch_references", return_value=[]),
+                patch("inky_bird_frame.controller.CodexRunner", FakeRunner),
+                patch("inky_bird_frame.controller.prepare_generated_plate", side_effect=prepare),
+                self.assertRaisesRegex(QualityReviewError, "research is disabled"),
+            ):
+                generate_candidate(config, species, config.controller.workspace_dir)
+            failed_history_path = next(
+                (config.controller.state_dir / "failed").glob("*/attempt-history.json")
+            )
+            history = json.loads(failed_history_path.read_text())
+
+        self.assertEqual(history["attempts"][0]["profile_refresh"], "disabled")
+
+    def test_repeated_profile_conflict_refreshes_only_once(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        cached_profile = SpeciesProfileData(
+            **{
+                **PROFILE,
+                "sources": [
+                    {
+                        "title": "Cornell",
+                        "url": "https://www.allaboutbirds.org/example",
+                    },
+                    {"title": "Audubon", "url": "https://www.audubon.org/example"},
+                ],
+            }
+        )
+        conflict_review = QualityReview(
+            False,
+            5,
+            5,
+            3,
+            5,
+            True,
+            ("Length remains disputed",),
+            profile_conflicts=(
+                {
+                    "field": "measurements.length",
+                    "profile_value": PROFILE["measurements"]["length"],
+                    "observed_value": "21-23 cm",
+                    "sources": [
+                        {
+                            "title": "Cornell",
+                            "url": "https://www.allaboutbirds.org/example",
+                        },
+                        {"title": "Audubon", "url": "https://www.audubon.org/example"},
+                    ],
+                },
+            ),
+        )
+
+        class FakeRunner:
+            def __init__(self, _executable: Path, _workspace: Path) -> None:
+                pass
+
+            def generate_plate(self, *_args: object, **_kwargs: object) -> Path:
+                output_path = _args[-3]
+                assert isinstance(output_path, Path)
+                output_path.write_bytes(b"generated")
+                return output_path
+
+            def review_plate(self, *_args: object, **_kwargs: object) -> QualityReview:
+                return conflict_review
+
+        def prepare(_source: Path, portrait: Path, display: Path) -> None:
+            portrait.write_bytes(b"portrait")
+            display.write_bytes(b"display")
+
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            cache = (
+                config.controller.state_dir / "profiles" / str(species.taxon_id) / "profile.json"
+            )
+            cache.parent.mkdir(parents=True)
+            cache.write_text(json.dumps(cached_profile))
+            with (
+                patch("inky_bird_frame.controller.load_or_fetch_references", return_value=[]),
+                patch("inky_bird_frame.controller.CodexRunner", FakeRunner),
+                patch("inky_bird_frame.controller.prepare_generated_plate", side_effect=prepare),
+                patch(
+                    "inky_bird_frame.controller._refresh_profile_after_conflict",
+                    return_value=cached_profile,
+                ) as refresh,
+                self.assertRaisesRegex(QualityReviewError, "remained after one"),
+            ):
+                generate_candidate(config, species, config.controller.workspace_dir)
+            failed_history_path = next(
+                (config.controller.state_dir / "failed").glob("*/attempt-history.json")
+            )
+            history = json.loads(failed_history_path.read_text())
+
+        refresh.assert_called_once()
+        self.assertEqual(len(history["attempts"]), 2)
+        self.assertEqual(history["attempts"][1]["profile_refresh"], "conflict_remained")
+
+    def test_terminal_review_failure_retains_versioned_attempt_history(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        failed_reviews = iter(
+            (
+                QualityReview(
+                    False,
+                    3,
+                    5,
+                    5,
+                    5,
+                    True,
+                    ("Bill is too long",),
+                    correction_findings=("Shorten the bill",),
+                ),
+                QualityReview(
+                    False,
+                    5,
+                    3,
+                    5,
+                    5,
+                    True,
+                    ("Leg is malformed",),
+                    correction_findings=("Repair the visible leg",),
+                ),
+                QualityReview(
+                    False,
+                    3,
+                    5,
+                    5,
+                    5,
+                    True,
+                    ("Bill regressed",),
+                    correction_findings=("Shorten the bill",),
+                ),
+            )
+        )
+
+        class FakeRunner:
+            def __init__(self, _executable: Path, _workspace: Path) -> None:
+                pass
+
+            def create_profile(self, *_args: object, **_kwargs: object) -> SpeciesProfileData:
+                output_path = _args[-2]
+                assert isinstance(output_path, Path)
+                output_path.write_text(json.dumps(PROFILE))
+                return PROFILE
+
+            def generate_plate(self, *_args: object, **_kwargs: object) -> Path:
+                output_path = _args[-3]
+                assert isinstance(output_path, Path)
+                output_path.write_bytes(b"generated")
+                return output_path
+
+            def review_plate(self, *_args: object, **_kwargs: object) -> QualityReview:
+                return next(failed_reviews)
+
+        def prepare(_source: Path, portrait: Path, display: Path) -> None:
+            portrait.write_bytes(b"portrait")
+            display.write_bytes(b"display")
+
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            with (
+                patch("inky_bird_frame.controller.load_or_fetch_references", return_value=[]),
+                patch("inky_bird_frame.controller.fetch_taxon_context"),
+                patch("inky_bird_frame.controller.CodexRunner", FakeRunner),
+                patch("inky_bird_frame.controller.prepare_generated_plate", side_effect=prepare),
+                self.assertRaises(QualityReviewError),
+            ):
+                generate_candidate(config, species, config.controller.workspace_dir)
+            run_history_path = next(
+                (config.controller.state_dir / "runs").glob("*/attempt-history.json")
+            )
+            failed_history_path = next(
+                (config.controller.state_dir / "failed").glob("*/attempt-history.json")
+            )
+            run_history = json.loads(run_history_path.read_text())
+            failed_history = json.loads(failed_history_path.read_text())
+
+        self.assertEqual(run_history, failed_history)
+        self.assertEqual(run_history["schema_version"], 1)
+        self.assertEqual(len(run_history["attempts"]), 3)
+        self.assertEqual(run_history["attempts"][0]["failed_axes"], ["species_accuracy"])
+        self.assertEqual(run_history["attempts"][1]["regressed_axes"], ["anatomy_accuracy"])
+        self.assertEqual(run_history["attempts"][2]["regressed_findings"], ["Shorten the bill"])
+
+    def test_generation_error_records_only_sanitized_error_type(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+
+        class FakeRunner:
+            def __init__(self, _executable: Path, _workspace: Path) -> None:
+                pass
+
+            def create_profile(self, *_args: object, **_kwargs: object) -> SpeciesProfileData:
+                output_path = _args[-2]
+                assert isinstance(output_path, Path)
+                output_path.write_text(json.dumps(PROFILE))
+                return PROFILE
+
+            def generate_plate(self, *_args: object, **_kwargs: object) -> Path:
+                raise GenerationError("sensitive upstream payload")
+
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            with (
+                patch("inky_bird_frame.controller.load_or_fetch_references", return_value=[]),
+                patch("inky_bird_frame.controller.fetch_taxon_context"),
+                patch("inky_bird_frame.controller.CodexRunner", FakeRunner),
+                self.assertRaisesRegex(GenerationError, "sensitive upstream payload"),
+            ):
+                generate_candidate(config, species, config.controller.workspace_dir)
+            history_path = next(
+                (config.controller.state_dir / "runs").glob("*/attempt-history.json")
+            )
+            history_text = history_path.read_text()
+            history = json.loads(history_text)
+
+        self.assertNotIn("sensitive upstream payload", history_text)
+        self.assertEqual(history["attempts"][0]["outcome"], "generation_error")
+        self.assertEqual(history["attempts"][0]["error_type"], "GenerationError")
 
     def test_runtime_generation_failure_remains_eligible(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -71,7 +71,7 @@ from inky_bird_frame.errors import (
     SpeciesStateError,
 )
 from inky_bird_frame.geo import DiscoveryLocation
-from inky_bird_frame.models import QualityReview, SpeciesProfileData
+from inky_bird_frame.models import ProfileConflict, QualityReview, SpeciesProfileData
 from inky_bird_frame.prompts import PROMPT_VERSION
 from inky_bird_frame.retry import RetryStore
 
@@ -2143,6 +2143,23 @@ class ControllerTests(unittest.TestCase):
                 species.taxon_id,
                 ("Keep the bill proportion accurate",),
                 invariant_findings=("Keep the bill proportion accurate",),
+                profile_conflicts=(
+                    {
+                        "field": "measurements.length",
+                        "profile_value": "20.9-23.5 cm",
+                        "observed_value": "21-23 cm",
+                        "sources": [
+                            {
+                                "title": "Cornell",
+                                "url": "https://www.allaboutbirds.org/example",
+                            },
+                            {
+                                "title": "Audubon",
+                                "url": "https://www.audubon.org/example",
+                            },
+                        ],
+                    },
+                ),
             )
             with (
                 patch(
@@ -2174,6 +2191,10 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(
             generate.call_args.kwargs["invariant_correction_findings"],
             ("Keep the bill proportion accurate",),
+        )
+        self.assertEqual(
+            generate.call_args.kwargs["initial_profile_conflicts"][0]["field"],
+            "measurements.length",
         )
         self.assertEqual(len(queue), 1)
         self.assertEqual(queue[0].common_name, species.common_name)
@@ -2245,6 +2266,7 @@ class ControllerTests(unittest.TestCase):
             True,
             ("The remaining anatomy is correct", "Crest is too short"),
             correction_findings=("Crest is too short",),
+            resolved_corrections=("Preserve the previous scale correction",),
         )
         passed_review = QualityReview(
             True,
@@ -2494,7 +2516,12 @@ class ControllerTests(unittest.TestCase):
                 patch("inky_bird_frame.controller.CodexRunner", FakeRunner),
                 patch("inky_bird_frame.controller.prepare_generated_plate", side_effect=prepare),
             ):
-                candidate = generate_candidate(config, species, config.controller.workspace_dir)
+                candidate = generate_candidate(
+                    config,
+                    species,
+                    config.controller.workspace_dir,
+                    initial_profile_conflicts=conflict_review.profile_conflicts,
+                )
             history_path = next(
                 (config.controller.state_dir / "runs").glob("*/attempt-history.json")
             )
@@ -2532,8 +2559,16 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(FakeRunner.corrections[2], ("Repair the visible leg",))
         self.assertEqual(FakeRunner.invariants, [(), (), ()])
         self.assertEqual(
-            FakeRunner.review_kwargs[1]["prior_profile_conflicts"],
+            FakeRunner.review_kwargs[0]["prior_profile_conflicts"],
             conflict_review.profile_conflicts,
+        )
+        self.assertEqual(
+            FakeRunner.review_kwargs[1]["prior_profile_conflicts"],
+            (),
+        )
+        self.assertEqual(
+            FakeRunner.review_kwargs[2]["prior_profile_conflicts"],
+            (),
         )
         self.assertEqual(
             FakeRunner.review_kwargs[2]["prior_corrections"],
@@ -2732,6 +2767,7 @@ class ControllerTests(unittest.TestCase):
                     True,
                     ("Leg is malformed",),
                     correction_findings=("Repair the visible leg",),
+                    resolved_corrections=("Shorten the bill",),
                 ),
                 QualityReview(
                     False,
@@ -2796,6 +2832,84 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(run_history["attempts"][0]["failed_axes"], ["species_accuracy"])
         self.assertEqual(run_history["attempts"][1]["regressed_axes"], ["anatomy_accuracy"])
         self.assertEqual(run_history["attempts"][2]["regressed_findings"], ["Shorten the bill"])
+
+    def test_reversed_correction_is_not_carried_as_an_invariant(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        reviews = iter(
+            (
+                QualityReview(
+                    False,
+                    3,
+                    5,
+                    5,
+                    5,
+                    True,
+                    ("Bill is too long",),
+                    correction_findings=("Shorten the bill",),
+                ),
+                QualityReview(
+                    False,
+                    3,
+                    5,
+                    5,
+                    5,
+                    True,
+                    ("Bill is now too short",),
+                    correction_findings=("Lengthen the bill",),
+                ),
+                QualityReview(True, 5, 5, 5, 5, True, ()),
+            )
+        )
+
+        class FakeRunner:
+            invariants: list[tuple[str, ...]] = []
+            review_history: list[tuple[str, ...]] = []
+
+            def __init__(self, _executable: Path, _workspace: Path) -> None:
+                pass
+
+            def create_profile(self, *_args: object, **_kwargs: object) -> SpeciesProfileData:
+                output_path = _args[-2]
+                assert isinstance(output_path, Path)
+                output_path.write_text(json.dumps(PROFILE))
+                return PROFILE
+
+            def generate_plate(self, *_args: object, **kwargs: object) -> Path:
+                output_path = _args[-3]
+                assert isinstance(output_path, Path)
+                invariants = kwargs.get("invariant_findings")
+                assert isinstance(invariants, tuple)
+                self.invariants.append(invariants)
+                output_path.write_bytes(b"generated")
+                return output_path
+
+            def review_plate(self, *_args: object, **kwargs: object) -> QualityReview:
+                prior_corrections = kwargs.get("prior_corrections")
+                assert isinstance(prior_corrections, tuple)
+                self.review_history.append(prior_corrections)
+                return next(reviews)
+
+        def prepare(_source: Path, portrait: Path, display: Path) -> None:
+            portrait.write_bytes(b"portrait")
+            display.write_bytes(b"display")
+
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            with (
+                patch("inky_bird_frame.controller.load_or_fetch_references", return_value=[]),
+                patch("inky_bird_frame.controller.fetch_taxon_context"),
+                patch("inky_bird_frame.controller.CodexRunner", FakeRunner),
+                patch("inky_bird_frame.controller.prepare_generated_plate", side_effect=prepare),
+            ):
+                generate_candidate(config, species, config.controller.workspace_dir)
+
+        self.assertEqual(FakeRunner.invariants, [(), (), ()])
+        self.assertEqual(
+            FakeRunner.review_history,
+            [(), ("Shorten the bill",), ("Shorten the bill", "Lengthen the bill")],
+        )
 
     def test_generation_error_records_only_sanitized_error_type(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
@@ -3193,6 +3307,102 @@ class ControllerTests(unittest.TestCase):
             generate.call_args.kwargs["initial_correction_findings"],
             ("Correct the ruler scale",),
         )
+
+    def test_exhausted_quality_review_preserves_conflict_only_guidance(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        location = DiscoveryLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        conflict = ProfileConflict(
+            field="measurements.length",
+            profile_value="20.9-23.5 cm",
+            observed_value="21-23 cm",
+            sources=[
+                {"title": "Cornell", "url": "https://www.allaboutbirds.org/example"},
+                {"title": "Audubon", "url": "https://www.audubon.org/example"},
+            ],
+        )
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            RetryStore(
+                config.controller.state_dir / "generation-retries.json"
+            ).set_quality_guidance(
+                species.taxon_id,
+                (),
+                profile_conflicts=(conflict,),
+            )
+            with (
+                patch(
+                    "inky_bird_frame.controller.discover_species",
+                    return_value=discovery_result(location, [species]),
+                ),
+                patch(
+                    "inky_bird_frame.controller.generate_candidate",
+                    side_effect=QualityReviewError("profile conflict remained"),
+                ) as generate,
+            ):
+                run_controller_cycle(config)
+
+            guidance = RetryStore(
+                config.controller.state_dir / "generation-retries.json"
+            ).quality_guidance(species.taxon_id)
+
+        self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(guidance.findings, ())
+            self.assertEqual(guidance.profile_conflicts, (conflict,))
+        self.assertEqual(
+            generate.call_args.kwargs["initial_profile_conflicts"],
+            (conflict,),
+        )
+
+    def test_retry_conflict_outside_current_allowlist_is_deferred(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        location = DiscoveryLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        conflict = ProfileConflict(
+            field="measurements.length",
+            profile_value="20.9-23.5 cm",
+            observed_value="21-23 cm",
+            sources=[
+                {"title": "Outside", "url": "https://outside.example/one"},
+                {"title": "Other", "url": "https://other.example/two"},
+            ],
+        )
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            RetryStore(
+                config.controller.state_dir / "generation-retries.json"
+            ).set_quality_guidance(
+                species.taxon_id,
+                (),
+                profile_conflicts=(conflict,),
+            )
+            with (
+                patch(
+                    "inky_bird_frame.controller.discover_species",
+                    return_value=discovery_result(location, [species]),
+                ),
+                patch("inky_bird_frame.controller.generate_candidate") as generate,
+            ):
+                result = run_controller_cycle(config)
+
+            retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
+
+        generate.assert_not_called()
+        failures = result["failures"]
+        self.assertIsInstance(failures, list)
+        if isinstance(failures, list):
+            self.assertFalse(failures[0]["terminal"])
+            self.assertIn("outside the current research allowlist", failures[0]["error"])
+        self.assertIsNotNone(retry_store.get(species.taxon_id))
+        guidance = retry_store.quality_guidance(species.taxon_id)
+        self.assertIsNotNone(guidance)
+        if guidance is not None:
+            self.assertEqual(guidance.profile_conflicts, (conflict,))
 
 
 class DiscoveryProviderTests(unittest.TestCase):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2553,8 +2553,9 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(
             FakeRunner.corrections[1],
             (
-                "Update every visible factual note to match the refreshed source-backed "
-                "profile exactly.",
+                "Update the primary bird, every supplementary study, and every visible factual "
+                "note to match the refreshed source-backed profile exactly, including its field "
+                "marks, palette, measurements, and anatomy.",
             ),
         )
         self.assertEqual(FakeRunner.corrections[2], ("Repair the visible leg",))

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 
-from inky_bird_frame.birds import BirdSpecies
-from inky_bird_frame.models import ReferencePhoto, SpeciesProfileData
-from inky_bird_frame.prompts import PROMPT_VERSION, plate_prompt, review_prompt
+from inky_bird_frame.birds import BirdSpecies, TaxonContext
+from inky_bird_frame.models import ProfileConflict, ReferencePhoto, SpeciesProfileData
+from inky_bird_frame.prompts import PROMPT_VERSION, plate_prompt, profile_prompt, review_prompt
 
 
 class PromptTests(unittest.TestCase):
     def test_prompt_contract_version(self) -> None:
-        self.assertEqual(PROMPT_VERSION, "field-journal-v4")
+        self.assertEqual(PROMPT_VERSION, "field-journal-v5")
 
     def test_plate_prompt_contains_species_facts_and_excludes_location(self) -> None:
         species = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 26, "iNaturalist")
@@ -80,6 +80,74 @@ class PromptTests(unittest.TestCase):
         self.assertIn("Correct the wing bars", prompt)
         self.assertIn("Create a new image", prompt)
 
+    def test_profile_and_review_prompts_include_bounded_conflict_history(self) -> None:
+        species = BirdSpecies(1, "Test Bird", "Avis test", 1, "test")
+        profile = SpeciesProfileData(
+            taxon_id=1,
+            common_name="Test Bird",
+            scientific_name="Avis test",
+            family="Testidae",
+            measurements={"length": "10 cm", "wingspan": "20 cm", "weight": "30 g"},
+            field_marks=["one", "two", "three", "four"],
+            habitat="Woods",
+            behavior="Perches",
+            palette=["red", "green", "blue"],
+            sources=[
+                {"title": "One", "url": "https://birds.example/one"},
+                {"title": "Two", "url": "https://field.example/two"},
+            ],
+        )
+        conflict = ProfileConflict(
+            **{
+                "field": "measurements.length",
+                "profile_value": "10 cm",
+                "observed_value": "12 cm",
+                "sources": [
+                    {"title": "One", "url": "https://birds.example/length"},
+                    {"title": "Two", "url": "https://field.example/length"},
+                ],
+            }
+        )
+        context = TaxonContext(
+            taxon_id=1,
+            common_name="Test Bird",
+            scientific_name="Avis test",
+            family="Testidae",
+            summary="A test bird.",
+            source_url="https://birds.example/taxon/1",
+        )
+
+        research = profile_prompt(
+            species,
+            context,
+            [],
+            ("birds.example", "field.example"),
+            prior_profile=profile,
+            profile_conflicts=(conflict,),
+        )
+        review = review_prompt(
+            species,
+            profile,
+            [],
+            ("birds.example", "field.example"),
+            prior_corrections=("Repair the visible leg",),
+            prior_profile_conflicts=(conflict,),
+        )
+        normalized_research = " ".join(research.split())
+        normalized_review = " ".join(review.split())
+
+        self.assertIn("one bounded re-adjudication", normalized_research)
+        self.assertIn(
+            "Do not assume either the prior profile or the review claim", normalized_research
+        )
+        self.assertIn('"field": "measurements.length"', research)
+        self.assertIn("Earlier review history for convergence checking", normalized_review)
+        self.assertIn("Repair the visible leg", normalized_review)
+        self.assertIn("never repeat a stale profile_value", normalized_review)
+        self.assertIn(
+            "drop a conflict that the current direct sources no longer support", normalized_review
+        )
+
     def test_plate_and_review_prompts_enforce_schematic_ruler(self) -> None:
         species = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 26, "iNaturalist")
         profile = SpeciesProfileData(
@@ -119,8 +187,8 @@ class PromptTests(unittest.TestCase):
         self.assertIn("BODY LENGTH: 7 in", prompt)
         self.assertIn("SCHEMATIC — NOT TO SCALE", prompt)
         self.assertIn("minimum at the bottom and maximum at the top", prompt)
-        self.assertIn("exactly four evenly spaced unlabeled interior ticks", normalized_prompt)
-        self.assertIn("ticks are subdivisions, not one-unit increments", normalized_prompt)
+        self.assertIn("roughly even, unlabeled interior ticks", normalized_prompt)
+        self.assertIn("count and spacing do not encode measurement units", normalized_prompt)
         self.assertIn("Do not draw a zero-based or wider full-range axis", prompt)
         self.assertIn("do not add a separate range bracket", normalized_prompt)
         self.assertIn("Match both the direction and degree", normalized_prompt)
@@ -146,13 +214,12 @@ class PromptTests(unittest.TestCase):
         normalized_review = " ".join(review.split())
 
         self.assertIn("values must increase from bottom to top", review)
-        self.assertIn("no separate marker may disagree with it", review)
+        self.assertIn("no separate marker may disagree with it", normalized_review)
         self.assertIn(
-            "range ruler must contain exactly four evenly spaced unlabeled interior ticks",
-            normalized_review,
+            "exact count or minor spacing variation is not a factual error", normalized_review
         )
-        self.assertIn("five proportional segments, not one-unit increments", normalized_review)
-        self.assertIn("Treat any mismatch as a material text error", normalized_review)
+        self.assertIn("wrong values or units", normalized_review)
+        self.assertIn("remains a material text error", normalized_review)
         self.assertIn("Read every visible text line in full", normalized_review)
         self.assertIn("duplicated, omitted, substituted, or nonsensical words", normalized_review)
         self.assertIn(
@@ -173,6 +240,13 @@ class PromptTests(unittest.TestCase):
             normalized_review,
         )
         self.assertIn("validate each study independently", normalized_review)
+        self.assertIn("naturally occluded far-side wing or leg is acceptable", normalized_review)
+        self.assertIn("never excuse a malformed", normalized_review)
+        self.assertIn("at least two direct HTTPS sources", normalized_review)
+        self.assertIn("Do not instruct the image generator", normalized_review)
+        self.assertIn("Identity fields are not adjudicable", normalized_review)
+        self.assertNotIn("exactly four evenly spaced", normalized_prompt)
+        self.assertNotIn("exactly four evenly spaced", normalized_review)
 
 
 if __name__ == "__main__":

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -143,6 +143,8 @@ class PromptTests(unittest.TestCase):
         self.assertIn('"field": "measurements.length"', research)
         self.assertIn("Earlier review history for convergence checking", normalized_review)
         self.assertIn("Repair the visible leg", normalized_review)
+        self.assertIn("resolved_corrections only when", normalized_review)
+        self.assertIn("must exactly match one earlier correction", normalized_review)
         self.assertIn("never repeat a stale profile_value", normalized_review)
         self.assertIn(
             "drop a conflict that the current direct sources no longer support", normalized_review

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -7,7 +7,8 @@ from tempfile import TemporaryDirectory
 
 from inky_bird_frame.birds import BirdSpecies
 from inky_bird_frame.errors import CatalogError
-from inky_bird_frame.retry import RetryGuidance, RetryStore
+from inky_bird_frame.models import ProfileConflict
+from inky_bird_frame.retry import RetryGuidance, RetryStore, parse_retry_profile_conflicts
 
 
 class RetryStoreTests(unittest.TestCase):
@@ -153,6 +154,103 @@ class RetryStoreTests(unittest.TestCase):
             ("Render clearly visible natural eyes.",),
         )
         self.assertEqual(reloaded, guidance)
+
+    def test_profile_conflicts_are_durable_without_image_findings(self) -> None:
+        conflict = ProfileConflict(
+            field="measurements.length",
+            profile_value="10-20 cm",
+            observed_value="12-15 cm",
+            sources=[
+                {"title": "Birds", "url": "https://birds.example/length"},
+                {"title": "Field", "url": "https://field.example/length"},
+            ],
+        )
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "retries.json"
+            guidance = RetryStore(path).set_quality_guidance(
+                42,
+                (),
+                profile_conflicts=(conflict,),
+            )
+
+            reloaded = RetryStore(path).quality_guidance(42)
+
+        self.assertEqual(guidance.findings, ())
+        self.assertEqual(guidance.profile_conflicts, (conflict,))
+        self.assertEqual(reloaded, guidance)
+
+    def test_retry_profile_conflicts_must_use_allowed_independent_sources(self) -> None:
+        conflict = {
+            "field": "measurements.length",
+            "profile_value": "10-20 cm",
+            "observed_value": "12-15 cm",
+            "sources": [
+                {"title": "One", "url": "https://outside.example/one"},
+                {"title": "Two", "url": "https://other.example/two"},
+            ],
+        }
+
+        with self.assertRaisesRegex(CatalogError, "Invalid retry quality guidance"):
+            parse_retry_profile_conflicts(
+                [conflict],
+                Path("retry.json"),
+                allowed_domains=("birds.example", "field.example"),
+            )
+
+        conflict["sources"] = [
+            {"title": "One", "url": "https://one.birds.example/one"},
+            {"title": "Two", "url": "https://two.birds.example/two"},
+        ]
+        with self.assertRaisesRegex(CatalogError, "Invalid retry quality guidance"):
+            parse_retry_profile_conflicts(
+                [conflict],
+                Path("retry.json"),
+                allowed_domains=("birds.example", "field.example"),
+            )
+
+    def test_retry_profile_conflicts_reject_malformed_state(self) -> None:
+        valid = {
+            "field": "measurements.length",
+            "profile_value": "10-20 cm",
+            "observed_value": "12-15 cm",
+            "sources": [
+                {"title": "Birds", "url": "https://birds.example/length"},
+                {"title": "Field", "url": "https://field.example/length"},
+            ],
+        }
+        cases: tuple[object, ...] = (
+            [valid, valid],
+            [{**valid, "observed_value": "10-20 cm"}],
+            [
+                {
+                    **valid,
+                    "sources": [
+                        {"title": "Birds", "url": "http://birds.example/length"},
+                        {"title": "Field", "url": "https://field.example/length"},
+                    ],
+                }
+            ],
+            [{**valid, "field": "scientific_name"}],
+            [
+                {
+                    **valid,
+                    "sources": [
+                        {"url": "https://birds.example/length"},
+                        {"title": "Field", "url": "https://field.example/length"},
+                    ],
+                }
+            ],
+        )
+
+        for raw in cases:
+            with (
+                self.subTest(raw=raw),
+                self.assertRaisesRegex(
+                    CatalogError,
+                    "Invalid retry quality guidance",
+                ),
+            ):
+                parse_retry_profile_conflicts(raw, Path("retry.json"))
 
     def test_correction_source_must_remain_in_archive(self) -> None:
         with TemporaryDirectory() as temporary:


### PR DESCRIPTION
## What changed

- advances the generation contract to `field-journal-v5`, keeping ruler endpoints, units, direction, and schematic semantics strict while treating unlabeled tick count and minor spacing as non-factual
- permits anatomically plausible far-side wing or leg occlusion without weakening visible eye, limb, foot, tail, bill, or duplicate-anatomy checks
- adds a structured, two-source profile-conflict channel; reviewer claims can trigger one bounded independent re-research pass but can never write canonical facts directly
- changes only disputed profile fields, retains private before/after evidence, preserves resolved corrections within a run, and records score/finding reversals
- writes schema-versioned private attempt histories for passes, terminal reviews, manual retries, generation errors, and review errors, including prompt/model identity and sanitized error types
- adds an optional `controller.codex_model` pin and documents configuration, recovery, evidence, and privacy behavior
- independently rejects unresolved profile conflicts at the deterministic catalog boundary

## Why

Recent retained failures showed three distinct problems being conflated: arbitrary ruler tick geometry, legitimate far-side occlusion, and disagreements between cached facts and later source-backed review. The old retry loop could turn factual conflicts into unsupported image edits and could forget corrections that had already converged.

This keeps the real quality bar intact while giving each failure class a bounded, auditable path.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest -q` — 604 tests passed
- `uv build`
- `uv run inky-bird-frame catalog validate --catalog catalog` — 136 species valid
- live retained-artifact calibration using the deployed Codex default (`gpt-5.6-sol`):
  - harmless Oystercatcher ruler spacing no longer failed; a real two-source length conflict was routed to profile adjudication
  - Nighthawk, Hooded Crow, and Brown Pelican passed after plausible occlusion/source review
  - Frigatebird routed measurement disagreements to profile adjudication
  - known Black Skimmer bill/iris hard negative still failed species/anatomy
  - known zero-based/mismatched ruler hard negative still failed text accuracy
  - isolated Oystercatcher re-research corrected the disputed length; controller tests prove unrelated fields remain unchanged

Publisher workspace cleanup is intentionally excluded and is reviewed separately in #215.