### PR TITLE
Release version 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.3.1"
+version = "0.4.0"
 description = "Generate and display reusable bird field-journal plates"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/inky_bird_frame/__init__.py
+++ b/src/inky_bird_frame/__init__.py
@@ -1,3 +1,3 @@
 """Local bird field-journal plates for Pimoroni Inky displays."""
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary

- bump package and runtime metadata to 0.4.0
- release private eBird archive history, self-hosted BirdNET-Go discovery, BirdNET Analyzer history import, and the `source = "all"` deprecation notice
- release the field-journal-v5 generation contract and bounded source-backed profile adjudication
- include publisher scratch recovery, paced iNaturalist taxonomy lookups, 29 reviewed catalog additions, and the Bird Buddy diagram correction

This is a version-only PR. The functional changes were reviewed and merged separately. No configuration migration is required; existing provider selections continue to work.

## Validation

- `uv sync --extra dev --locked`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest -q` — 604 tests passed
- `uv build` — 0.4.0 source distribution and wheel
- package and runtime metadata both report 0.4.0
- `uv run inky-bird-frame catalog validate --catalog catalog` — 144 species valid
- `git diff --check`

The required hosted quality job will repeat these checks and add Compose, controller-container build, and container smoke validation.