### PR TITLE
Make catalog upgrades and generation status authoritative

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,9 @@ reviewed replacements as migration history, replaces the entry transactionally,
 rebuilds the index, and validates the result. Pull-request CI accepts the
 replacement only when the newest record exactly matches the base catalog.
 Ordinary catalog contributions remain add-only. Controller catalog sync accepts
-the recorded ancestry so an installation may safely skip intermediate releases.
+the recorded ancestry only when deployment explicitly enables reviewed
+migrations, so an installation may safely skip intermediate releases. A
+validated destination descendant is retained; catalog sync never downgrades it.
 
 ### Required plate contents
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ uv run inky-bird-frame collection list --config config.toml
 uv run inky-bird-frame collection add 12942 --config config.toml
 uv run inky-bird-frame collection remove 12942 --config config.toml --dry-run
 
-# Inspect approved, actionable, deferred, terminal-blocked, and failed work.
+# Inspect current generation work and the underlying durable state.
 uv run inky-bird-frame status --config config.toml
 
 # Serve the catalog and rotate the next approved plate.

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,6 +16,8 @@ x-controller-common: &controller-common
 services:
   bootstrap:
     <<: *controller-common
+    environment:
+      INKY_CATALOG_SYNC_APPLY_REVIEWED_MIGRATIONS: "1"
     command:
       - catalog
       - sync

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,8 +84,10 @@ entire export validates; a missing previously imported checklist fails closed
 unless the operator explicitly permits history reduction.
 
 A locked generation cycle completes that migration, recovers passing pending
-work, and then reads the latest non-stale snapshot and durable seed queue.
-Current observations take priority over queued seed taxa. The cycle then:
+work, and then passes the latest non-stale snapshot, durable queue, retry
+schedule, approvals, and terminal states through the same side-effect-free work
+calculation exposed by `status`. Current observations take priority over queued
+taxa, and retry-due candidates are actionable. The cycle then:
 
 1. selects taxa without a terminal local state;
 2. acquires and verifies licensed references;

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -22,10 +22,16 @@ One failed scheduled job is logged and retried later without stopping the HTTP
 service or unrelated jobs.
 
 `bootstrap` runs `catalog sync --source-catalog /app/catalog --catalog
-/data/catalog --state-dir /data/var/controller`. The sync is add-only: it
-validates the bundled public catalog, copies only species missing from the
-persistent catalog, rebuilds the index, and holds the controller state lock so
-it cannot overwrite an approved plate or race a running cycle. The
+/data/catalog --state-dir /data/var/controller`. Compose opts into reviewed
+migrations through `INKY_CATALOG_SYNC_APPLY_REVIEWED_MIGRATIONS=1` instead of a
+version-specific command-line argument, so the current Compose definition can
+still start an older image after the matching persistent snapshot is restored.
+Bootstrap validates the bundled and persistent catalogs, copies missing species, and
+applies only replacements whose recorded approval hashes and complete migration
+ancestry match the persistent plate. A validated persistent descendant is
+retained and reported as `retained_newer`; bootstrap never downgrades it.
+Unrelated or tampered conflicts fail closed. The sync rebuilds the index and
+holds the controller state lock so it cannot race a running cycle. The
 [operations guide](operations.md#copy-species-between-catalogs) describes the
 command in general.
 
@@ -296,6 +302,12 @@ when Bird Buddy is enabled. Protect authentication volumes if you include them.
 `docker compose down` keeps all volumes. `docker compose down --volumes`
 deletes permanent controller state and should not be part of a normal update.
 
+Before an update, take a restorable point-in-time snapshot of `controller-data`
+and the matching configuration files. Stop `scheduler` and `controller` while
+capturing a filesystem-level copy if the backup system cannot snapshot the
+volume atomically. Keep that snapshot until the updated controller has completed
+bootstrap, refresh, generation status, and display verification.
+
 ## Update
 
 Read the release notes, then change `INKY_BIRD_IMAGE` in `.env` to the desired
@@ -312,8 +324,14 @@ curl --fail --silent http://127.0.0.1:8793/health
 Recreating the services is required after changing `controller.env`; a restart
 does not reload a container's environment.
 
-For rollback, restore the prior image tag in `.env` and repeat the same `pull`
-and `up` commands. Persistent data is not removed.
+Changing the image tag rolls back application code only; it does not roll back
+persistent state. Reviewed catalog sync is forward-only. A newer, validated
+persistent descendant is retained rather than replaced with an older bundled
+plate. To roll back catalog or state migrations, stop the stack, restore the
+matching pre-update `controller-data` snapshot and configuration, select the
+prior image tag, and repeat the `pull` and `up` commands. Do not combine an old
+image with newer persistent state unless that release's notes explicitly state
+that the combination is compatible.
 
 ## Build from source
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -259,21 +259,30 @@ weight of one instead of fabricated evidence.
 
 ## Interpret generation status
 
-`status` separates persistent generation work into these views:
+`status` preserves these top-level views for compatibility:
 
-- `queued`: unapproved seed-queue taxa still eligible for automatic work;
-- `deferred`: the subset governed by a durable retry schedule after a transient
-  failure; and
-- `terminal_blocked`: queued taxa with an incomplete pending directory,
-  rejected state, or exhausted failed state that require explicit `retry`.
+- `queued`: unapproved taxa in the durable seed or human-review queue;
+- `deferred`: all retained retry records;
+- `terminal_blocked`: terminal states associated with the durable queue; and
+- `failed`: retained failed-artifact paths, which are not necessarily current
+  work.
 
-`deferred` can overlap `queued`; it explains when an otherwise actionable taxon
-will be attempted again. `terminal_blocked` never counts toward `queued_count`
-in generation-cycle output. Passing pending candidates remain visible in the
-separate `pending` view and are recovered at the start of a generation cycle.
-An interrupted pending directory without a manifest appears as
-`incomplete_pending` under `terminal_blocked`; `retry TAXON_ID` archives the
-partial directory before making the taxon eligible again.
+Use the nested `generation` object as the authoritative work view. It combines
+the current discovery snapshot with durable queue-only retries using the same
+calculation as generation. `eligible` contains every unapproved, nonterminal
+candidate; `actionable` is the retry-due subset generation can attempt now;
+`deferred` is waiting for `next_attempt_at`; and `terminal_blocked` includes live
+or queued taxa with incomplete pending, rejected, or failed state. Each list has
+a matching count.
+
+`generation.complete` is true only when the discovery snapshot exists and is no
+older than twice `schedule.refresh_minutes`. Missing or stale discovery remains
+visible as `generation.discovery.status`, preserves the candidates known from
+local state, and leaves `actionable` empty. Corrupt catalog, discovery, or retry
+state fails the command instead of being repaired or presented as healthy.
+Passing pending candidates remain visible in the separate top-level `pending`
+view and are recovered at the start of a generation cycle. `retry TAXON_ID`
+archives an incomplete or terminal candidate before making it eligible again.
 
 ## Run a combined cycle
 
@@ -300,12 +309,17 @@ inky-bird-frame catalog sync --source-catalog /path/to/source \
   --catalog /path/to/destination
 ```
 
-The command is add-only. It validates both catalogs, refuses a destination
-taxon that conflicts with its immutable source version, and reports published
-and already-present taxa. Pass `--state-dir` with the controller state
-directory when the destination is a live controller catalog, so the copy holds
-the same lock as generation. The Docker bootstrap service uses this command to
-copy the image's bundled catalog into persistent storage; see the
+The command is add-only by default. It validates both catalogs, refuses a
+destination taxon that conflicts with its immutable source version, and reports
+published and already-present taxa. Controller bootstrap adds
+`--apply-reviewed-migrations`. That option accepts only hash-bound migration
+ancestry: it applies a newer reviewed source, permits skipped intermediate
+releases, and reports a validated newer destination under `retained_newer`
+without downgrading it. An unrelated, incomplete, or tampered history still
+fails closed. Pass `--state-dir` with the controller state directory when the
+destination is live so the copy holds the same lock as generation. The Docker
+bootstrap service uses this mode to copy the image's bundled catalog into
+persistent storage; see the
 [Docker controller guide](docker.md#what-runs).
 
 ## Catalog publication

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -267,6 +267,12 @@ weight of one instead of fabricated evidence.
 - `failed`: retained failed-artifact paths, which are not necessarily current
   work.
 
+The compatibility `deferred` list and nested generation view use the same
+captured retry records, while `failed` comes from the same locked local-state
+snapshot. The top-level list intentionally includes every retained retry record;
+the nested `generation.deferred` list remains the authoritative set currently
+waiting for its retry time.
+
 Use the nested `generation` object as the authoritative work view. It combines
 the current discovery snapshot with durable queue-only retries using the same
 calculation as generation. `eligible` contains every unapproved, nonterminal

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -311,12 +311,15 @@ inky-bird-frame catalog sync --source-catalog /path/to/source \
 
 The command is add-only by default. It validates both catalogs, refuses a
 destination taxon that conflicts with its immutable source version, and reports
-published and already-present taxa. Controller bootstrap adds
-`--apply-reviewed-migrations`. That option accepts only hash-bound migration
-ancestry: it applies a newer reviewed source, permits skipped intermediate
-releases, and reports a validated newer destination under `retained_newer`
-without downgrading it. An unrelated, incomplete, or tampered history still
-fails closed. Pass `--state-dir` with the controller state directory when the
+published and already-present taxa. Controller bootstrap enables reviewed
+migrations with `INKY_CATALOG_SYNC_APPLY_REVIEWED_MIGRATIONS=1` instead of a
+version-specific command argument, so the current Compose file remains usable
+with older rollback images. The equivalent manual option,
+`--apply-reviewed-migrations`, accepts only hash-bound migration ancestry: it
+applies a newer reviewed source, permits skipped intermediate releases, and
+reports a validated newer destination under `retained_newer` without
+downgrading it. An unrelated, incomplete, or tampered history still fails
+closed. Pass `--state-dir` with the controller state directory when the
 destination is live so the copy holds the same lock as generation. The Docker
 bootstrap service uses this mode to copy the image's bundled catalog into
 persistent storage; see the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -117,12 +117,13 @@ by `species_limit` and BirdWeather's 100-species maximum. Species are also
 deduplicated against the other discovery providers. Repeated detections update
 one species record; they do not create more plates. If a detected species is
 absent from `approved`, it still needs a plate before it can appear. Check
-`pending`, `deferred`, `terminal_blocked`, and `failed` before forcing a run. A
-plate you previously rejected or an interrupted pending directory without a
-manifest is also terminal; for a live-only detection, either state may be
-absent from those lists. Inspect the taxon and run `retry TAXON_ID` to make it
-eligible again. When no deferred or terminal state exists, let the scheduled
-generator run or invoke
+the nested `generation` object before forcing a run. It includes live-only and
+durably queued detections. `generation.complete = false` means a missing or stale
+refresh prevents immediate action even when `eligible` is nonempty. A plate you
+previously rejected or an interrupted pending directory without a manifest
+appears in `generation.terminal_blocked`; inspect the taxon and run
+`retry TAXON_ID` to make it eligible again. When `generation.actionable` is
+nonempty, let the scheduled generator run or invoke
 `inky-bird-frame generate --config /path/to/config.toml` for an immediate
 attempt.
 

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -405,18 +405,20 @@ def collection_remove_command(args: argparse.Namespace) -> int:
 
 def approve_command(args: argparse.Namespace) -> int:
     config = _config(args)
-    entry = approve_candidate(
-        config.controller.state_dir,
-        config.controller.catalog_dir,
-        args.taxon_id,
-    )
+    with catalog_state_lock(config.controller.state_dir):
+        entry = approve_candidate(
+            config.controller.state_dir,
+            config.controller.catalog_dir,
+            args.taxon_id,
+        )
     print_result(entry.as_dict())
     return 0
 
 
 def reject_command(args: argparse.Namespace) -> int:
     config = _config(args)
-    destination = reject_candidate(config.controller.state_dir, args.taxon_id, args.reason)
+    with catalog_state_lock(config.controller.state_dir):
+        destination = reject_candidate(config.controller.state_dir, args.taxon_id, args.reason)
     print_result({"taxon_id": args.taxon_id, "status": "rejected", "path": str(destination)})
     return 0
 
@@ -1006,9 +1008,11 @@ def retry_command(args: argparse.Namespace) -> int:
                 identity[1],
                 identity[2],
             )
