### PR TITLE
Document BirdNET macOS network access

### DIFF
--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -240,6 +240,38 @@ proxy. The endpoint must be reachable without HTTP authentication; keep it on a
 trusted network or VPN. Do not embed credentials, query parameters, or
 fragments. A BirdNET-Go-only configuration needs no discovery location.
 
+### macOS Local Network access
+
+On macOS 15 and later, Local Network privacy applies to LaunchAgents. A direct
+BirdNET-Go address on the controller's attached subnet can therefore work from
+Terminal but fail during the scheduled refresh with `[Errno 65] No route to
+host`. Apple documents the distinction between command-line tools and
+LaunchAgents in [TN3179: Understanding local network privacy][apple-tn3179].
+
+If you already run a reverse proxy on a routed network path, prefer its HTTPS
+base URL:
+
+```toml
+[discovery]
+sources = ["birdnet-go"]
+birdnet_go_url = "https://birdnet.example.net"
+```
+
+The proxy must expose the same unauthenticated BirdNET-Go API. After changing
+the URL, test the installed service instead of relying on a manual refresh:
+
+```bash
+refresh_label="gui/$(id -u)/com.inky-bird-frame.refresh"
+refresh_pid="$(launchctl kickstart -kp "$refresh_label")"
+while kill -0 "$refresh_pid" 2>/dev/null; do sleep 1; done
+tail -n 200 "$HOME/Library/Application Support/Inky Bird Frame/logs/refresh.log"
+```
+
+The newest result should show the `birdnet-go` provider with `status` set to
+`ok`. If both the direct address and the proxy fail from LaunchAgent context,
+follow Apple's current Local Network privacy guidance rather than adding a
+broad network exception without reviewing its system-wide effect.
+
 Inky uses BirdNET-Go's documented read-only
 `/api/v2/analytics/species/summary` endpoint. It supplies the selected date
 window and species limit, then reads only names, counts, and the last-heard
@@ -254,6 +286,8 @@ remain private unresolved diagnostics and cannot trigger plate generation. A
 BirdNET-Go failure degrades only this provider; other configured sources keep
 running. The legacy singular `source = "all"` retains its existing meaning and
 does not silently enable access to a local BirdNET-Go server.
+
+[apple-tn3179]: https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy
 
 ## BirdNET Analyzer CSV import
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -134,6 +134,27 @@ was reachable but one or more scientific names did not exactly match an active
 iNaturalist bird species. Correct false positives in BirdNET-Go; its next
 summary will exclude detections marked false-positive.
 
+On macOS 15 or later, compare manual and scheduled refreshes before changing
+the BirdNET-Go server. If a manual refresh succeeds but the LaunchAgent reports
+`[Errno 65] No route to host`, macOS Local Network privacy may be blocking the
+background process:
+
+```bash
+inky-bird-frame refresh --config "/path/to/config.toml"
+refresh_label="gui/$(id -u)/com.inky-bird-frame.refresh"
+refresh_pid="$(launchctl kickstart -kp "$refresh_label")"
+while kill -0 "$refresh_pid" 2>/dev/null; do sleep 1; done
+tail -n 200 "$HOME/Library/Application Support/Inky Bird Frame/logs/refresh.log"
+```
+
+An unauthenticated HTTPS reverse proxy on a routed network path can avoid the
+direct-subnet restriction. Set `birdnet_go_url` to the proxy's base URL and
+repeat the LaunchAgent test. The proxy must preserve
+`/api/v2/analytics/species/summary`; Inky does not send proxy credentials. See
+the [BirdNET-Go macOS setup](discovery.md#macos-local-network-access) and
+[Apple TN3179](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy)
+for the platform behavior and system-wide alternatives.
+
 For BirdNET Analyzer, verify the CSV was imported before enabling the provider.
 An undated import is intentionally empty in every finite window; use
 `window = "all-time"` or reimport with `--observed-on` only when the recording


### PR DESCRIPTION
## Summary

Document a macOS Local Network privacy failure that can affect scheduled BirdNET-Go discovery even when the same URL works from Terminal.

The setup guide now recommends an existing unauthenticated HTTPS reverse proxy on a routed network path when a direct same-subnet address fails from LaunchAgent context. The troubleshooting guide shows how to compare manual and scheduled refreshes and verify the provider after changing the URL.

## Change type

- [ ] Code
- [x] Documentation
- [ ] Catalog plate
- [ ] Tests or continuous integration
- [ ] Other maintenance

## Validation

- `uv run ruff format --check .` — passed
- `uv run ruff check .` — passed
- `uv run mypy` — passed
- `uv run pytest` — 609 passed, 49 subtests passed
- `uv run inky-bird-frame catalog validate --catalog catalog` — 152 species, valid
- `git diff --check` — passed
- Public documentation scrub for private hosts, addresses, paths, and credentials — passed

Live validation used the installed macOS LaunchAgent context: the direct same-subnet URL returned `Errno 65`, while the routed HTTPS proxy returned usable BirdNET-Go summaries through the production parser. No private endpoint or observation data is included in this pull request.

## Review notes

This is documentation only. It does not change provider behavior or configuration defaults. The proxy remains subject to the existing requirement that BirdNET-Go's read-only API be reachable without HTTP authentication.