### PR TITLE
Release version 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,10 +287,10 @@ counts, or media references. See the
 [discovery guide](docs/discovery.md#ebird-personal-archive) for the import and
 update workflow.
 
-The legacy singular `source = "all"` setting is deprecated and will be removed
-in a future minor release. Replace it with
+Version 0.5.0 removed the legacy `source = "all"` setting. Replace it with
 `sources = ["inaturalist", "ebird", "birdweather"]`; the provider selection is
-identical.
+identical. Other legacy singular values remain accepted for compatibility, but
+new configurations should use `sources`.
 
 Choose `last-day`, `last-week`, `last-30-days`, `last-year`, or `all-time` for
 the observation window. Provider limits still apply. The

--- a/config.example.toml
+++ b/config.example.toml
@@ -3,8 +3,8 @@
 # nearby public sightings, eBird Archive imports your private personal history, BirdWeather
 # and self-hosted BirdNET-Go provide acoustic station detections, BirdNET Analyzer imports
 # private CSV history, and authorized Bird Buddy accounts provide read-only feeder postcards.
-# Legacy singular source values remain accepted for compatibility, but source = "all" is
-# deprecated. Replace it with sources = ["inaturalist", "ebird", "birdweather"].
+# Version 0.5.0 removed the ambiguous source = "all" value. Use the explicit sources array;
+# sources = ["inaturalist", "ebird", "birdweather"] preserves its former behavior.
 # See docs/discovery.md.
 sources = ["inaturalist"]
 # Choose exactly one location form for iNaturalist or eBird. The legacy five-digit US

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -284,17 +284,33 @@ Every scientific name must still resolve exactly to one active iNaturalist bird
 species. Custom classifier labels, non-birds, and ambiguous or unmatched names
 remain private unresolved diagnostics and cannot trigger plate generation. A
 BirdNET-Go failure degrades only this provider; other configured sources keep
-running. The legacy singular `source = "all"` retains its existing meaning and
-does not silently enable access to a local BirdNET-Go server.
+running. BirdNET-Go runs only when you include `birdnet-go` in the explicit
+`sources` array.
 
 [apple-tn3179]: https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy
 
 ## BirdNET Analyzer CSV import
 
-BirdNET Analyzer is the offline desktop and command-line analyzer from the
-BirdNET team. Its official CSV output contains segment offsets, species names,
-confidence, and a source-file field, but no absolute recording date. Inky never
-guesses one from a filename or filesystem timestamp.
+[BirdNET Analyzer](https://github.com/birdnet-team/BirdNET-Analyzer) is the
+offline desktop and command-line analyzer from the BirdNET team. Its official
+CSV output contains segment offsets, species names, confidence, and a
+source-file field, but no absolute recording date. Inky never guesses one from
+a filename or filesystem timestamp.
+
+For a directory of recordings, ask Analyzer to create one importable table in
+addition to its per-file results:
+
+```bash
+python3 -m birdnet_analyzer.analyze /path/to/recordings \
+  --output /path/to/analyzer-output \
+  --rtype csv \
+  --combine_results \
+  --min_conf 0.7
+```
+
+This example uses a minimum confidence of `0.70`. Choose a threshold that fits
+your detector policy, then review `BirdNET_CombinedTable.csv` before import.
+Inky accepts one CSV per import and does not apply a second confidence filter.
 
 Import an Analyzer CSV into controller-private history, then opt in to the
 provider:
@@ -302,7 +318,7 @@ provider:
 ```bash
 inky-bird-frame birdnet-analyzer import \
   --config /path/to/config.toml \
-  --csv /path/to/BirdNET_Analyzer_results.csv
+  --csv /path/to/analyzer-output/BirdNET_CombinedTable.csv
 ```
 
 ```toml
@@ -481,18 +497,17 @@ case, the prior active catalog stays in place.
 
 The legacy singular values `source = "inaturalist"`, `"ebird"`, `"combined"`,
 and `"birdweather"` remain accepted. Do not set both `source` and `sources`.
-`source = "all"` is deprecated and will be removed in a future minor release.
-Its meaning remains frozen to the three providers present when it was
-introduced, so an application upgrade cannot silently contact a future
-provider. Migrate it now without changing behavior:
+Version 0.5.0 removed `source = "all"` because its frozen three-provider meaning
+became misleading as new providers were added. Replace it without changing
+behavior:
 
 ```toml
 [discovery]
 sources = ["inaturalist", "ebird", "birdweather"]
 ```
 
-`config validate` reports this deprecation when the legacy setting is present.
-New configurations should always use the explicit array.
+Configuration loading now fails with this migration when `source = "all"` is
+present. New configurations should always use the explicit array.
 
 iNaturalist supplies observation counts, BirdWeather supplies station detection
 counts, Bird Buddy supplies distinct postcard counts, and eBird's nearby

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.4.1"
+version = "0.5.0"
 description = "Generate and display reusable bird field-journal plates"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/inky_bird_frame/__init__.py
+++ b/src/inky_bird_frame/__init__.py
@@ -1,3 +1,3 @@
 """Local bird field-journal plates for Pimoroni Inky displays."""
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -1180,16 +1180,6 @@ def config_validate_command(args: argparse.Namespace) -> int:
     config = _config(args)
     destinations = validate_notification_destinations(config)
     deprecations: list[dict[str, str]] = []
-    if config.discovery.legacy_all_source:
-        deprecations.append(
-            {
-                "setting": "discovery.source",
-                "message": (
-                    'source = "all" is deprecated and will be removed in a future minor release'
-                ),
-                "replacement": ('sources = ["inaturalist", "ebird", "birdweather"]'),
-            }
-        )
     if config.discovery.latitude is not None:
         location_mode = "coordinates"
     elif config.discovery.postal_code is not None:

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -426,8 +426,8 @@ def load_config(path: Path, *, load_secrets: bool = True) -> AppConfig:
         source_value = _optional_string(discovery, "source", default="inaturalist")
         if source_value == "all":
             raise ConfigurationError(
-                'discovery.source = "all" is no longer supported; use '
-                'discovery.sources = ["inaturalist", "ebird", "birdweather"]'
+                'discovery.source = "all" is no longer supported; replace it in '
+                '[discovery] with sources = ["inaturalist", "ebird", "birdweather"]'
             )
         try:
             discovery_sources = LEGACY_DISCOVERY_SOURCES[source_value]

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -38,11 +38,6 @@ LEGACY_DISCOVERY_SOURCES: dict[str, tuple[DiscoveryProvider, ...]] = {
     "ebird": (DiscoveryProvider.EBIRD,),
     "combined": (DiscoveryProvider.INATURALIST, DiscoveryProvider.EBIRD),
     "birdweather": (DiscoveryProvider.BIRDWEATHER,),
-    "all": (
-        DiscoveryProvider.INATURALIST,
-        DiscoveryProvider.EBIRD,
-        DiscoveryProvider.BIRDWEATHER,
-    ),
 }
 
 
@@ -103,7 +98,6 @@ class DiscoveryConfig:
     birdweather_token_env: str | None = field(default=None, repr=False)
     birdbuddy_include_manual_sightings: bool = False
     birdnet_go_url: str | None = None
-    legacy_all_source: bool = False
 
 
 @dataclass(frozen=True)
@@ -418,7 +412,6 @@ def load_config(path: Path, *, load_secrets: bool = True) -> AppConfig:
     except ValueError as exc:
         raise ConfigurationError(str(exc)) from exc
 
-    legacy_all_source = False
     if "source" in discovery and "sources" in discovery:
         raise ConfigurationError("Choose discovery.source or discovery.sources, not both")
     if "sources" in discovery:
@@ -431,7 +424,11 @@ def load_config(path: Path, *, load_secrets: bool = True) -> AppConfig:
             raise ConfigurationError(str(exc)) from exc
     else:
         source_value = _optional_string(discovery, "source", default="inaturalist")
-        legacy_all_source = "source" in discovery and source_value == "all"
+        if source_value == "all":
+            raise ConfigurationError(
+                'discovery.source = "all" is no longer supported; use '
+                'discovery.sources = ["inaturalist", "ebird", "birdweather"]'
+            )
         try:
             discovery_sources = LEGACY_DISCOVERY_SOURCES[source_value]
         except KeyError as exc:
@@ -632,7 +629,6 @@ def load_config(path: Path, *, load_secrets: bool = True) -> AppConfig:
                 default=False,
             ),
             birdnet_go_url=birdnet_go_url,
-            legacy_all_source=legacy_all_source,
         ),
         controller=ControllerConfig(
             workspace_dir=_path(_string(controller, "workspace_dir"), base_dir),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,10 +163,9 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["total_checklists"], 2)
         self.assertNotIn("species", payload)
 
-    def test_config_validate_reports_legacy_all_source_deprecation(self) -> None:
+    def test_config_validate_reports_no_deprecations(self) -> None:
         config = SimpleNamespace(
             discovery=SimpleNamespace(
-                legacy_all_source=True,
                 latitude=1.0,
                 longitude=2.0,
                 postal_code=None,
@@ -195,11 +194,7 @@ class CliTests(unittest.TestCase):
 
         payload = json.loads(output.getvalue())["data"]
         self.assertEqual(result, 0)
-        self.assertEqual(payload["deprecations"][0]["setting"], "discovery.source")
-        self.assertIn(
-            'sources = ["inaturalist", "ebird", "birdweather"]',
-            payload["deprecations"][0]["replacement"],
-        )
+        self.assertEqual(payload["deprecations"], [])
 
     def test_birdnet_analyzer_import_parses_explicit_date_and_redacts_path(self) -> None:
         args = build_parser().parse_args(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -385,9 +385,10 @@ class ConfigTests(unittest.TestCase):
                 load_config(path)
 
         self.assertIn(
-            'discovery.sources = ["inaturalist", "ebird", "birdweather"]',
+            '[discovery] with sources = ["inaturalist", "ebird", "birdweather"]',
             str(raised.exception),
         )
+        self.assertNotIn("discovery.sources", str(raised.exception))
 
     def test_explicit_sources_select_former_all_providers(self) -> None:
         configured = CONFIG.replace(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,13 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from inky_bird_frame.birds import ObservationWindow
-from inky_bird_frame.config import DiscoveryProvider, NotificationEvent, RotationMode, load_config
+from inky_bird_frame.config import (
+    DiscoveryProvider,
+    NotificationEvent,
+    RotationMode,
+    discovery_source_label,
+    load_config,
+)
 from inky_bird_frame.errors import ConfigurationError
 
 CONFIG = """
@@ -364,7 +370,7 @@ class ConfigTests(unittest.TestCase):
                 with self.assertRaisesRegex(ConfigurationError, "query, or a fragment"):
                     load_config(path)
 
-    def test_legacy_all_source_does_not_implicitly_enable_new_private_sources(self) -> None:
+    def test_rejects_removed_all_source_with_migration(self) -> None:
         configured = CONFIG.replace(
             "[discovery]\n",
             '[discovery]\nsource = "all"\n'
@@ -374,15 +380,16 @@ class ConfigTests(unittest.TestCase):
         with TemporaryDirectory() as temporary:
             path = Path(temporary) / "config.toml"
             path.write_text(configured)
-            config = load_config(path)
 
-        self.assertNotIn(DiscoveryProvider.BIRDBUDDY, config.discovery.sources)
-        self.assertNotIn(DiscoveryProvider.BIRDNET_GO, config.discovery.sources)
-        self.assertNotIn(DiscoveryProvider.BIRDNET_ANALYZER, config.discovery.sources)
-        self.assertNotIn(DiscoveryProvider.EBIRD_ARCHIVE, config.discovery.sources)
-        self.assertTrue(config.discovery.legacy_all_source)
+            with self.assertRaisesRegex(ConfigurationError, "no longer supported") as raised:
+                load_config(path)
 
-    def test_explicit_sources_are_not_marked_as_legacy_all(self) -> None:
+        self.assertIn(
+            'discovery.sources = ["inaturalist", "ebird", "birdweather"]',
+            str(raised.exception),
+        )
+
+    def test_explicit_sources_select_former_all_providers(self) -> None:
         configured = CONFIG.replace(
             "[discovery]\n",
             '[discovery]\nsources = ["inaturalist", "ebird", "birdweather"]\n'
@@ -394,7 +401,18 @@ class ConfigTests(unittest.TestCase):
             path.write_text(configured)
             config = load_config(path)
 
-        self.assertFalse(config.discovery.legacy_all_source)
+        self.assertEqual(
+            config.discovery.sources,
+            (
+                DiscoveryProvider.INATURALIST,
+                DiscoveryProvider.EBIRD,
+                DiscoveryProvider.BIRDWEATHER,
+            ),
+        )
+        self.assertEqual(
+            discovery_source_label(config.discovery.sources),
+            "inaturalist,ebird,birdweather",
+        )
 
     def test_rejects_source_and_sources_together(self) -> None:
         configured = CONFIG.replace(
@@ -420,10 +438,11 @@ class ConfigTests(unittest.TestCase):
                 with self.assertRaisesRegex(ConfigurationError, message):
                     load_config(path)
 
-    def test_all_source_requires_both_provider_credentials(self) -> None:
+    def test_explicit_former_all_sources_require_both_provider_credentials(self) -> None:
         configured = CONFIG.replace(
             "[discovery]\n",
-            '[discovery]\nsource = "all"\nebird_api_key = "ebird-secret"\n',
+            '[discovery]\nsources = ["inaturalist", "ebird", "birdweather"]\n'
+            'ebird_api_key = "ebird-secret"\n',
         )
         with TemporaryDirectory() as temporary:
             path = Path(temporary) / "config.toml"

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3631,14 +3631,14 @@ class DiscoveryProviderTests(unittest.TestCase):
         self.assertEqual(snapshot["place_name"], "")
         self.assertEqual(snapshot["state"], "")
 
-    def test_all_mode_station_fallback_clears_previous_location_metadata(self) -> None:
+    def test_multi_provider_station_fallback_clears_previous_location_metadata(self) -> None:
         species = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 7, "BirdWeather")
         with TemporaryDirectory() as temporary:
             config_path = Path(temporary) / "config.toml"
             config_path.write_text(
                 CONFIG.replace(
                     "[discovery]\n",
-                    '[discovery]\nsource = "all"\n'
+                    '[discovery]\nsources = ["inaturalist", "ebird", "birdweather"]\n'
                     'ebird_api_key = "ebird-secret"\n'
                     'birdweather_token = "station-secret"\n',
                 )
@@ -3717,7 +3717,7 @@ class DiscoveryProviderTests(unittest.TestCase):
         self.assertEqual(fetch.call_args.kwargs["token"], "station-secret")
         lookup.assert_not_called()
 
-    def test_all_mode_uses_birdweather_when_zip_lookup_fails(self) -> None:
+    def test_multi_provider_mode_uses_birdweather_when_zip_lookup_fails(self) -> None:
         detection = BirdWeatherSpecies(
             42,
             "Eastern Bluebird",
@@ -3731,7 +3731,7 @@ class DiscoveryProviderTests(unittest.TestCase):
             config_path.write_text(
                 CONFIG.replace(
                     "[discovery]\n",
-                    '[discovery]\nsource = "all"\n'
+                    '[discovery]\nsources = ["inaturalist", "ebird", "birdweather"]\n'
                     'ebird_api_key = "ebird-secret"\n'
                     'birdweather_token = "station-secret"\n',
                 )
@@ -3764,7 +3764,7 @@ class DiscoveryProviderTests(unittest.TestCase):
         inaturalist.assert_not_called()
         ebird.assert_not_called()
 
-    def test_all_mode_continues_when_birdweather_fails(self) -> None:
+    def test_multi_provider_mode_continues_when_birdweather_fails(self) -> None:
         inaturalist = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 9, "iNaturalist")
         ebird = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 1, "eBird")
         observation = EbirdSpecies("easblu", "Eastern Bluebird", "Sialia sialis", "2026-07-12")
@@ -3773,7 +3773,7 @@ class DiscoveryProviderTests(unittest.TestCase):
             config_path.write_text(
                 CONFIG.replace(
                     "[discovery]\n",
-                    '[discovery]\nsource = "all"\n'
+                    '[discovery]\nsources = ["inaturalist", "ebird", "birdweather"]\n'
                     'ebird_api_key = "ebird-secret"\n'
                     'birdweather_token = "station-secret"\n',
                 )

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## What changed

This releases Inky Bird Frame 0.5.0 and makes the planned removal of the deprecated `discovery.source = "all"` shorthand atomic with the version change.

Configurations that still use the shorthand now fail with a direct migration to:

```toml
sources = ["inaturalist", "ebird", "birdweather"]
```

That explicit list preserves the old behavior without implying that newly added providers will be enabled automatically. The other legacy singular values remain compatible.

The release documentation also records the validated BirdNET Analyzer combined-CSV workflow, including where confidence filtering belongs and the filename users should import.

## Validation

- `uv lock --check`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest` — 609 passed, 49 subtests passed
- `uv run inky-bird-frame catalog validate --catalog catalog`
- catalog add-only validation against `origin/main`
- workflow action pinning check
- `actionlint -color`
- `shellcheck deploy/*.sh`
- `uv build` — 0.5.0 sdist and wheel
- package, runtime, and lockfile version consistency

Docker is not installed on the development Mac, so the hosted `cli-quality` job remains the source of truth for Compose validation and container build/smoke tests.
