### PR TITLE
Release version 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.5.0"
+version = "0.6.0"
 description = "Generate and display reusable bird field-journal plates"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/inky_bird_frame/__init__.py
+++ b/src/inky_bird_frame/__init__.py
@@ -1,3 +1,3 @@
 """Local bird field-journal plates for Pimoroni Inky displays."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary

Prepare Inky Bird Frame 0.6.0 after the opt-in browser catalog interface landed. Align the project, runtime, and lockfile versions at 0.6.0.

The release also includes nine new bird plates and GitHub Actions dependency maintenance merged since 0.5.0. Browser access remains disabled unless an operator configures an exact trusted origin, so no configuration or catalog-state migration is required.

## Change type

- [ ] Code
- [ ] Documentation
- [ ] Catalog plate
- [ ] Tests or continuous integration
- [x] Other maintenance

## Validation

- `uv lock --check`
- `uv sync --extra dev --locked`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest` (616 passed, 75 subtests passed)
- `uv run inky-bird-frame catalog validate --catalog catalog` (162 species, valid)
- Catalog add-only validation against `origin/main` (no additions, valid)
- `uv run python .github/scripts/check_workflow_pinning.py .github/workflows`
- `actionlint -color`
- `shellcheck deploy/*.sh`
- `uv build` (0.6.0 source distribution and wheel)
- Package, runtime, and lockfile version consistency
- `git diff --check`

## Review notes

The GitHub release notes will thank and tag @dwalters0, whose first external contribution identified the browser-client gap implemented in #246.
