### PR TITLE
Clean abandoned catalog publish work

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -445,6 +445,18 @@ without automatic pruning so failed and rejected work stays available for
 inspection. Check them first when investigating a generation failure. Entries
 are safe to delete once they have been reviewed.
 
+`catalog-publish-work/` is disposable publisher scratch space, not retained
+generation evidence. Each publication invocation removes abandoned
+`publish-*` directories while holding the exclusive publisher lock, before it
+creates a new work directory. Files, symbolic links, and unrelated directories
+are never removed. The command reports `abandoned_work_directories` and
+`cleaned_work_directories`. A `--dry-run` reports abandoned work but leaves it
+untouched; the next real publication removes it before Git prunes stale
+worktree registrations. If recovery cannot remove a matching directory, the
+real publication stops with an actionable error instead of creating more
+scratch state and risking further disk exhaustion; `--dry-run` remains
+available for non-destructive diagnosis.
+
 ## Log retention
 
 On systemd hosts the services log JSON to journald and rely on the

--- a/src/inky_bird_frame/publisher.py
+++ b/src/inky_bird_frame/publisher.py
@@ -109,6 +109,30 @@ def exclusive_publish_lock(state_dir: Path) -> Iterator[None]:
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
+def _abandoned_publish_work(work_parent: Path) -> tuple[Path, ...]:
+    return tuple(
+        candidate
+        for candidate in sorted(work_parent.iterdir())
+        if candidate.name.startswith("publish-")
+        and not candidate.is_symlink()
+        and candidate.is_dir()
+    )
+
+
+def _cleanup_abandoned_publish_work_locked(work_parent: Path) -> int:
+    """Remove scratch directories left by publishers that no longer hold the lock."""
+    removed = 0
+    for candidate in _abandoned_publish_work(work_parent):
+        try:
+            shutil.rmtree(candidate)
+        except OSError as exc:
+            raise CatalogPublishError(
+                f"Could not remove abandoned catalog publication work: {candidate.name}"
+            ) from exc
+        removed += 1
+    return removed
+
+
 def _check_json_privacy(value: object, source: Path) -> None:
     if isinstance(value, dict):
         for key, child in value.items():
@@ -1028,9 +1052,13 @@ def run_catalog_publish(config: AppConfig, *, dry_run: bool = False) -> dict[str
             publication.remote,
             f"+refs/heads/{publication.base_branch}:{remote_ref}",
         )
-        _git(checkout, "worktree", "prune")
         work_parent = config.controller.state_dir / "catalog-publish-work"
         work_parent.mkdir(parents=True, exist_ok=True)
+        abandoned_work_directories = len(_abandoned_publish_work(work_parent))
+        cleaned_work_directories = (
+            0 if dry_run else _cleanup_abandoned_publish_work_locked(work_parent)
+        )
+        _git(checkout, "worktree", "prune")
         with TemporaryDirectory(prefix="publish-", dir=work_parent) as temporary:
             source_snapshot = Path(temporary) / "source-catalog"
             with catalog_state_lock(config.controller.state_dir):
@@ -1074,6 +1102,8 @@ def run_catalog_publish(config: AppConfig, *, dry_run: bool = False) -> dict[str
                     "merged": False,
                     "commit": None,
                     "pull_request": None,
+                    "abandoned_work_directories": abandoned_work_directories,
+                    "cleaned_work_directories": cleaned_work_directories,
                 }
                 if not changed:
                     return result

