### PR TITLE
Add Access-Control-Allow-Origin wildcard

### DIFF
--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -38,6 +38,7 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Cache-Control", "no-store")
+        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(body)
 
@@ -48,6 +49,7 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
         self.send_response(HTTPStatus.OK)
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header(
             "Cache-Control",
             "public, max-age=86400, immutable" if content_addressed else "no-cache",


### PR DESCRIPTION
## Summary

Small change to add wild cards to Access-Control-Allow-Origin header. This allows JavaScript clients to call the API to retrieve bird indexes and images.

## Change type

- [ x] Code
- [ ] Documentation
- [ ] Catalog plate
- [ ] Tests or continuous integration
- [ ] Other maintenance

## Validation

Not validated, want this in the docker pipeline so I can test but it should work.

## Review notes

For a web application with no authentication and no sensitive data, this has no security implications in the current state.