-        for source, destination in terminal_moves:
-            shutil.move(str(source), destination)
-            moved.append(str(destination))
+        if terminal_moves:
+            with catalog_state_lock(config.controller.state_dir):
+                for source, destination in terminal_moves:
+                    shutil.move(str(source), destination)
+                    moved.append(str(destination))
         retry_store.clear(args.taxon_id)
         queued_for_generation = any(
             species.taxon_id == args.taxon_id for species in read_generation_queue(config)
@@ -1047,7 +1051,8 @@ def status_command(args: argparse.Namespace) -> int:
         entries = validate_public_catalog(config.controller.catalog_dir)
         approved = {entry.taxon_id for entry in entries}
         queue = read_generation_queue_partition(config, approved=approved)
-        generation = read_generation_work(config, approved=approved)
+        retries = RetryStore(config.controller.state_dir / "generation-retries.json").records()
+        generation = read_generation_work(config, approved=approved, retry_records=retries)
         collection = collection_status(config, approved=entries)
         pending = []
         for path in sorted((config.controller.state_dir / "pending").glob("*/manifest.json")):
@@ -1061,7 +1066,7 @@ def status_command(args: argparse.Namespace) -> int:
                         "path": str(path.parent),
                     }
                 )
-    retries = RetryStore(config.controller.state_dir / "generation-retries.json")
+        failed = [str(path) for path in sorted((config.controller.state_dir / "failed").glob("*"))]
     print_result(
         {
             "approved": [entry.as_dict() for entry in entries],
@@ -1069,10 +1074,8 @@ def status_command(args: argparse.Namespace) -> int:
             "pending": pending,
             "queued": [species_to_dict(item) for item in queue.actionable],
             "terminal_blocked": [entry.as_dict() for entry in queue.terminal_blocked],
-            "deferred": [record.as_dict() for record in retries.records()],
-            "failed": [
-                str(path) for path in sorted((config.controller.state_dir / "failed").glob("*"))
-            ],
+            "deferred": [record.as_dict() for record in retries],
+            "failed": failed,
             "generation": generation.as_dict(),
         }
     )

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -1043,7 +1043,8 @@ def retry_command(args: argparse.Namespace) -> int:
 
 def status_command(args: argparse.Namespace) -> int:
     config = _config(args)
