### PR TITLE
Release version 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.4.0"
+version = "0.4.1"
 description = "Generate and display reusable bird field-journal plates"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/inky_bird_frame/__init__.py
+++ b/src/inky_bird_frame/__init__.py
@@ -1,3 +1,3 @@
 """Local bird field-journal plates for Pimoroni Inky displays."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary

- release the retained generation-attempt selection fix as v0.4.1
- keep package, runtime, and lockfile versions aligned

## Validation

- `uv run pytest` (609 passed, 49 subtests passed)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- public catalog validation (149 species)
- workflow action pinning check
- `uv build`
- package and runtime metadata both report 0.4.1
- `git diff --check`

No configuration migration is required.