--- a/src/inky_bird_frame/publisher.py
+++ b/src/inky_bird_frame/publisher.py
@@ -1043,6 +1043,12 @@ def run_catalog_publish(config: AppConfig, *, dry_run: bool = False) -> dict[str
         raise CatalogPublishError("Catalog checkout_dir is not configured")
 
     with exclusive_publish_lock(config.controller.state_dir):
+        work_parent = config.controller.state_dir / "catalog-publish-work"
+        work_parent.mkdir(parents=True, exist_ok=True)
+        abandoned_work_directories = len(_abandoned_publish_work(work_parent))
+        cleaned_work_directories = (
+            0 if dry_run else _cleanup_abandoned_publish_work_locked(work_parent)
+        )
         repository = _validate_checkout(checkout, publication)
         remote_ref = f"refs/remotes/{publication.remote}/{publication.base_branch}"
         _git(
@@ -1051,12 +1057,6 @@ def run_catalog_publish(config: AppConfig, *, dry_run: bool = False) -> dict[str
             "--prune",
             publication.remote,
             f"+refs/heads/{publication.base_branch}:{remote_ref}",
-        )
-        work_parent = config.controller.state_dir / "catalog-publish-work"
-        work_parent.mkdir(parents=True, exist_ok=True)
-        abandoned_work_directories = len(_abandoned_publish_work(work_parent))
-        cleaned_work_directories = (
-            0 if dry_run else _cleanup_abandoned_publish_work_locked(work_parent)
         )
         _git(checkout, "worktree", "prune")
         with TemporaryDirectory(prefix="publish-", dir=work_parent) as temporary:

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -15,8 +15,10 @@ from inky_bird_frame.config import PublicCatalogConfig, load_config
 from inky_bird_frame.errors import CatalogPublishError
 from inky_bird_frame.http import write_json_atomic
 from inky_bird_frame.publisher import (
+    _abandoned_publish_work,
     _catalog_transaction_prefix,
     _check_json_privacy,
+    _cleanup_abandoned_publish_work_locked,
     _remote_repository,
     _validate_checkout,
     replace_public_catalog_taxon,
@@ -191,6 +193,58 @@ def _initialize_remote(root: Path) -> tuple[Path, Path]:
 
 
 class PublisherTests(unittest.TestCase):
+    def test_cleans_only_abandoned_publish_directories(self) -> None:
+        with TemporaryDirectory() as temporary, TemporaryDirectory() as external:
+            work_parent = Path(temporary)
+            abandoned = work_parent / "publish-abandoned"
+            (abandoned / "checkout").mkdir(parents=True)
+            (abandoned / "checkout/file").write_text("scratch")
+            preserved_directory = work_parent / "other-work"
+            preserved_directory.mkdir()
+            preserved_file = work_parent / "publish-file"
+            preserved_file.write_text("not a directory")
+            publish_symlink = work_parent / "publish-link"
+            outside = Path(external)
+            publish_symlink.symlink_to(outside, target_is_directory=True)
+
+            removed = _cleanup_abandoned_publish_work_locked(work_parent)
+
+            self.assertEqual(removed, 1)
+            self.assertFalse(abandoned.exists())
+            self.assertTrue(preserved_directory.is_dir())
+            self.assertTrue(preserved_file.is_file())
+            self.assertTrue(publish_symlink.is_symlink())
+            self.assertTrue(outside.is_dir())
+
+    def test_finds_abandoned_publish_work_without_removing_it(self) -> None:
+        with TemporaryDirectory() as temporary:
+            work_parent = Path(temporary)
+            abandoned = work_parent / "publish-abandoned"
+            abandoned.mkdir()
+
+            found = _abandoned_publish_work(work_parent)
+
+            self.assertEqual(found, (abandoned,))
+            self.assertTrue(abandoned.is_dir())
+
+    def test_abandoned_publish_cleanup_fails_closed(self) -> None:
+        with TemporaryDirectory() as temporary:
+            work_parent = Path(temporary)
+            abandoned = work_parent / "publish-abandoned"
+            abandoned.mkdir()
+
+            with (
+                patch(
+                    "inky_bird_frame.publisher.shutil.rmtree",
+                    side_effect=PermissionError("denied"),
+                ),
+                self.assertRaisesRegex(
+                    CatalogPublishError,
+                    "Could not remove abandoned catalog publication work",
+                ),
+            ):
+                _cleanup_abandoned_publish_work_locked(work_parent)
+
     def test_birdbuddy_private_fields_are_rejected_from_catalog_json(self) -> None:
         for field in (
             "authorization_confirmed_at",
@@ -1173,6 +1227,9 @@ class PublisherTests(unittest.TestCase):
             config = load_config(_write_config(root, checkout))
             _create_species(config.controller.catalog_dir, 1, "Example Bird")
             (config.controller.catalog_dir / ".staging").mkdir()
+            abandoned_work = config.controller.state_dir / "catalog-publish-work/publish-abandoned"
+            abandoned_work.mkdir(parents=True)
+            (abandoned_work / "partial").write_text("scratch")
 
             def fake_gh(
                 _publication: object,
@@ -1214,6 +1271,9 @@ class PublisherTests(unittest.TestCase):
             self.assertTrue(first["pushed"])
             self.assertTrue(first["merged"])
             self.assertTrue(first["changed"])
+            self.assertEqual(first["abandoned_work_directories"], 1)
+            self.assertEqual(first["cleaned_work_directories"], 1)
+            self.assertFalse(abandoned_work.exists())
             self.assertIsInstance(first["commit"], str)
             self.assertIn(
                 "catalog/species/1-example-bird/manifest.json",
@@ -1228,8 +1288,12 @@ class PublisherTests(unittest.TestCase):
 
             self.assertFalse(second["pushed"])
             self.assertFalse(second["changed"])
+            self.assertEqual(second["abandoned_work_directories"], 0)
+            self.assertEqual(second["cleaned_work_directories"], 0)
 
             _create_species(config.controller.catalog_dir, 2, "Second Bird")
+            dry_run_abandoned = config.controller.state_dir / "catalog-publish-work/publish-dry-run"
+            dry_run_abandoned.mkdir()
             with patch(
                 "inky_bird_frame.publisher._validate_checkout",
                 return_value="example/inky-bird-frame",
@@ -1238,6 +1302,9 @@ class PublisherTests(unittest.TestCase):
 
             self.assertTrue(dry_run["changed"])
             self.assertFalse(dry_run["pushed"])
+            self.assertEqual(dry_run["abandoned_work_directories"], 1)
+            self.assertEqual(dry_run["cleaned_work_directories"], 0)
+            self.assertTrue(dry_run_abandoned.is_dir())
             self.assertNotIn(
                 "2-second-bird", _run_git(remote, "ls-tree", "-r", "--name-only", "main")
             )
@@ -1252,6 +1319,8 @@ class PublisherTests(unittest.TestCase):
                 final = run_catalog_publish(config)
 
             self.assertTrue(final["pushed"])
+            self.assertEqual(final["cleaned_work_directories"], 1)
+            self.assertFalse(dry_run_abandoned.exists())
             self.assertIn(
                 "catalog/species/2-second-bird/manifest.json",
                 _run_git(remote, "ls-tree", "-r", "--name-only", "main"),

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -245,6 +245,26 @@ class PublisherTests(unittest.TestCase):
             ):
                 _cleanup_abandoned_publish_work_locked(work_parent)
 
+    def test_cleans_abandoned_work_before_checkout_validation(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            checkout = root / "checkout"
+            checkout.mkdir()
+            config = load_config(_write_config(root, checkout))
+            abandoned = config.controller.state_dir / "catalog-publish-work/publish-abandoned"
+            abandoned.mkdir(parents=True)
+
+            with (
+                patch(
+                    "inky_bird_frame.publisher._validate_checkout",
+                    side_effect=CatalogPublishError("checkout unavailable"),
+                ),
+                self.assertRaisesRegex(CatalogPublishError, "checkout unavailable"),
+            ):
+                run_catalog_publish(config)
+
+            self.assertFalse(abandoned.exists())
+
     def test_birdbuddy_private_fields_are_rejected_from_catalog_json(self) -> None:
         for field in (
             "authorization_confirmed_at",


### PR DESCRIPTION
## Summary
- remove abandoned `catalog-publish-work/publish-*` directories under the exclusive publisher lock
- keep dry runs non-destructive and fail closed if real cleanup cannot complete
- report discovered and cleaned scratch directories, with operational documentation

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest -q`
- `uv build`
- `uv run inky-bird-frame catalog validate --catalog catalog` (143 species)
- `git diff --check origin/main...HEAD`