-    entries = validate_public_catalog(config.controller.catalog_dir)
+    with catalog_state_lock(config.controller.state_dir):
+        entries = validate_public_catalog(config.controller.catalog_dir)
     queue = read_generation_queue_partition(config, approved={entry.taxon_id for entry in entries})
     generation = read_generation_work(
         config,

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -29,7 +29,6 @@ from .catalog import (
     find_taxon_directory,
     has_valid_approved_candidate,
     read_json,
-    rebuild_catalog_index,
     reject_candidate,
     sha256_file,
 )
@@ -54,6 +53,7 @@ from .controller import (
     import_approved_collection,
     read_generation_queue,
     read_generation_queue_partition,
+    read_generation_work,
     remove_collection_member,
     retry_approved_candidate,
     run_controller_cycle,
@@ -88,6 +88,8 @@ from .publisher import (
 from .retry import RetryStore, parse_retry_profile_conflicts
 from .scheduler import ScheduledJob, SubprocessCommandRunner, run_scheduler
 from .server import serve_catalog
+
+CATALOG_SYNC_REVIEWED_MIGRATIONS_ENV = "INKY_CATALOG_SYNC_APPLY_REVIEWED_MIGRATIONS"
 
 
 def print_result(data: object) -> None:
@@ -1041,8 +1043,12 @@ def retry_command(args: argparse.Namespace) -> int:
 
 def status_command(args: argparse.Namespace) -> int:
     config = _config(args)
-    entries = rebuild_catalog_index(config.controller.catalog_dir)
+    entries = validate_public_catalog(config.controller.catalog_dir)
     queue = read_generation_queue_partition(config, approved={entry.taxon_id for entry in entries})
+    generation = read_generation_work(
+        config,
+        approved={entry.taxon_id for entry in entries},
+    )
     collection = collection_status(config, approved=entries)
     retries = RetryStore(config.controller.state_dir / "generation-retries.json")
     pending = []
@@ -1068,6 +1074,7 @@ def status_command(args: argparse.Namespace) -> int:
             "failed": [
                 str(path) for path in sorted((config.controller.state_dir / "failed").glob("*"))
             ],
+            "generation": generation.as_dict(),
         }
     )
     return 0
@@ -1145,11 +1152,14 @@ def catalog_prepare_command(args: argparse.Namespace) -> int:
 
 def catalog_sync_command(args: argparse.Namespace) -> int:
     lock = catalog_state_lock(args.state_dir) if args.state_dir is not None else nullcontext()
+    apply_reviewed_migrations = args.apply_reviewed_migrations or (
+        os.environ.get(CATALOG_SYNC_REVIEWED_MIGRATIONS_ENV) == "1"
+    )
     with lock:
         result = sync_public_catalog(
             args.source_catalog,
             args.catalog,
-            allow_replacements=False,
+            allow_replacements=apply_reviewed_migrations,
         )
     print_result(
         {
@@ -1738,6 +1748,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--state-dir",
         type=Path,
         help="Optional controller state directory used to lock catalog writes",
+    )
+    catalog_sync_parser.add_argument(
+        "--apply-reviewed-migrations",
+        action="store_true",
+        help=(
+            "Apply only hash-bound reviewed replacements from the source and retain a "
+            "validated newer destination"
+        ),
     )
     catalog_sync_parser.set_defaults(func=catalog_sync_command)
     catalog_validate_parser = catalog_subparsers.add_parser(

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -1049,19 +1049,19 @@ def status_command(args: argparse.Namespace) -> int:
         queue = read_generation_queue_partition(config, approved=approved)
         generation = read_generation_work(config, approved=approved)
         collection = collection_status(config, approved=entries)
+        pending = []
+        for path in sorted((config.controller.state_dir / "pending").glob("*/manifest.json")):
+            manifest = read_json(path)
+            if isinstance(manifest, dict):
+                pending.append(
+                    {
+                        "taxon_id": manifest.get("taxon_id"),
+                        "common_name": manifest.get("common_name"),
+                        "quality_review": manifest.get("quality_review"),
+                        "path": str(path.parent),
+                    }
+                )
     retries = RetryStore(config.controller.state_dir / "generation-retries.json")
-    pending = []
-    for path in sorted((config.controller.state_dir / "pending").glob("*/manifest.json")):
-        manifest = read_json(path)
-        if isinstance(manifest, dict):
-            pending.append(
-                {
-                    "taxon_id": manifest.get("taxon_id"),
-                    "common_name": manifest.get("common_name"),
-                    "quality_review": manifest.get("quality_review"),
-                    "path": str(path.parent),
-                }
-            )
     print_result(
         {
             "approved": [entry.as_dict() for entry in entries],

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -1045,12 +1045,10 @@ def status_command(args: argparse.Namespace) -> int:
     config = _config(args)
     with catalog_state_lock(config.controller.state_dir):
         entries = validate_public_catalog(config.controller.catalog_dir)
-    queue = read_generation_queue_partition(config, approved={entry.taxon_id for entry in entries})
-    generation = read_generation_work(
-        config,
-        approved={entry.taxon_id for entry in entries},
-    )
-    collection = collection_status(config, approved=entries)
+        approved = {entry.taxon_id for entry in entries}
+        queue = read_generation_queue_partition(config, approved=approved)
+        generation = read_generation_work(config, approved=approved)
+        collection = collection_status(config, approved=entries)
     retries = RetryStore(config.controller.state_dir / "generation-retries.json")
     pending = []
     for path in sorted((config.controller.state_dir / "pending").glob("*/manifest.json")):

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -1968,11 +1968,16 @@ def generate_candidate(
                     max_attempts=config.controller.max_generation_attempts,
                     correction_source_sha256=correction_source_sha256,
                 )
-                destination = candidate_directory(state_dir, species)
-                destination.parent.mkdir(parents=True, exist_ok=True)
-                if destination.exists():
-                    raise CatalogError(f"Pending destination already exists: {destination}")
-                shutil.copytree(attempt_dir, destination)
+                with catalog_state_lock(state_dir):
+                    if species.taxon_id in approved_taxon_ids(config.controller.catalog_dir):
+                        raise CatalogError(f"Taxon {species.taxon_id} is already approved")
+                    if find_taxon_directory(state_dir / "pending", species.taxon_id) is not None:
+                        raise CatalogError(
+                            f"Taxon {species.taxon_id} already has a pending candidate"
+                        )
+                    destination = candidate_directory(state_dir, species)
+                    destination.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copytree(attempt_dir, destination)
                 return destination
 
             resolved_corrections = tuple(
@@ -2038,9 +2043,10 @@ def generate_candidate(
             ) or (REVIEW_FAILURE_FALLBACK,)
             correction_source = portrait_path
 
-        failed = state_dir / "failed" / f"{species.taxon_id}-{_timestamp()}"
-        failed.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(work, failed)
+        with catalog_state_lock(state_dir):
+            failed = state_dir / "failed" / f"{species.taxon_id}-{_timestamp()}"
+            failed.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(work, failed)
         reason = terminal_detail or (
             "the configured maximum of "
             f"{config.controller.max_generation_attempts} attempts was exhausted"
@@ -2204,11 +2210,16 @@ def read_generation_work(
     *,
     approved: set[int] | None = None,
     now: datetime | None = None,
+    retry_records: list[RetryRecord] | None = None,
 ) -> GenerationWork:
     """Read local state and return the same generation classification used by a cycle."""
     snapshot = _read_discovery_snapshot(config) if _snapshot_path(config).exists() else None
     queued_species = read_generation_queue(config)
-    retry_records = RetryStore(config.controller.state_dir / "generation-retries.json").records()
+    retained_retries = (
+        retry_records
+        if retry_records is not None
+        else RetryStore(config.controller.state_dir / "generation-retries.json").records()
+    )
     return calculate_generation_work(
         snapshot=snapshot,
         queued_species=queued_species,
@@ -2220,7 +2231,7 @@ def read_generation_work(
             snapshot.species if snapshot is not None else [],
             queued_species,
         ),
-        retry_records=retry_records,
+        retry_records=retained_retries,
         now=now or datetime.now(UTC),
         maximum_age=timedelta(minutes=config.schedule.refresh_minutes * 2),
     )
@@ -2455,24 +2466,25 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                     }
                 )
             except QualityReviewError as exc:
-                retry_store.clear(species.taxon_id)
-                remaining_profile_conflicts = (
-                    guidance.profile_conflicts
-                    if guidance is not None and exc.profile_conflicts is None
-                    else exc.profile_conflicts or ()
-                )
-                if guidance is not None and (
-                    guidance.invariant_findings or remaining_profile_conflicts
-                ):
-                    retry_store.set_quality_guidance(
-                        species.taxon_id,
-                        guidance.invariant_findings,
-                        invariant_findings=guidance.invariant_findings,
-                        profile_conflicts=remaining_profile_conflicts,
+                with catalog_state_lock(config.controller.state_dir):
+                    retry_store.clear(species.taxon_id)
+                    remaining_profile_conflicts = (
+                        guidance.profile_conflicts
+                        if guidance is not None and exc.profile_conflicts is None
+                        else exc.profile_conflicts or ()
                     )
-                else:
-                    retry_store.clear_quality_guidance(species.taxon_id)
-                failure_path = record_failure(config.controller.state_dir, species, exc)
+                    if guidance is not None and (
+                        guidance.invariant_findings or remaining_profile_conflicts
+                    ):
+                        retry_store.set_quality_guidance(
+                            species.taxon_id,
+                            guidance.invariant_findings,
+                            invariant_findings=guidance.invariant_findings,
+                            profile_conflicts=remaining_profile_conflicts,
+                        )
+                    else:
+                        retry_store.clear_quality_guidance(species.taxon_id)
+                    failure_path = record_failure(config.controller.state_dir, species, exc)
                 failures.append(
                     {
                         "taxon_id": species.taxon_id,
@@ -2485,8 +2497,9 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
             except MissingDependencyError:
                 raise
             except SpeciesStateError as exc:
-                retry_store.clear(species.taxon_id)
-                failure_path = record_failure(config.controller.state_dir, species, exc)
+                with catalog_state_lock(config.controller.state_dir):
+                    retry_store.clear(species.taxon_id)
+                    failure_path = record_failure(config.controller.state_dir, species, exc)
                 failures.append(
                     {
                         "taxon_id": species.taxon_id,

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -88,7 +88,7 @@ from .models import ProfileConflict, ReferencePhoto, SpeciesProfileData
 from .prompts import PROMPT_VERSION
 from .references import download_references, fetch_reference_candidates
 from .research import ResearchBudget
-from .retry import RetryStore, parse_retry_profile_conflicts
+from .retry import RetryRecord, RetryStore, parse_retry_profile_conflicts
 from .timeutil import parse_utc_timestamp
 
 REVIEW_FAILURE_FALLBACK = "The previous attempt did not meet every automated review threshold."
@@ -164,6 +164,34 @@ class TerminalQueueEntry:
 class GenerationQueuePartition:
     actionable: list[BirdSpecies]
     terminal_blocked: list[TerminalQueueEntry]
+
+
+@dataclass(frozen=True)
+class GenerationWork:
+    complete: bool
+    discovery_status: str
+    discovery_refreshed_at: datetime | None
+    eligible: list[BirdSpecies]
+    actionable: list[BirdSpecies]
+    deferred: list[RetryRecord]
+    terminal_blocked: list[TerminalQueueEntry]
+
+    def as_dict(self) -> dict[str, object]:
+        discovery: dict[str, object] = {"status": self.discovery_status}
+        if self.discovery_refreshed_at is not None:
+            discovery["refreshed_at"] = self.discovery_refreshed_at.isoformat()
+        return {
+            "complete": self.complete,
+            "discovery": discovery,
+            "eligible_count": len(self.eligible),
+            "eligible": [_species_payload(species) for species in self.eligible],
+            "actionable_count": len(self.actionable),
+            "actionable": [_species_payload(species) for species in self.actionable],
+            "deferred_count": len(self.deferred),
+            "deferred": [record.as_dict() for record in self.deferred],
+            "terminal_blocked_count": len(self.terminal_blocked),
+            "terminal_blocked": [entry.as_dict() for entry in self.terminal_blocked],
+        }
 
 
 @contextmanager
@@ -2073,6 +2101,131 @@ def _partition_generation_queue(
     return GenerationQueuePartition(actionable, terminal_blocked)
 
 
+def calculate_generation_work(
+    *,
+    snapshot: DiscoverySnapshot | None,
+    queued_species: list[BirdSpecies],
+    approved: set[int],
+    terminal_states: dict[int, tuple[str, tuple[Path, ...]]],
+    retry_records: list[RetryRecord],
+    now: datetime,
+    maximum_age: timedelta,
+) -> GenerationWork:
+    """Classify generation work from an explicit, side-effect-free state snapshot."""
+    if snapshot is None:
+        discovery_status = "missing"
+        complete = False
+        observed_species: list[BirdSpecies] = []
+        refreshed_at = None
+    else:
+        refreshed_at = snapshot.refreshed_at.astimezone(UTC)
+        complete = now.astimezone(UTC) - refreshed_at <= maximum_age
+        discovery_status = "fresh" if complete else "stale"
+        observed_species = snapshot.species
+
+    retry_by_taxon = {record.taxon_id: record for record in retry_records}
+    generation_species = list(observed_species)
+    observed_taxa = {species.taxon_id for species in observed_species}
+    for queued in queued_species:
+        if queued.taxon_id in observed_taxa:
+            continue
+        retry = retry_by_taxon.get(queued.taxon_id)
+        if (
+            HUMAN_REVIEW_SOURCE not in queued.sources
+            and retry is not None
+            and retry.common_name is not None
+            and retry.scientific_name is not None
+        ):
+            queued = BirdSpecies(
+                taxon_id=queued.taxon_id,
+                common_name=retry.common_name,
+                scientific_name=retry.scientific_name,
+                observation_count=queued.observation_count,
+                source=queued.source,
+                sources=queued.sources,
+                latest_detection_at=queued.latest_detection_at,
+            )
+        generation_species.append(queued)
+
+    eligible: list[BirdSpecies] = []
+    terminal_blocked: list[TerminalQueueEntry] = []
+    for species in generation_species:
+        if species.taxon_id in approved:
+            continue
+        terminal = terminal_states.get(species.taxon_id)
+        if terminal is None:
+            eligible.append(species)
+            continue
+        state, paths = terminal
+        if state != "pending":
+            terminal_blocked.append(TerminalQueueEntry(species, state, paths))
+
+    eligible_taxa = {species.taxon_id for species in eligible}
+    deferred = sorted(
+        (
+            record
+            for record in retry_records
+            if record.taxon_id in eligible_taxa and record.next_attempt_at > now
+        ),
+        key=lambda record: record.next_attempt_at,
+    )
+    deferred_taxa = {record.taxon_id for record in deferred}
+    actionable = (
+        [species for species in eligible if species.taxon_id not in deferred_taxa]
+        if complete
+        else []
+    )
+    return GenerationWork(
+        complete,
+        discovery_status,
+        refreshed_at,
+        eligible,
+        actionable,
+        deferred,
+        terminal_blocked,
+    )
+
+
+def _generation_terminal_states(
+    state_dir: Path,
+    observed_species: list[BirdSpecies],
+    queued_species: list[BirdSpecies],
+) -> dict[int, tuple[str, tuple[Path, ...]]]:
+    taxon_ids = {species.taxon_id for species in (*observed_species, *queued_species)}
+    return {
+        taxon_id: terminal
+        for taxon_id in taxon_ids
+        if (terminal := _terminal_state(state_dir, taxon_id)) is not None
+    }
+
+
+def read_generation_work(
+    config: AppConfig,
+    *,
+    approved: set[int] | None = None,
+    now: datetime | None = None,
+) -> GenerationWork:
+    """Read local state and return the same generation classification used by a cycle."""
+    snapshot = _read_discovery_snapshot(config) if _snapshot_path(config).exists() else None
+    queued_species = read_generation_queue(config)
+    retry_records = RetryStore(config.controller.state_dir / "generation-retries.json").records()
+    return calculate_generation_work(
+        snapshot=snapshot,
+        queued_species=queued_species,
+        approved=(
+            approved if approved is not None else approved_taxon_ids(config.controller.catalog_dir)
+        ),
+        terminal_states=_generation_terminal_states(
+            config.controller.state_dir,
+            snapshot.species if snapshot is not None else [],
+            queued_species,
+        ),
+        retry_records=retry_records,
+        now=now or datetime.now(UTC),
+        maximum_age=timedelta(minutes=config.schedule.refresh_minutes * 2),
+    )
+
+
 def read_generation_queue_partition(
     config: AppConfig, *, approved: set[int] | None = None
 ) -> GenerationQueuePartition:
@@ -2146,28 +2299,40 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                 )
             published = approve_passing_candidates(config)
         snapshot = _read_discovery_snapshot(config)
-        maximum_age = timedelta(minutes=config.schedule.refresh_minutes * 2)
-        if datetime.now(UTC) - snapshot.refreshed_at.astimezone(UTC) > maximum_age:
+        species_list = snapshot.species
+        retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
+        work = calculate_generation_work(
+            snapshot=snapshot,
+            queued_species=queued_species,
+            approved=approved_taxon_ids(config.controller.catalog_dir),
+            terminal_states=_generation_terminal_states(
+                config.controller.state_dir,
+                species_list,
+                queued_species,
+            ),
+            retry_records=retry_store.records(),
+            now=datetime.now(UTC),
+            maximum_age=timedelta(minutes=config.schedule.refresh_minutes * 2),
+        )
+        if not work.complete:
             raise DataSourceError(
                 "Discovery state is stale; a successful refresh is required before generation"
             )
-        species_list = snapshot.species
         for species in species_list:
             synchronize_generation_retry_identity(config, queued_species, species)
-        generation_species = list(species_list)
         observed_taxa = {species.taxon_id for species in species_list}
-        retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
         for queued in queued_species:
             if queued.taxon_id in observed_taxa:
                 continue
             retry = retry_store.get(queued.taxon_id)
+            synchronized = queued
             if (
                 HUMAN_REVIEW_SOURCE not in queued.sources
                 and retry is not None
                 and retry.common_name is not None
                 and retry.scientific_name is not None
             ):
-                queued = BirdSpecies(
+                synchronized = BirdSpecies(
                     taxon_id=queued.taxon_id,
                     common_name=retry.common_name,
                     scientific_name=retry.scientific_name,
@@ -2176,16 +2341,9 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                     sources=queued.sources,
                     latest_detection_at=queued.latest_detection_at,
                 )
-            synchronize_generation_retry_identity(config, queued_species, queued)
-            generation_species.append(queued)
+            synchronize_generation_retry_identity(config, queued_species, synchronized)
         retry_store = RetryStore(config.controller.state_dir / "generation-retries.json")
-        approved = approved_taxon_ids(config.controller.catalog_dir)
-        eligible = [
-            species
-            for species in generation_species
-            if species.taxon_id not in approved
-            and not _has_terminal_state(config.controller.state_dir, species.taxon_id)
-        ]
+        eligible = work.eligible
         generated: list[dict[str, object]] = []
         failures: list[dict[str, object]] = []
         attempted_count = 0

--- a/src/inky_bird_frame/publisher.py
+++ b/src/inky_bird_frame/publisher.py
@@ -458,7 +458,7 @@ def _validate_catalog_replacement(
         (index for index, record in enumerate(records) if record[1:] == base_approval),
         None,
     )
-    if matching_index is None or (not allow_ancestor and matching_index != len(records) - 1):
+    if matching_index != len(base_records):
         raise CatalogPublishError("Catalog migration does not match the approved base artifacts")
     candidate_approved_at = parse_utc_timestamp(candidate.get("approved_at"))
     replaced_approved_at = parse_utc_timestamp(records[matching_index][1])
@@ -516,6 +516,30 @@ def _validate_catalog_migration_convergence(
         raise CatalogPublishError(
             f"Catalog taxon {destination.get('taxon_id')} conflicts with immutable local approval"
         )
+
+
+def _catalog_sync_should_replace(destination: Path, source: Path) -> bool:
+    """Validate migration ancestry and return whether source is newer."""
+    if _trees_match_without_catalog_migration(destination, source):
+        try:
+            _validate_catalog_migration_convergence(destination, source)
+        except CatalogPublishError as forward_error:
+            try:
+                _validate_catalog_migration_convergence(source, destination)
+            except CatalogPublishError as reverse_error:
+                raise forward_error from reverse_error
+            return False
+        return True
+
+    try:
+        _validate_catalog_replacement(destination, source, allow_ancestor=True)
+    except CatalogPublishError as forward_error:
+        try:
+            _validate_catalog_replacement(source, destination, allow_ancestor=True)
+        except CatalogPublishError as reverse_error:
+            raise forward_error from reverse_error
+        return False
+    return True
 
 
 def validate_catalog_additions(
@@ -757,6 +781,7 @@ def sync_public_catalog(
 
     published: list[dict[str, object]] = []
     replaced: list[dict[str, object]] = []
+    retained_newer: list[dict[str, object]] = []
     existing: list[int] = []
 
     transaction = _new_catalog_transaction(destination_catalog)
@@ -779,14 +804,16 @@ def sync_public_catalog(
                         raise CatalogPublishError(
                             f"Catalog taxon {taxon_id} conflicts with immutable local approval"
                         )
-                    if _trees_match_without_catalog_migration(destination, source):
-                        _validate_catalog_migration_convergence(destination, source)
-                    else:
-                        _validate_catalog_replacement(
-                            destination,
-                            source,
-                            allow_ancestor=True,
+                    if not _catalog_sync_should_replace(destination, source):
+                        retained_newer.append(
+                            {
+                                "taxon_id": entry.taxon_id,
+                                "common_name": entry.common_name,
+                                "scientific_name": entry.scientific_name,
+                                "slug": entry.slug,
+                            }
                         )
+                        continue
                     staged = transaction / "replacement" / source.name
                     backup = transaction / "approved" / destination.name
                     backup.parent.mkdir(exist_ok=True)
@@ -826,7 +853,12 @@ def sync_public_catalog(
         transaction.mkdir(exist_ok=True)
         raise
     _commit_catalog_transaction(transaction, destination_catalog)
-    return {"published": published, "replaced": replaced, "already_present": existing}
+    return {
+        "published": published,
+        "replaced": replaced,
+        "retained_newer": retained_newer,
+        "already_present": existing,
+    }
 
 
 def _redact_command_output(value: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 import inky_bird_frame
 from inky_bird_frame.birdnet_analyzer import BirdNetAnalyzerImportStats
 from inky_bird_frame.birds import BirdSpecies, DateRange
-from inky_bird_frame.catalog import sha256_file
+from inky_bird_frame.catalog import rebuild_catalog_index, sha256_file
 from inky_bird_frame.cli import (
     _confirm_birdbuddy_authorization,
     birdbuddy_login_command,
@@ -50,6 +50,7 @@ from inky_bird_frame.controller import (
 )
 from inky_bird_frame.ebird_archive import EbirdArchiveHistory, EbirdArchiveImportStats
 from inky_bird_frame.errors import (
+    CatalogPublishError,
     ConfigurationError,
     DataSourceError,
     GenerationError,
@@ -449,12 +450,29 @@ class CliTests(unittest.TestCase):
         self.assertEqual(str(args.source_catalog), "bundled-catalog")
         self.assertEqual(str(args.catalog), "managed-catalog")
         self.assertEqual(str(args.state_dir), "controller-state")
+        self.assertFalse(args.apply_reviewed_migrations)
+
+    def test_catalog_sync_parses_reviewed_migration_opt_in(self) -> None:
+        args = build_parser().parse_args(
+            [
+                "catalog",
+                "sync",
+                "--source-catalog",
+                "bundled-catalog",
+                "--catalog",
+                "managed-catalog",
+                "--apply-reviewed-migrations",
+            ]
+        )
+
+        self.assertTrue(args.apply_reviewed_migrations)
 
     def test_catalog_sync_uses_controller_catalog_lock(self) -> None:
         args = Namespace(
             source_catalog=Path("bundled-catalog"),
             catalog=Path("managed-catalog"),
             state_dir=Path("controller-state"),
+            apply_reviewed_migrations=True,
         )
         with (
             patch("inky_bird_frame.cli.catalog_state_lock") as catalog_lock,
@@ -470,7 +488,65 @@ class CliTests(unittest.TestCase):
         sync.assert_called_once_with(
             Path("bundled-catalog"),
             Path("managed-catalog"),
+            allow_replacements=True,
+        )
+
+    def test_catalog_sync_remains_add_only_without_reviewed_migration_opt_in(self) -> None:
+        args = build_parser().parse_args(
+            [
+                "catalog",
+                "sync",
+                "--source-catalog",
+                "bundled-catalog",
+                "--catalog",
+                "managed-catalog",
+            ]
+        )
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "inky_bird_frame.cli.sync_public_catalog",
+                return_value={"published": [], "already_present": []},
+            ) as sync,
+            redirect_stdout(io.StringIO()),
+        ):
+            catalog_sync_command(args)
+
+        sync.assert_called_once_with(
+            Path("bundled-catalog"),
+            Path("managed-catalog"),
             allow_replacements=False,
+        )
+
+    def test_catalog_sync_accepts_compose_environment_opt_in(self) -> None:
+        args = build_parser().parse_args(
+            [
+                "catalog",
+                "sync",
+                "--source-catalog",
+                "bundled-catalog",
+                "--catalog",
+                "managed-catalog",
+            ]
+        )
+        with (
+            patch.dict(
+                "os.environ",
+                {"INKY_CATALOG_SYNC_APPLY_REVIEWED_MIGRATIONS": "1"},
+                clear=True,
+            ),
+            patch(
+                "inky_bird_frame.cli.sync_public_catalog",
+                return_value={"published": [], "already_present": []},
+            ) as sync,
+            redirect_stdout(io.StringIO()),
+        ):
+            catalog_sync_command(args)
+
+        sync.assert_called_once_with(
+            Path("bundled-catalog"),
+            Path("managed-catalog"),
+            allow_replacements=True,
         )
 
     def test_scheduler_requires_explicit_config(self) -> None:
@@ -555,6 +631,18 @@ class CliTests(unittest.TestCase):
             actionable=[actionable],
             terminal_blocked=[SimpleNamespace(as_dict=lambda: blocked)],
         )
+        generation_payload = {
+            "complete": False,
+            "discovery": {"status": "missing"},
+            "eligible_count": 0,
+            "eligible": [],
+            "actionable_count": 0,
+            "actionable": [],
+            "deferred_count": 0,
+            "deferred": [],
+            "terminal_blocked_count": 0,
+            "terminal_blocked": [],
+        }
         with TemporaryDirectory() as temporary:
             state = Path(temporary)
             config = SimpleNamespace(
@@ -563,8 +651,12 @@ class CliTests(unittest.TestCase):
             output = io.StringIO()
             with (
                 patch("inky_bird_frame.cli._config", return_value=config),
-                patch("inky_bird_frame.cli.rebuild_catalog_index", return_value=[]),
+                patch("inky_bird_frame.cli.validate_public_catalog", return_value=[]),
                 patch("inky_bird_frame.cli.read_generation_queue_partition", return_value=queue),
+                patch(
+                    "inky_bird_frame.cli.read_generation_work",
+                    return_value=SimpleNamespace(as_dict=lambda: generation_payload),
+                ),
                 patch(
                     "inky_bird_frame.cli.collection_status",
                     return_value={"collection_count": 0, "members": []},
@@ -577,6 +669,62 @@ class CliTests(unittest.TestCase):
         self.assertEqual([entry["taxon_id"] for entry in payload["queued"]], [1])
         self.assertEqual(payload["terminal_blocked"], [blocked])
         self.assertEqual(payload["collection"], {"collection_count": 0})
+        self.assertEqual(payload["generation"], generation_payload)
+
+    def test_status_validates_without_rewriting_catalog_or_state(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            catalog = root / "catalog"
+            state = root / "state"
+            source_species = (
+                Path(__file__).resolve().parents[1] / "catalog/species/9083-northern-cardinal"
+            )
+            shutil.copytree(source_species, catalog / "species/9083-northern-cardinal")
+            rebuild_catalog_index(catalog)
+            index = catalog / "index.json"
+            index_before = index.read_bytes()
+            modified_before = index.stat().st_mtime_ns
+            config = SimpleNamespace(
+                controller=SimpleNamespace(catalog_dir=catalog, state_dir=state),
+                schedule=SimpleNamespace(refresh_minutes=15),
+            )
+            output = io.StringIO()
+
+            with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
+                status_command(Namespace())
+
+            state_entries = list(state.rglob("*"))
+            payload = json.loads(output.getvalue())["data"]
+            self.assertFalse(payload["generation"]["complete"])
+            self.assertEqual(payload["generation"]["discovery"], {"status": "missing"})
+            self.assertEqual(index.read_bytes(), index_before)
+            self.assertEqual(index.stat().st_mtime_ns, modified_before)
+            self.assertEqual(state_entries, [])
+
+    def test_status_fails_closed_without_repairing_an_invalid_catalog(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            catalog = root / "catalog"
+            state = root / "state"
+            (catalog / "species").mkdir(parents=True)
+            index = catalog / "index.json"
+            index.write_text("{}")
+            index_before = index.read_bytes()
+            modified_before = index.stat().st_mtime_ns
+            config = SimpleNamespace(
+                controller=SimpleNamespace(catalog_dir=catalog, state_dir=state),
+                schedule=SimpleNamespace(refresh_minutes=15),
+            )
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                self.assertRaisesRegex(CatalogPublishError, "index does not match"),
+            ):
+                status_command(Namespace())
+
+            self.assertEqual(index.read_bytes(), index_before)
+            self.assertEqual(index.stat().st_mtime_ns, modified_before)
+            self.assertFalse(state.exists())
 
     def test_seed_supports_historical_dates_and_coordinates(self) -> None:
         args = build_parser().parse_args(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,8 @@ import shutil
 import stat
 import unittest
 from argparse import Namespace
-from contextlib import redirect_stdout
+from collections.abc import Iterator
+from contextlib import contextmanager, redirect_stdout
 from datetime import UTC, date, datetime
 from importlib.metadata import version
 from pathlib import Path
@@ -671,7 +672,7 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["collection"], {"collection_count": 0})
         self.assertEqual(payload["generation"], generation_payload)
 
-    def test_status_validates_without_rewriting_catalog_or_state(self) -> None:
+    def test_status_validates_without_rewriting_catalog_data(self) -> None:
         with TemporaryDirectory() as temporary:
             root = Path(temporary)
             catalog = root / "catalog"
@@ -699,7 +700,7 @@ class CliTests(unittest.TestCase):
             self.assertEqual(payload["generation"]["discovery"], {"status": "missing"})
             self.assertEqual(index.read_bytes(), index_before)
             self.assertEqual(index.stat().st_mtime_ns, modified_before)
-            self.assertEqual(state_entries, [])
+            self.assertEqual(state_entries, [state / "catalog-state.lock"])
 
     def test_status_fails_closed_without_repairing_an_invalid_catalog(self) -> None:
         with TemporaryDirectory() as temporary:
@@ -724,7 +725,41 @@ class CliTests(unittest.TestCase):
 
             self.assertEqual(index.read_bytes(), index_before)
             self.assertEqual(index.stat().st_mtime_ns, modified_before)
-            self.assertFalse(state.exists())
+            self.assertEqual(list(state.rglob("*")), [state / "catalog-state.lock"])
+
+    def test_status_validates_catalog_while_state_lock_is_held(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            state = root / "state"
+            config = SimpleNamespace(
+                controller=SimpleNamespace(catalog_dir=root / "catalog", state_dir=state),
+                schedule=SimpleNamespace(refresh_minutes=15),
+            )
+            lock_held = False
+
+            @contextmanager
+            def state_lock(state_dir: Path) -> Iterator[None]:
+                nonlocal lock_held
+                self.assertEqual(state_dir, state)
+                lock_held = True
+                try:
+                    yield
+                finally:
+                    lock_held = False
+
+            def validating(_catalog_dir: Path) -> list[object]:
+                self.assertTrue(lock_held)
+                return []
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                patch("inky_bird_frame.cli.catalog_state_lock", side_effect=state_lock),
+                patch("inky_bird_frame.cli.validate_public_catalog", side_effect=validating),
+                redirect_stdout(io.StringIO()),
+            ):
+                status_command(Namespace())
+
+            self.assertFalse(lock_held)
 
     def test_seed_supports_historical_dates_and_coordinates(self) -> None:
         args = build_parser().parse_args(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -791,6 +791,62 @@ class CliTests(unittest.TestCase):
 
             self.assertFalse(lock_held)
 
+    def test_status_snapshots_pending_candidates_before_releasing_state_lock(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            state = root / "state"
+            pending_dir = state / "pending/42-pending-bird"
+            pending_dir.mkdir(parents=True)
+            pending_manifest = pending_dir / "manifest.json"
+            pending_manifest.write_text(json.dumps({"taxon_id": 42, "common_name": "Pending Bird"}))
+            published_dir = state / "published/42-pending-bird"
+            config = SimpleNamespace(
+                controller=SimpleNamespace(catalog_dir=root / "catalog", state_dir=state),
+                schedule=SimpleNamespace(refresh_minutes=15),
+            )
+            output = io.StringIO()
+
+            @contextmanager
+            def state_lock(_state_dir: Path) -> Iterator[None]:
+                yield
+                published_dir.parent.mkdir(parents=True)
+                pending_dir.rename(published_dir)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                patch("inky_bird_frame.cli.catalog_state_lock", side_effect=state_lock),
+                patch("inky_bird_frame.cli.validate_public_catalog", return_value=[]),
+                patch(
+                    "inky_bird_frame.cli.read_generation_queue_partition",
+                    return_value=SimpleNamespace(actionable=[], terminal_blocked=[]),
+                ),
+                patch(
+                    "inky_bird_frame.cli.read_generation_work",
+                    return_value=SimpleNamespace(as_dict=lambda: {}),
+                ),
+                patch(
+                    "inky_bird_frame.cli.collection_status",
+                    return_value={"members": []},
+                ),
+                redirect_stdout(output),
+            ):
+                status_command(Namespace())
+
+            payload = json.loads(output.getvalue())["data"]
+            self.assertEqual(
+                payload["pending"],
+                [
+                    {
+                        "taxon_id": 42,
+                        "common_name": "Pending Bird",
+                        "quality_review": None,
+                        "path": str(pending_dir),
+                    }
+                ],
+            )
+            self.assertFalse(pending_dir.exists())
+            self.assertTrue(published_dir.exists())
+
     def test_seed_supports_historical_dates_and_coordinates(self) -> None:
         args = build_parser().parse_args(
             [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,7 @@ from inky_bird_frame.birds import BirdSpecies, DateRange
 from inky_bird_frame.catalog import rebuild_catalog_index, sha256_file
 from inky_bird_frame.cli import (
     _confirm_birdbuddy_authorization,
+    approve_command,
     birdbuddy_login_command,
     birdbuddy_logout_command,
     birdnet_analyzer_import_command,
@@ -36,6 +37,7 @@ from inky_bird_frame.cli import (
     main,
     notifications_dispatch_command,
     refresh_command,
+    reject_command,
     retry_command,
     seed_command,
     serve_command,
@@ -92,6 +94,44 @@ def write_test_species_identity(directory: Path) -> None:
 
 
 class CliTests(unittest.TestCase):
+    def test_manual_candidate_transitions_hold_catalog_lock(self) -> None:
+        config = controller_config(Path("state"), Path("catalog"))
+        lock_held = False
+        transitions: list[tuple[str, int]] = []
+
+        @contextmanager
+        def state_lock(state_dir: Path) -> Iterator[None]:
+            nonlocal lock_held
+            self.assertEqual(state_dir, Path("state"))
+            self.assertFalse(lock_held)
+            lock_held = True
+            try:
+                yield
+            finally:
+                lock_held = False
+
+        def approve(_state_dir: Path, _catalog_dir: Path, taxon_id: int) -> SimpleNamespace:
+            self.assertTrue(lock_held)
+            transitions.append(("approve", taxon_id))
+            return SimpleNamespace(as_dict=lambda: {"taxon_id": taxon_id})
+
+        def reject(_state_dir: Path, taxon_id: int, _reason: str) -> Path:
+            self.assertTrue(lock_held)
+            transitions.append(("reject", taxon_id))
+            return Path("rejected") / str(taxon_id)
+
+        with (
+            patch("inky_bird_frame.cli._config", return_value=config),
+            patch("inky_bird_frame.cli.catalog_state_lock", side_effect=state_lock),
+            patch("inky_bird_frame.cli.approve_candidate", side_effect=approve),
+            patch("inky_bird_frame.cli.reject_candidate", side_effect=reject),
+            redirect_stdout(io.StringIO()),
+        ):
+            approve_command(Namespace(taxon_id=42))
+            reject_command(Namespace(taxon_id=43, reason="Incorrect anatomy"))
+
+        self.assertEqual(transitions, [("approve", 42), ("reject", 43)])
+
     def test_ebird_archive_commands_are_private_and_parse_reduction_opt_in(self) -> None:
         args = build_parser().parse_args(
             [
@@ -736,6 +776,8 @@ class CliTests(unittest.TestCase):
                 schedule=SimpleNamespace(refresh_minutes=15),
             )
             lock_held = False
+            retained_retries = [SimpleNamespace(as_dict=lambda: {"taxon_id": 42})]
+            output = io.StringIO()
 
             @contextmanager
             def state_lock(state_dir: Path) -> Iterator[None]:
@@ -759,10 +801,14 @@ class CliTests(unittest.TestCase):
                 return SimpleNamespace(actionable=[], terminal_blocked=[])
 
             def generation_snapshot(
-                _config: object, *, approved: set[int] | None = None
+                _config: object,
+                *,
+                approved: set[int] | None = None,
+                retry_records: list[object] | None = None,
             ) -> SimpleNamespace:
                 self.assertTrue(lock_held)
                 self.assertEqual(approved, set())
+                self.assertIs(retry_records, retained_retries)
                 return SimpleNamespace(as_dict=lambda: {})
 
             def collection_snapshot(
@@ -775,6 +821,7 @@ class CliTests(unittest.TestCase):
             with (
                 patch("inky_bird_frame.cli._config", return_value=config),
                 patch("inky_bird_frame.cli.catalog_state_lock", side_effect=state_lock),
+                patch("inky_bird_frame.cli.RetryStore") as retry_store,
                 patch("inky_bird_frame.cli.validate_public_catalog", side_effect=validating),
                 patch(
                     "inky_bird_frame.cli.read_generation_queue_partition",
@@ -785,11 +832,14 @@ class CliTests(unittest.TestCase):
                     side_effect=generation_snapshot,
                 ),
                 patch("inky_bird_frame.cli.collection_status", side_effect=collection_snapshot),
-                redirect_stdout(io.StringIO()),
+                redirect_stdout(output),
             ):
+                retry_store.return_value.records.return_value = retained_retries
                 status_command(Namespace())
 
             self.assertFalse(lock_held)
+            retry_store.return_value.records.assert_called_once_with()
+            self.assertEqual(json.loads(output.getvalue())["data"]["deferred"], [{"taxon_id": 42}])
 
     def test_status_snapshots_pending_candidates_before_releasing_state_lock(self) -> None:
         with TemporaryDirectory() as temporary:
@@ -846,6 +896,71 @@ class CliTests(unittest.TestCase):
             )
             self.assertFalse(pending_dir.exists())
             self.assertTrue(published_dir.exists())
+
+    def test_status_snapshots_failed_paths_before_releasing_state_lock(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            state = root / "state"
+            failed_dir = state / "failed/42-failed-bird"
+            failed_dir.mkdir(parents=True)
+            archived_dir = state / "archive/42-failed-bird"
+            config = SimpleNamespace(
+                controller=SimpleNamespace(catalog_dir=root / "catalog", state_dir=state),
+                schedule=SimpleNamespace(refresh_minutes=15),
+            )
+            generation_payload = {
+                "terminal_blocked": [
+                    {
+                        "taxon_id": 42,
+                        "state": "failed",
+                        "paths": [str(failed_dir)],
+                    }
+                ]
+            }
+            output = io.StringIO()
+
+            @contextmanager
+            def state_lock(_state_dir: Path) -> Iterator[None]:
+                yield
+                archived_dir.parent.mkdir(parents=True)
+                failed_dir.rename(archived_dir)
+
+            def generation_snapshot(
+                _config: object,
+                *,
+                approved: set[int] | None = None,
+                retry_records: list[object] | None = None,
+            ) -> SimpleNamespace:
+                self.assertEqual(approved, set())
+                self.assertEqual(retry_records, [])
+                self.assertTrue(failed_dir.is_dir())
+                return SimpleNamespace(as_dict=lambda: generation_payload)
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                patch("inky_bird_frame.cli.catalog_state_lock", side_effect=state_lock),
+                patch("inky_bird_frame.cli.validate_public_catalog", return_value=[]),
+                patch(
+                    "inky_bird_frame.cli.read_generation_queue_partition",
+                    return_value=SimpleNamespace(actionable=[], terminal_blocked=[]),
+                ),
+                patch(
+                    "inky_bird_frame.cli.read_generation_work",
+                    side_effect=generation_snapshot,
+                ),
+                patch(
+                    "inky_bird_frame.cli.collection_status",
+                    return_value={"members": []},
+                ),
+                redirect_stdout(output),
+            ):
+                status_command(Namespace())
+
+            payload = json.loads(output.getvalue())["data"]
+            self.assertEqual(payload["generation"], generation_payload)
+            self.assertEqual(payload["failed"], [str(failed_dir)])
+            self.assertFalse(failed_dir.exists())
+            self.assertTrue(archived_dir.exists())
 
     def test_seed_supports_historical_dates_and_coordinates(self) -> None:
         args = build_parser().parse_args(
@@ -2499,8 +2614,33 @@ rotation_mode = "shuffle_bag"
             )
             config = controller_config(state_dir)
             output = io.StringIO()
+            lock_held = False
+            pending_move_locked = False
+            real_move = shutil.move
 
-            with patch("inky_bird_frame.cli._config", return_value=config), redirect_stdout(output):
+            @contextmanager
+            def state_lock(_state_dir: Path) -> Iterator[None]:
+                nonlocal lock_held
+                self.assertFalse(lock_held)
+                lock_held = True
+                try:
+                    yield
+                finally:
+                    lock_held = False
+
+            def move(source: str, destination: Path) -> str:
+                nonlocal pending_move_locked
+                if Path(source) == pending:
+                    self.assertTrue(lock_held)
+                    pending_move_locked = True
+                return str(real_move(Path(source), destination))
+
+            with (
+                patch("inky_bird_frame.cli._config", return_value=config),
+                patch("inky_bird_frame.cli.catalog_state_lock", side_effect=state_lock),
+                patch("inky_bird_frame.cli.shutil.move", side_effect=move),
+                redirect_stdout(output),
+            ):
                 retry_command(Namespace(taxon_id=42))
 
             result = json.loads(output.getvalue())["data"]
@@ -2509,6 +2649,7 @@ rotation_mode = "shuffle_bag"
         self.assertTrue(result["queued_for_generation"])
         self.assertEqual(queue[0].common_name, "Queued Bird")
         self.assertEqual(queue[0].scientific_name, "Avis ordinata")
+        self.assertTrue(pending_move_locked)
 
     def test_retry_prefers_current_identity_over_older_edit_source(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -751,10 +751,40 @@ class CliTests(unittest.TestCase):
                 self.assertTrue(lock_held)
                 return []
 
+            def queue_snapshot(
+                _config: object, *, approved: set[int] | None = None
+            ) -> SimpleNamespace:
+                self.assertTrue(lock_held)
+                self.assertEqual(approved, set())
+                return SimpleNamespace(actionable=[], terminal_blocked=[])
+
+            def generation_snapshot(
+                _config: object, *, approved: set[int] | None = None
+            ) -> SimpleNamespace:
+                self.assertTrue(lock_held)
+                self.assertEqual(approved, set())
+                return SimpleNamespace(as_dict=lambda: {})
+
+            def collection_snapshot(
+                _config: object, *, approved: list[object] | None = None
+            ) -> dict[str, object]:
+                self.assertTrue(lock_held)
+                self.assertEqual(approved, [])
+                return {"members": []}
+
             with (
                 patch("inky_bird_frame.cli._config", return_value=config),
                 patch("inky_bird_frame.cli.catalog_state_lock", side_effect=state_lock),
                 patch("inky_bird_frame.cli.validate_public_catalog", side_effect=validating),
+                patch(
+                    "inky_bird_frame.cli.read_generation_queue_partition",
+                    side_effect=queue_snapshot,
+                ),
+                patch(
+                    "inky_bird_frame.cli.read_generation_work",
+                    side_effect=generation_snapshot,
+                ),
+                patch("inky_bird_frame.cli.collection_status", side_effect=collection_snapshot),
                 redirect_stdout(io.StringIO()),
             ):
                 status_command(Namespace())

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import unittest
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -57,6 +59,7 @@ from inky_bird_frame.controller import (
     read_generation_queue,
     read_generation_queue_partition,
     read_generation_work,
+    record_failure,
     remove_collection_member,
     retry_approved_candidate,
     run_controller_cycle,
@@ -1594,6 +1597,17 @@ class ControllerTests(unittest.TestCase):
     def test_read_generation_work_includes_a_live_only_species(self) -> None:
         now = datetime(2026, 8, 30, 12, 0, tzinfo=UTC)
         species = BirdSpecies(1, "Live Bird", "Avis live", 2, "birdnet-go")
+        retained_retry = RetryRecord(
+            taxon_id=species.taxon_id,
+            attempts=1,
+            error_type="DataSourceError",
+            error="retry is due",
+            first_failed_at=now - timedelta(minutes=5),
+            last_failed_at=now - timedelta(minutes=5),
+            next_attempt_at=now,
+            common_name=species.common_name,
+            scientific_name=species.scientific_name,
+        )
         with TemporaryDirectory() as temporary:
             config_path = Path(temporary) / "config.toml"
             config_path.write_text(CONFIG)
@@ -1619,8 +1633,15 @@ class ControllerTests(unittest.TestCase):
                 )
             )
 
-            work = read_generation_work(config, approved=set(), now=now)
+            with patch("inky_bird_frame.controller.RetryStore") as retry_store:
+                work = read_generation_work(
+                    config,
+                    approved=set(),
+                    now=now,
+                    retry_records=[retained_retry],
+                )
 
+        retry_store.assert_not_called()
         self.assertTrue(work.complete)
         self.assertEqual([item.taxon_id for item in work.actionable], [species.taxon_id])
 
@@ -2550,6 +2571,8 @@ class ControllerTests(unittest.TestCase):
 
     def test_failed_review_is_corrected_and_passing_attempt_is_staged(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        catalog_lock_held = False
+        catalog_lock_entries = 0
         failed_review = QualityReview(
             False,
             3,
@@ -2587,6 +2610,7 @@ class ControllerTests(unittest.TestCase):
                 self.workspace = workspace.resolve()
 
             def create_profile(self, *_args: object, **_kwargs: object) -> SpeciesProfileData:
+                assert not catalog_lock_held
                 output_path = _args[-2]
                 assert isinstance(output_path, Path)
                 assert not output_path.resolve().is_relative_to(self.workspace)
@@ -2594,6 +2618,7 @@ class ControllerTests(unittest.TestCase):
                 return PROFILE
 
             def generate_plate(self, *_args: object, **_kwargs: object) -> Path:
+                assert not catalog_lock_held
                 output_path = _args[-3]
                 correction = _args[-1]
                 assert isinstance(output_path, Path)
@@ -2611,6 +2636,7 @@ class ControllerTests(unittest.TestCase):
                 return output_path
 
             def review_plate(self, *_args: object, **_kwargs: object) -> QualityReview:
+                assert not catalog_lock_held
                 portrait_path = _args[3]
                 assert isinstance(portrait_path, Path)
                 self.review_paths.append(portrait_path)
@@ -2618,6 +2644,7 @@ class ControllerTests(unittest.TestCase):
                 return next(self.reviews)
 
         def prepare(_source: Path, portrait: Path, display: Path) -> None:
+            assert not catalog_lock_held
             portrait.write_bytes(b"portrait")
             display.write_bytes(b"display")
 
@@ -2631,11 +2658,26 @@ class ControllerTests(unittest.TestCase):
             source_plate = config.controller.state_dir / "archive/source/portrait.png"
             source_plate.parent.mkdir(parents=True)
             source_plate.write_bytes(b"source")
+
+            @contextmanager
+            def state_lock(state_dir: Path) -> Iterator[None]:
+                nonlocal catalog_lock_held, catalog_lock_entries
+                self.assertEqual(state_dir, config.controller.state_dir)
+                self.assertFalse(candidate_directory(state_dir, species).exists())
+                catalog_lock_held = True
+                catalog_lock_entries += 1
+                try:
+                    yield
+                finally:
+                    self.assertTrue(candidate_directory(state_dir, species).is_dir())
+                    catalog_lock_held = False
+
             with (
                 patch("inky_bird_frame.controller.load_or_fetch_references", return_value=[]),
                 patch("inky_bird_frame.controller.fetch_taxon_context"),
                 patch("inky_bird_frame.controller.CodexRunner", FakeRunner),
                 patch("inky_bird_frame.controller.prepare_generated_plate", side_effect=prepare),
+                patch("inky_bird_frame.controller.catalog_state_lock", side_effect=state_lock),
             ):
                 candidate = generate_candidate(
                     config,
@@ -2679,6 +2721,7 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(manifest["status"], "pending")
         self.assertFalse((candidate / "attempt-history.json").exists())
         self.assertEqual(len(private_histories), 1)
+        self.assertEqual(catalog_lock_entries, 1)
 
     def test_profile_conflict_triggers_one_source_backed_refresh(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
@@ -3088,6 +3131,8 @@ class ControllerTests(unittest.TestCase):
 
     def test_terminal_review_failure_retains_versioned_attempt_history(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        catalog_lock_held = False
+        catalog_lock_entries = 0
         initial_conflict = ProfileConflict(
             field="measurements.length",
             profile_value=PROFILE["measurements"]["length"],
@@ -3138,21 +3183,25 @@ class ControllerTests(unittest.TestCase):
                 pass
 
             def create_profile(self, *_args: object, **_kwargs: object) -> SpeciesProfileData:
+                assert not catalog_lock_held
                 output_path = _args[-2]
                 assert isinstance(output_path, Path)
                 output_path.write_text(json.dumps(PROFILE))
                 return PROFILE
 
             def generate_plate(self, *_args: object, **_kwargs: object) -> Path:
+                assert not catalog_lock_held
                 output_path = _args[-3]
                 assert isinstance(output_path, Path)
                 output_path.write_bytes(b"generated")
                 return output_path
 
             def review_plate(self, *_args: object, **_kwargs: object) -> QualityReview:
+                assert not catalog_lock_held
                 return next(failed_reviews)
 
         def prepare(_source: Path, portrait: Path, display: Path) -> None:
+            assert not catalog_lock_held
             portrait.write_bytes(b"portrait")
             display.write_bytes(b"display")
 
@@ -3160,11 +3209,26 @@ class ControllerTests(unittest.TestCase):
             config_path = Path(temporary) / "config.toml"
             config_path.write_text(CONFIG)
             config = load_config(config_path)
+
+            @contextmanager
+            def state_lock(state_dir: Path) -> Iterator[None]:
+                nonlocal catalog_lock_held, catalog_lock_entries
+                self.assertEqual(state_dir, config.controller.state_dir)
+                self.assertFalse(catalog_lock_held)
+                catalog_lock_held = True
+                catalog_lock_entries += 1
+                try:
+                    yield
+                finally:
+                    self.assertTrue(any((state_dir / "failed").glob("*/attempt-history.json")))
+                    catalog_lock_held = False
+
             with (
                 patch("inky_bird_frame.controller.load_or_fetch_references", return_value=[]),
                 patch("inky_bird_frame.controller.fetch_taxon_context"),
                 patch("inky_bird_frame.controller.CodexRunner", FakeRunner),
                 patch("inky_bird_frame.controller.prepare_generated_plate", side_effect=prepare),
+                patch("inky_bird_frame.controller.catalog_state_lock", side_effect=state_lock),
                 self.assertRaises(QualityReviewError) as raised,
             ):
                 generate_candidate(
@@ -3189,6 +3253,7 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(run_history["attempts"][0]["failed_axes"], ["species_accuracy"])
         self.assertEqual(run_history["attempts"][1]["regressed_axes"], ["anatomy_accuracy"])
         self.assertEqual(run_history["attempts"][2]["regressed_findings"], ["Shorten the bill"])
+        self.assertEqual(catalog_lock_entries, 1)
 
     def test_reversed_correction_is_not_carried_as_an_invariant(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
@@ -3414,16 +3479,39 @@ class ControllerTests(unittest.TestCase):
     def test_catalog_failure_is_terminal_for_species_without_aborting_cycle(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
         location = DiscoveryLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        lock_held = False
+        failure_transition_locked = False
         with TemporaryDirectory() as temporary:
             config_path = Path(temporary) / "config.toml"
             config_path.write_text(CONFIG)
             config = load_config(config_path)
+
+            @contextmanager
+            def state_lock(_state_dir: Path) -> Iterator[None]:
+                nonlocal lock_held
+                self.assertFalse(lock_held)
+                lock_held = True
+                try:
+                    yield
+                finally:
+                    lock_held = False
+
+            def record(
+                state_dir: Path, failed_species: BirdSpecies, error: SpeciesStateError
+            ) -> Path:
+                nonlocal failure_transition_locked
+                self.assertTrue(lock_held)
+                failure_transition_locked = True
+                return record_failure(state_dir, failed_species, error)
+
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",
                     return_value=discovery_result(location, [species]),
                 ),
                 patch("inky_bird_frame.controller.generate_candidate") as generate,
+                patch("inky_bird_frame.controller.catalog_state_lock", side_effect=state_lock),
+                patch("inky_bird_frame.controller.record_failure", side_effect=record),
             ):
                 generate.side_effect = SpeciesStateError("cached references are invalid")
                 result = run_controller_cycle(config)
@@ -3431,6 +3519,7 @@ class ControllerTests(unittest.TestCase):
             failures = list((config.controller.state_dir / "failed").glob("9083-*"))
 
         self.assertEqual(len(failures), 1)
+        self.assertTrue(failure_transition_locked)
         failure_results = result["failures"]
         self.assertIsInstance(failure_results, list)
         if isinstance(failure_results, list):
@@ -3624,6 +3713,8 @@ class ControllerTests(unittest.TestCase):
     def test_exhausted_quality_review_becomes_terminal(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
         location = DiscoveryLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        lock_held = False
+        failure_transition_locked = False
         with TemporaryDirectory() as temporary:
             config_path = Path(temporary) / "config.toml"
             config_path.write_text(CONFIG)
@@ -3636,12 +3727,33 @@ class ControllerTests(unittest.TestCase):
                 ("Correct the ruler scale",),
                 invariant_findings=("Keep the eyes clearly visible",),
             )
+
+            @contextmanager
+            def state_lock(_state_dir: Path) -> Iterator[None]:
+                nonlocal lock_held
+                self.assertFalse(lock_held)
+                lock_held = True
+                try:
+                    yield
+                finally:
+                    lock_held = False
+
+            def record(
+                state_dir: Path, failed_species: BirdSpecies, error: QualityReviewError
+            ) -> Path:
+                nonlocal failure_transition_locked
+                self.assertTrue(lock_held)
+                failure_transition_locked = True
+                return record_failure(state_dir, failed_species, error)
+
             with (
                 patch(
                     "inky_bird_frame.controller.discover_species",
                     return_value=discovery_result(location, [species]),
                 ),
                 patch("inky_bird_frame.controller.generate_candidate") as generate,
+                patch("inky_bird_frame.controller.catalog_state_lock", side_effect=state_lock),
+                patch("inky_bird_frame.controller.record_failure", side_effect=record),
             ):
                 generate.side_effect = QualityReviewError("review attempts exhausted")
                 result = run_controller_cycle(config)
@@ -3652,6 +3764,7 @@ class ControllerTests(unittest.TestCase):
             ).quality_guidance(species.taxon_id)
 
         self.assertEqual(len(failures), 1)
+        self.assertTrue(failure_transition_locked)
         failure_results = result["failures"]
         self.assertIsInstance(failure_results, list)
         if isinstance(failure_results, list):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -43,6 +43,7 @@ from inky_bird_frame.controller import (
     _merge_provider_species,
     _merge_refreshed_profile,
     add_collection_member,
+    calculate_generation_work,
     collection_status,
     discover_species,
     enqueue_seed_species,
@@ -55,6 +56,7 @@ from inky_bird_frame.controller import (
     load_or_fetch_references,
     read_generation_queue,
     read_generation_queue_partition,
+    read_generation_work,
     remove_collection_member,
     retry_approved_candidate,
     run_controller_cycle,
@@ -74,7 +76,7 @@ from inky_bird_frame.errors import (
 from inky_bird_frame.geo import DiscoveryLocation
 from inky_bird_frame.models import ProfileConflict, QualityReview, SpeciesProfileData
 from inky_bird_frame.prompts import PROMPT_VERSION
-from inky_bird_frame.retry import RetryStore
+from inky_bird_frame.retry import RetryRecord, RetryStore
 
 
 def discovery_result(location: DiscoveryLocation, species: list[BirdSpecies]) -> DiscoveryResult:
@@ -1479,6 +1481,149 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(partition.terminal_blocked[1].species.taxon_id, 3)
         self.assertEqual(partition.terminal_blocked[1].state, "incomplete_pending")
 
+    def test_generation_work_combines_live_and_queued_species(self) -> None:
+        now = datetime(2026, 8, 30, 12, 0, tzinfo=UTC)
+        deferred = BirdSpecies(1, "Current Bird", "Avis current", 4, "birdnet-go")
+        blocked = BirdSpecies(2, "Blocked Bird", "Avis blocked", 2, "birdweather")
+        pending = BirdSpecies(3, "Pending Bird", "Avis pending", 1, "birdbuddy")
+        queued = BirdSpecies(4, "Old Name", "Avis old", 0, "historical-seed")
+        approved = BirdSpecies(5, "Approved Bird", "Avis approved", 3, "inaturalist")
+        retry_records = [
+            RetryRecord(
+                taxon_id=deferred.taxon_id,
+                attempts=1,
+                error_type="DataSourceError",
+                error="temporary",
+                first_failed_at=now,
+                last_failed_at=now,
+                next_attempt_at=now + timedelta(minutes=5),
+                common_name=deferred.common_name,
+                scientific_name=deferred.scientific_name,
+            ),
+            RetryRecord(
+                taxon_id=queued.taxon_id,
+                attempts=1,
+                error_type="DataSourceError",
+                error="temporary",
+                first_failed_at=now - timedelta(minutes=5),
+                last_failed_at=now - timedelta(minutes=5),
+                next_attempt_at=now,
+                common_name="Recovered Name",
+                scientific_name="Avis recovered",
+            ),
+        ]
+
+        work = calculate_generation_work(
+            snapshot=DiscoverySnapshot(
+                now - timedelta(minutes=1),
+                "Exampleville",
+                "XY",
+                [deferred, blocked, pending, approved],
+            ),
+            queued_species=[
+                BirdSpecies(1, "Stale Bird", "Avis stale", 0, "historical-seed"),
+                queued,
+            ],
+            approved={approved.taxon_id},
+            terminal_states={
+                blocked.taxon_id: ("failed", (Path("state/failed/2-blocked"),)),
+                pending.taxon_id: ("pending", (Path("state/pending/3-pending"),)),
+            },
+            retry_records=retry_records,
+            now=now,
+            maximum_age=timedelta(minutes=30),
+        )
+
+        self.assertTrue(work.complete)
+        self.assertEqual(work.discovery_status, "fresh")
+        self.assertEqual([species.taxon_id for species in work.eligible], [1, 4])
+        self.assertEqual([species.taxon_id for species in work.actionable], [4])
+        self.assertEqual(work.actionable[0].common_name, "Recovered Name")
+        self.assertEqual([record.taxon_id for record in work.deferred], [1])
+        self.assertEqual([entry.species.taxon_id for entry in work.terminal_blocked], [2])
+
+    def test_generation_work_never_claims_actionability_without_fresh_discovery(self) -> None:
+        now = datetime(2026, 8, 30, 12, 0, tzinfo=UTC)
+        observed = BirdSpecies(1, "Observed Bird", "Avis observed", 2, "birdnet-go")
+        queued = BirdSpecies(2, "Queued Bird", "Avis queued", 0, "human-review")
+
+        stale = calculate_generation_work(
+            snapshot=DiscoverySnapshot(
+                now - timedelta(minutes=31),
+                "Exampleville",
+                "XY",
+                [observed],
+            ),
+            queued_species=[queued],
+            approved=set(),
+            terminal_states={},
+            retry_records=[],
+            now=now,
+            maximum_age=timedelta(minutes=30),
+        )
+        missing = calculate_generation_work(
+            snapshot=None,
+            queued_species=[queued],
+            approved=set(),
+            terminal_states={},
+            retry_records=[],
+            now=now,
+            maximum_age=timedelta(minutes=30),
+        )
+
+        self.assertFalse(stale.complete)
+        self.assertEqual(stale.discovery_status, "stale")
+        self.assertEqual([species.taxon_id for species in stale.eligible], [1, 2])
+        self.assertEqual(stale.actionable, [])
+        self.assertFalse(missing.complete)
+        self.assertEqual(missing.discovery_status, "missing")
+        self.assertEqual([species.taxon_id for species in missing.eligible], [2])
+        self.assertEqual(missing.actionable, [])
+
+    def test_generation_work_surfaces_corrupt_discovery_state(self) -> None:
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            (config.controller.state_dir / "discovery.json").write_text("{")
+
+            with self.assertRaisesRegex(CatalogError, "Invalid discovery state"):
+                read_generation_work(config)
+
+    def test_read_generation_work_includes_a_live_only_species(self) -> None:
+        now = datetime(2026, 8, 30, 12, 0, tzinfo=UTC)
+        species = BirdSpecies(1, "Live Bird", "Avis live", 2, "birdnet-go")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            (config.controller.state_dir / "discovery.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "refreshed_at": now.isoformat(),
+                        "place_name": "Exampleville",
+                        "state": "XY",
+                        "species": [
+                            {
+                                "taxon_id": species.taxon_id,
+                                "common_name": species.common_name,
+                                "scientific_name": species.scientific_name,
+                                "observation_count": species.observation_count,
+                                "source": species.source,
+                            }
+                        ],
+                    }
+                )
+            )
+
+            work = read_generation_work(config, approved=set(), now=now)
+
+        self.assertTrue(work.complete)
+        self.assertEqual([item.taxon_id for item in work.actionable], [species.taxon_id])
+
     def test_generation_prioritizes_current_species_before_seed_queue(self) -> None:
         current = BirdSpecies(1, "Current Bird", "Avis current", 4, "iNaturalist")
         queued = BirdSpecies(2, "Queued Bird", "Avis queued", 3, "iNaturalist")
@@ -1598,6 +1743,64 @@ class ControllerTests(unittest.TestCase):
         self.assertEqual(result["attempted_count"], 1)
         self.assertEqual(result["deferred_count"], 2)
         self.assertEqual(result["outstanding_retry_count"], 2)
+
+    def test_generation_rechecks_retry_due_status_for_each_species(self) -> None:
+        first = BirdSpecies(1, "First Bird", "Avis first", 4, "iNaturalist")
+        retrying = BirdSpecies(2, "Retrying Bird", "Avis retrying", 3, "iNaturalist")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            (config.controller.state_dir / "discovery.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "refreshed_at": datetime.now(UTC).isoformat(),
+                        "place_name": "Exampleville",
+                        "state": "XY",
+                        "species": [
+                            {
+                                "taxon_id": species.taxon_id,
+                                "common_name": species.common_name,
+                                "scientific_name": species.scientific_name,
+                                "observation_count": species.observation_count,
+                                "source": species.source,
+                            }
+                            for species in (first, retrying)
+                        ],
+                    }
+                )
+            )
+            RetryStore(config.controller.state_dir / "generation-retries.json").record_failure(
+                retrying.taxon_id,
+                DataSourceError("temporary"),
+                now=datetime.now(UTC),
+                initial_minutes=30,
+                maximum_minutes=60,
+                species=retrying,
+            )
+            attempted: list[int] = []
+            due_checks: list[int] = []
+
+            def fail_generation(_config: object, species: BirdSpecies, _workspace: object) -> Path:
+                attempted.append(species.taxon_id)
+                raise DataSourceError("temporary")
+
+            def now_due(_store: RetryStore, taxon_id: int, _now: datetime) -> bool:
+                due_checks.append(taxon_id)
+                return True
+
+            with (
+                patch("inky_bird_frame.controller.approved_taxon_ids", return_value=set()),
+                patch("inky_bird_frame.controller.generate_candidate", side_effect=fail_generation),
+                patch.object(RetryStore, "due", autospec=True, side_effect=now_due),
+                patch("inky_bird_frame.controller.rebuild_catalog_index", return_value=[]),
+            ):
+                run_generation_cycle(config)
+
+        self.assertEqual(due_checks, [first.taxon_id, retrying.taxon_id])
+        self.assertEqual(attempted, [first.taxon_id, retrying.taxon_id])
 
     def test_due_unattempted_retry_remains_outstanding(self) -> None:
         first = BirdSpecies(1, "First Bird", "Avis first", 4, "iNaturalist")
@@ -1810,7 +2013,10 @@ class ControllerTests(unittest.TestCase):
                     "inky_bird_frame.controller._read_discovery_snapshot",
                     side_effect=[initial, latest],
                 ),
-                patch("inky_bird_frame.controller._has_terminal_state", return_value=True),
+                patch(
+                    "inky_bird_frame.controller._generation_terminal_states",
+                    return_value={1: ("failed", (Path("state/failed/1-alpha"),))},
+                ),
                 patch("inky_bird_frame.controller._write_active_catalog", return_value=0) as write,
             ):
                 run_generation_cycle(config)
@@ -1837,6 +2043,92 @@ class ControllerTests(unittest.TestCase):
 
             with self.assertRaisesRegex(DataSourceError, "stale"):
                 run_generation_cycle(config)
+
+    def test_stale_generation_does_not_refresh_retry_identity_or_archive_profile(self) -> None:
+        old = BirdSpecies(42, "Old Bird Name", "Avis old", 0, HUMAN_REVIEW_SOURCE)
+        observed = BirdSpecies(42, "Current Bird Name", "Avis current", 3, "eBird")
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            state_dir = config.controller.state_dir
+            state_dir.mkdir(parents=True)
+            write_collection(
+                state_dir,
+                [],
+                legacy_seed_queue_migrated_at="2026-08-05T12:00:00+00:00",
+            )
+            queue_path = state_dir / "generation-queue.json"
+            queue_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "species": [
+                            {
+                                "taxon_id": old.taxon_id,
+                                "common_name": old.common_name,
+                                "scientific_name": old.scientific_name,
+                                "observation_count": old.observation_count,
+                                "source": old.source,
+                                "sources": list(old.sources),
+                            }
+                        ],
+                    }
+                )
+            )
+            retry_path = state_dir / "generation-retries.json"
+            RetryStore(retry_path).record_failure(
+                old.taxon_id,
+                GenerationError("temporary failure"),
+                now=datetime(2026, 8, 5, tzinfo=UTC),
+                initial_minutes=5,
+                maximum_minutes=60,
+                species=old,
+            )
+            profile_path = state_dir / "profiles/42/profile.json"
+            profile_path.parent.mkdir(parents=True)
+            profile_path.write_text(
+                json.dumps(
+                    {
+                        "taxon_id": old.taxon_id,
+                        "common_name": old.common_name,
+                        "scientific_name": old.scientific_name,
+                    }
+                )
+            )
+            (state_dir / "discovery.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "refreshed_at": "2000-01-01T00:00:00+00:00",
+                        "place_name": "Exampleville",
+                        "state": "XY",
+                        "species": [
+                            {
+                                "taxon_id": observed.taxon_id,
+                                "common_name": observed.common_name,
+                                "scientific_name": observed.scientific_name,
+                                "observation_count": observed.observation_count,
+                                "source": observed.source,
+                            }
+                        ],
+                    }
+                )
+            )
+            before = {
+                queue_path: queue_path.read_bytes(),
+                retry_path: retry_path.read_bytes(),
+                profile_path: profile_path.read_bytes(),
+            }
+
+            with self.assertRaisesRegex(DataSourceError, "stale"):
+                run_generation_cycle(config)
+
+            after = {path: path.read_bytes() for path in before}
+            archive_exists = (state_dir / "archive").exists()
+
+        self.assertEqual(after, before)
+        self.assertFalse(archive_exists)
 
     def test_refresh_writes_only_observed_approved_species_to_private_active_catalog(
         self,

--- a/tests/test_deployment_scripts.py
+++ b/tests/test_deployment_scripts.py
@@ -11,6 +11,14 @@ def _controller_installers() -> list[str]:
     ]
 
 
+def test_docker_bootstrap_applies_only_reviewed_catalog_migrations() -> None:
+    compose = (Path(__file__).resolve().parents[1] / "compose.yaml").read_text()
+
+    bootstrap = compose.split("  controller:", maxsplit=1)[0]
+    assert 'INKY_CATALOG_SYNC_APPLY_REVIEWED_MIGRATIONS: "1"' in bootstrap
+    assert "--apply-reviewed-migrations" not in bootstrap
+
+
 def test_controller_installers_use_provider_lists_for_managed_credentials() -> None:
     for script in _controller_installers():
         assert 'environment_credentials.append("geoapify_api_key_env")' in script

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -493,6 +493,91 @@ class PublisherTests(unittest.TestCase):
             )
             self.assertEqual(len(validate_public_catalog(corrected_local)), 1)
 
+    def test_sync_retains_a_newer_reviewed_destination(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            replacement = root / "replacement"
+            _create_species(source, 1, "Example Bird")
+            shutil.copytree(source, destination)
+            replacement_directory = _create_portrait_replacement(
+                replacement,
+                1,
+                "Example Bird",
+                approved_at="2026-07-10T00:00:00+00:00",
+                color="black",
+            )
+            replace_public_catalog_taxon(
+                replacement,
+                destination,
+                1,
+                "Human review found incorrect proportions.",
+            )
+            newer_portrait = (replacement_directory / "portrait.png").read_bytes()
+
+            result = sync_public_catalog(source, destination, allow_replacements=True)
+
+            self.assertEqual(result["published"], [])
+            self.assertEqual(result["replaced"], [])
+            self.assertEqual(
+                result["retained_newer"],
+                [
+                    {
+                        "taxon_id": 1,
+                        "common_name": "Example Bird",
+                        "scientific_name": "Avis exemplaris",
+                        "slug": "example-bird",
+                    }
+                ],
+            )
+            self.assertEqual(
+                (destination / "species/1-example-bird/portrait.png").read_bytes(),
+                newer_portrait,
+            )
+            self.assertEqual(len(validate_public_catalog(destination)), 1)
+
+    def test_sync_retains_newer_migration_metadata_for_matching_assets(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            original = root / "original"
+            published = root / "published"
+            corrected_without_migration = root / "corrected-without-migration"
+            replacement = root / "replacement"
+            _create_species(original, 1, "Example Bird")
+            shutil.copytree(original, published)
+            _create_portrait_replacement(
+                replacement,
+                1,
+                "Example Bird",
+                approved_at="2026-07-10T00:00:00+00:00",
+                color="black",
+            )
+            shutil.copytree(replacement, corrected_without_migration)
+            replace_public_catalog_taxon(
+                replacement,
+                published,
+                1,
+                "Human review found incorrect proportions.",
+            )
+
+            result = sync_public_catalog(
+                corrected_without_migration,
+                published,
+                allow_replacements=True,
+            )
+
+            self.assertEqual(result["replaced"], [])
+            retained_newer = result["retained_newer"]
+            self.assertIsInstance(retained_newer, list)
+            assert isinstance(retained_newer, list)
+            self.assertEqual([item["taxon_id"] for item in retained_newer], [1])
+            manifest = json.loads((published / "species/1-example-bird/manifest.json").read_text())
+            self.assertEqual(
+                manifest["catalog_migration"]["reason"],
+                "Human review found incorrect proportions.",
+            )
+
     def test_sync_rejects_a_valid_replacement_without_explicit_opt_in(self) -> None:
         with TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -583,6 +668,38 @@ class PublisherTests(unittest.TestCase):
             with self.assertRaisesRegex(CatalogPublishError, "preserve migration history"):
                 validate_catalog_additions(first, tampered)
 
+            forked = root / "forked"
+            shutil.copytree(second, forked)
+            forked_manifest_path = forked / "species/1-example-bird/manifest.json"
+            forked_manifest = json.loads(forked_manifest_path.read_text())
+            forked_migration = forked_manifest["catalog_migration"]
+            forked_migration["history"].append(
+                {
+                    "reason": "Unrelated fork.",
+                    "replaces": {
+                        "approved_at": "2026-07-09T12:00:00+00:00",
+                        "display_sha256": "c" * 64,
+                        "portrait_sha256": "d" * 64,
+                    },
+                }
+            )
+            write_json_atomic(forked_manifest_path, forked_manifest)
+            rebuild_catalog_index(forked)
+            self.assertEqual(len(validate_public_catalog(forked)), 1)
+
+            forked_destination = root / "forked-destination"
+            shutil.copytree(first, forked_destination)
+            with self.assertRaisesRegex(
+                CatalogPublishError,
+                "does not match the approved base artifacts",
+            ):
+                sync_public_catalog(forked, forked_destination, allow_replacements=True)
+            with self.assertRaisesRegex(
+                CatalogPublishError,
+                "preserve migration history",
+            ):
+                sync_public_catalog(first, forked, allow_replacements=True)
+
             shutil.copytree(original, skipped_controller)
             result = sync_public_catalog(
                 second,
@@ -599,6 +716,17 @@ class PublisherTests(unittest.TestCase):
                 (second / "species/1-example-bird/portrait.png").read_bytes(),
             )
             self.assertEqual(len(validate_public_catalog(skipped_controller)), 1)
+
+            retained = sync_public_catalog(original, second, allow_replacements=True)
+
+            retained_newer = retained["retained_newer"]
+            self.assertIsInstance(retained_newer, list)
+            assert isinstance(retained_newer, list)
+            self.assertEqual([item["taxon_id"] for item in retained_newer], [1])
+            self.assertEqual(
+                (second / "species/1-example-bird/portrait.png").read_bytes(),
+                (second_source / "species/1-example-bird/portrait.png").read_bytes(),
+            )
 
     def test_interrupted_committed_cleanup_keeps_the_installed_replacement(self) -> None:
         with TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary\n- apply only reviewed, hash-bound catalog migrations during controller bootstrap while keeping manual sync add-only by default\n- retain a validated newer persistent catalog entry instead of downgrading it\n- derive generation status and generation execution from one side-effect-free work classifier\n- report missing or stale discovery without claiming work is actionable\n- document snapshot-backed rollback for persistent catalog and state migrations\n\n## Safety boundaries\n- arbitrary, incomplete, divergent, forked, or tampered catalog histories fail closed\n- bootstrap uses an environment opt-in that older rollback images safely ignore\n- status validates without rebuilding or rewriting the catalog\n- stale discovery cannot rewrite retry identity, queue state, or cached profiles\n- retry due status is checked as each species is reached\n- current observations continue to take priority over durable queue entries\n\n## Verification\n- Ruff format check and lint\n- strict MyPy: 56 source files\n- full Pytest: 630 passed, 75 subtests passed\n- catalog validation: 162 species\n- workflow action pinning: 6 files\n- package sdist and wheel build\n- git diff check\n- independent exact-head review with all findings resolved