### PR TITLE
Fix retained generation attempt selection

### DIFF
--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -430,11 +430,13 @@ def _retry_quality_guidance(
         return (), None, ()
     attempts: list[tuple[int, Path]] = []
     for attempt_path in failed_directories[-1].glob("attempt-*"):
+        if not attempt_path.is_dir():
+            continue
         try:
             attempt_number = int(attempt_path.name.removeprefix("attempt-"))
         except ValueError as exc:
             raise SpeciesStateError(f"Invalid generation attempt: {attempt_path}") from exc
-        if attempt_number <= 0 or not attempt_path.is_dir():
+        if attempt_number <= 0:
             raise SpeciesStateError(f"Invalid generation attempt: {attempt_path}")
         attempts.append((attempt_number, attempt_path))
     if not attempts:

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -430,13 +430,13 @@ def _retry_quality_guidance(
         return (), None, ()
     attempts: list[tuple[int, Path]] = []
     for attempt_path in failed_directories[-1].glob("attempt-*"):
-        if not attempt_path.is_dir():
+        if attempt_path.name == "attempt-history.json":
             continue
         try:
             attempt_number = int(attempt_path.name.removeprefix("attempt-"))
         except ValueError as exc:
             raise SpeciesStateError(f"Invalid generation attempt: {attempt_path}") from exc
-        if attempt_number <= 0:
+        if attempt_number <= 0 or not attempt_path.is_dir():
             raise SpeciesStateError(f"Invalid generation attempt: {attempt_path}")
         attempts.append((attempt_number, attempt_path))
     if not attempts:
@@ -537,6 +537,8 @@ def _retry_archived_quality_guidance(
             f"Retained generation profile identity does not match taxon {taxon_id}: {profile_path}"
         )
     for attempt_path in run.glob("attempt-*"):
+        if attempt_path.name == "attempt-history.json":
+            continue
         if (
             attempt_path.is_symlink()
             or not attempt_path.is_dir()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2327,6 +2327,7 @@ rotation_mode = "shuffle_bag"
                     }
                 )
             )
+            (run / "attempt-history.json").write_text(json.dumps({"attempts": []}))
             config = controller_config(state_dir)
             output = io.StringIO()
 
@@ -2722,6 +2723,25 @@ rotation_mode = "shuffle_bag"
                 retry_command(Namespace(taxon_id=42, source_attempt=2))
 
             self.assertTrue((state_dir / "failed/42-example-bird").is_dir())
+            self.assertFalse((state_dir / "archive").exists())
+
+    def test_retry_rejects_non_directory_attempt_before_archiving(self) -> None:
+        with TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            failed = state_dir / "failed/42-example-bird"
+            review = failed / "attempt-01/quality-review.json"
+            review.parent.mkdir(parents=True)
+            review.write_text(json.dumps({"passed": False, "findings": ["Fix the tail"]}))
+            (failed / "attempt-02").write_text("corrupt attempt")
+            config = controller_config(state_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(SpeciesStateError, "Invalid generation attempt"),
+            ):
+                retry_command(Namespace(taxon_id=42, source_attempt=1))
+
+            self.assertTrue(failed.is_dir())
             self.assertFalse((state_dir / "archive").exists())
 
     def test_retry_rejects_malformed_quality_review_before_archiving(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1230,6 +1230,7 @@ rotation_mode = "shuffle_bag"
                         }
                     )
                 )
+            (failed / "attempt-history.json").write_text(json.dumps({"attempts": []}))
             (failed / "profile.json").write_text(
                 json.dumps(
                     {


### PR DESCRIPTION
## Summary

- ignore non-directory generation metadata when selecting retained `attempt-*` artifacts
- keep malformed attempt directories fail-closed
- cover `attempt-history.json` in the retained-attempt retry test

## Production evidence

A v0.4.0 terminal retry with `--source-attempt` failed before mutating state because `attempt-history.json` was parsed as an attempt directory. Both affected birds retained all failed artifacts and remained terminal.

## Validation

- `uv run pytest` (609 passed, 49 subtests passed)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- public catalog validation (148 species)
- workflow action pinning check
- `uv build`
- `git diff --check`

Docker validation is delegated to the hosted quality job because Docker is not installed on the controller Mac.