### PR TITLE
Harden the controller HTTP boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
           trap 'docker volume rm --force "$config_volume"' EXIT
           docker volume create "$config_volume"
           docker run --rm inky-bird-frame:ci --help
+          docker run --rm inky-bird-frame:ci --version
           docker run --rm --entrypoint codex inky-bird-frame:ci --version
           run_sandbox() {
             docker run --rm --read-only --cap-drop ALL \
@@ -159,6 +160,14 @@ jobs:
             exit 1
           fi
           docker run --rm --entrypoint gh inky-bird-frame:ci --version
+          docker run --rm --entrypoint test inky-bird-frame:ci \
+            -s /usr/share/licenses/inky-bird-frame/third-party/codex/LICENSE
+          docker run --rm --entrypoint test inky-bird-frame:ci \
+            -s /usr/share/licenses/inky-bird-frame/third-party/codex/NOTICE
+          docker run --rm --entrypoint test inky-bird-frame:ci \
+            -s /usr/share/licenses/inky-bird-frame/third-party/github-cli/LICENSE
+          docker run --rm --entrypoint test inky-bird-frame:ci \
+            -s /usr/share/licenses/inky-bird-frame/THIRD_PARTY_NOTICES.md
           docker run --rm inky-bird-frame:ci catalog validate --catalog /app/catalog
           docker run --rm --interactive \
             --volume "$config_volume:/data" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,12 @@ ARG TARGETARCH
 ARG CODEX_VERSION=0.144.3
 ARG CODEX_AMD64_SHA256=b9b4ae8e9b561c64dfbc5ef52c6319cba750ac87de3c7f55885026231e3aea89
 ARG CODEX_ARM64_SHA256=dd76cfd5a2cf9bcf0e3224afe28e23065cfd27262e06e0ffbc8fa40343f0905a
+ARG CODEX_LICENSE_SHA256=d17f227e4df5da1600391338865ce0f3055211760a36688f816941d58232d8dc
+ARG CODEX_NOTICE_SHA256=9d71575ecfd9a843fc1677b0efb08053c6ba9fd686a0de1a6f5382fd3c220915
 ARG GH_VERSION=2.95.0
 ARG GH_AMD64_SHA256=25d1e4729e8808c9ed3d613e96ebd3f3e44446f2d368c89d878a71a36ddb3d8c
 ARG GH_ARM64_SHA256=d41e0b3b6218e5741c8bb4db39b16e53a59e0e06299a8489bd38f623ef7ebaae
+ARG GH_LICENSE_SHA256=6da4adc42392c8485e40b4251c7e332fc3352df1947c9ffade71dd60b14a7a4f
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
@@ -30,18 +33,25 @@ RUN set -eux; \
       arm64) codex_arch=aarch64; codex_sha="${CODEX_ARM64_SHA256}"; gh_arch=arm64; gh_sha="${GH_ARM64_SHA256}" ;; \
       *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
-    mkdir -p /out; \
+    mkdir -p /out/licenses/codex /out/licenses/github-cli; \
     codex_archive=/tmp/codex.tar.gz; \
     curl -fsSL "https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/codex-${codex_arch}-unknown-linux-musl.tar.gz" -o "${codex_archive}"; \
     printf '%s  %s\n' "${codex_sha}" "${codex_archive}" | sha256sum -c -; \
     tar -xzf "${codex_archive}" -C /out; \
     mv "/out/codex-${codex_arch}-unknown-linux-musl" /out/codex; \
+    curl -fsSL "https://raw.githubusercontent.com/openai/codex/rust-v${CODEX_VERSION}/LICENSE" -o /out/licenses/codex/LICENSE; \
+    curl -fsSL "https://raw.githubusercontent.com/openai/codex/rust-v${CODEX_VERSION}/NOTICE" -o /out/licenses/codex/NOTICE; \
+    printf '%s  %s\n' "${CODEX_LICENSE_SHA256}" /out/licenses/codex/LICENSE | sha256sum -c -; \
+    printf '%s  %s\n' "${CODEX_NOTICE_SHA256}" /out/licenses/codex/NOTICE | sha256sum -c -; \
     gh_archive=/tmp/gh.tar.gz; \
     curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${gh_arch}.tar.gz" -o "${gh_archive}"; \
     printf '%s  %s\n' "${gh_sha}" "${gh_archive}" | sha256sum -c -; \
     tar -xzf "${gh_archive}" -C /tmp; \
     mv "/tmp/gh_${GH_VERSION}_linux_${gh_arch}/bin/gh" /out/gh; \
-    chmod 0755 /out/codex /out/gh
+    mv "/tmp/gh_${GH_VERSION}_linux_${gh_arch}/LICENSE" /out/licenses/github-cli/LICENSE; \
+    printf '%s  %s\n' "${GH_LICENSE_SHA256}" /out/licenses/github-cli/LICENSE | sha256sum -c -; \
+    chmod 0755 /out/codex /out/gh; \
+    chmod 0644 /out/licenses/codex/LICENSE /out/licenses/codex/NOTICE /out/licenses/github-cli/LICENSE
 
 FROM ${PYTHON_IMAGE} AS runtime
 ARG VCS_REF=unknown
@@ -61,6 +71,8 @@ RUN apt-get update \
 COPY --from=build /app/.venv /app/.venv
 COPY --from=tool-downloads /out/codex /usr/local/bin/codex
 COPY --from=tool-downloads /out/gh /usr/local/bin/gh
+COPY --from=tool-downloads /out/licenses/ /usr/share/licenses/inky-bird-frame/third-party/
+COPY LICENSE THIRD_PARTY_NOTICES.md /usr/share/licenses/inky-bird-frame/
 COPY --chown=10001:10001 catalog /app/catalog
 RUN mkdir -p \
       /data/catalog/species \

--- a/README.md
+++ b/README.md
@@ -57,14 +57,15 @@ from a separate origin, add that exact origin:
 cors_allowed_origins = ["https://frame.example.test"]
 ```
 
-An HTTPS application must use a same-origin application proxy or reach the
-controller through an HTTPS endpoint. A VPN alone does not prevent mixed
-content. A same-origin proxy makes the request server-side and does not need a
-CORS setting. Cross-origin access is disabled by default, does not add
-authentication, and does not make the controller safe to expose to the
-internet. See
+A same-origin application proxy is the recommended browser path. It can
+authenticate users, keeps the controller on the trusted network, and needs no
+CORS setting. Direct cross-origin access is disabled by default. Browser local
+network and mixed-content policies vary, so a direct connection may prompt for
+permission or fail even when its origin is allowed. Browser reads never count
+as display-node health. Allowing an origin does not add authentication or make
+the controller safe to expose to the internet. See
 [Browser applications](docs/installation.md#browser-applications) for the
-configuration and network limits.
+API, privacy, and network limits.
 
 The roles may run on one capable Raspberry Pi, but the recommended wall build
 keeps the lightweight display node behind the frame and runs the controller on
@@ -246,6 +247,9 @@ inky-bird-frame doctor display --config /path/to/config.toml
 ## Operate
 
 ```bash
+# Identify the installed application before an update or bug report.
+uv run inky-bird-frame --version
+
 # Refresh observations and the private active catalog without invoking Codex.
 uv run inky-bird-frame refresh --config config.toml
 
@@ -402,6 +406,13 @@ or publisher credentials. See
 [`CONTRIBUTING.md`](CONTRIBUTING.md) for the complete workflow and engineering
 expectations, and [`SECURITY.md`](SECURITY.md) for private vulnerability
 reporting.
+
+## License
+
+Inky Bird Frame is available under the [MIT License](LICENSE). The controller
+container also includes Codex CLI and GitHub CLI. Their licenses and the exact
+in-image notice paths are listed in
+[`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
 
 ## Development
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,16 @@
+# Third-party notices
+
+Inky Bird Frame is licensed under the [MIT License](LICENSE). The controller
+container also redistributes these command-line tools:
+
+| Component | License | Source |
+| --- | --- | --- |
+| [OpenAI Codex CLI](https://github.com/openai/codex) | Apache License 2.0 | The version is pinned by `CODEX_VERSION` in [`Dockerfile`](Dockerfile). |
+| [GitHub CLI](https://github.com/cli/cli) | MIT License | The version is pinned by `GH_VERSION` in [`Dockerfile`](Dockerfile). |
+
+The container stores the exact license material distributed with those pinned
+versions under `/usr/share/licenses/inky-bird-frame/third-party/`. The build
+verifies each file before it copies the notices into the runtime image.
+
+Installed Python and Debian packages retain the license and copyright material
+provided by their package formats.

--- a/config.example.toml
+++ b/config.example.toml
@@ -56,7 +56,7 @@ codex_path = "codex"
 bind_host = "0.0.0.0"
 port = 8793
 # Cross-origin browser access is disabled by default. List the exact HTTP or HTTPS origins
-# of trusted browser applications that need to fetch /v1/catalog and /v1/assets/*.
+# of trusted browser applications that need the active catalog and its portrait/display PNGs.
 # Use ASCII hostnames or canonical IP addresses. Internationalized names, punycode,
 # wildcards, credentials, paths, queries, and fragments are rejected.
 # cors_allowed_origins = ["https://frame.example.test"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,26 +131,66 @@ Notification delivery is an independent durable outbox. Application state is
 committed first, each destination is acknowledged separately, and provider
 failures never block controller or display work.
 
-The controller also exposes a read-only HTTP catalog:
+The controller exposes a small HTTP interface:
 
-- `GET /health`
+- `GET /health`: service state, catalog counts, and application version
 - `GET /v1/catalog`
-- `GET /v1/assets/<catalog-relative-path>`
+- `GET /v1/assets/<active-image-path>`
+- `POST /v1/display-fetch`
+- `POST /v1/display-success`
 
 Cross-origin browser access to the catalog and assets is disabled unless the
 operator configures exact trusted origins. The server echoes a matching origin
 and varies cache entries by `Origin`; it never enables credentialed browser
-requests or grants wildcard access. Health and display-heartbeat responses are
-served without cross-origin access headers.
+requests or grants wildcard access. Health and display telemetry responses are
+served without cross-origin access headers. Ordinary catalog and browser reads
+never update physical-display health.
 
-`/health` reports approved and active species counts from the last built
-catalog index and never rebuilds it, so a health check answers cheaply at any
-catalog size. The server also records the time of the last `/v1/catalog`
-fetch in `display-last-fetch.json` and of the last display-reported completed
-update (`GET /v1/display-success`) in `display-last-success.json`, both under
-`state_dir`; the notifications cycle uses them to raise the display-staleness
-events described in
-[`notifications.md`](notifications.md#events-and-noise-controls).
+Catalog schema version 1 has three top-level fields: `schema_version`,
+`generated_at`, and `species`. Each species entry contains `taxon_id`,
+`common_name`, `scientific_name`, `slug`, `portrait_path`, `portrait_sha256`,
+`display_path`, `display_sha256`, and `approved_at`. `observation_count` and
+`latest_detection_at` are optional. The server projects only these fields from
+private controller state. It never exposes provider names, raw observations,
+locations, credentials, or private provider state.
+
+The asset route serves only portrait and display PNG paths present in the
+current active catalog. It verifies each file against the catalog SHA-256 before
+sending bytes. Catalog responses use `no-store`; an image request becomes
+immutable-cacheable only when its `sha256` query matches the verified active
+catalog digest. Catalog JSON and image responses carry
+`X-Content-Type-Options: nosniff`.
+
+Schema version 1 may gain an optional field only after a privacy review.
+Removing a required field, changing a field's meaning or type, or exposing a
+different data class requires a new schema version or route. Display nodes
+reject an unsupported schema version and ignore unknown entry fields.
+
+`/health` reads the approved count from the last built catalog index and the
+active count from current active-catalog state. It never rebuilds or scans the
+catalog, so the check stays cheap at any catalog size. Its additive `version`
+field comes from installed package metadata.
+
+After a display node parses the catalog, it posts the fixed JSON payload
+`{"schema_version": 1}` to `/v1/display-fetch`. It posts the same bounded
+payload to `/v1/display-success` only after a verified panel update. The server
+records those times under `state_dir`, and the notifications cycle uses them to
+raise the display-staleness events described in
+[`notifications.md`](notifications.md#events-and-noise-controls). The POST
+routes reject browser `Origin` headers and do not grant CORS access.
+
+Display telemetry is not authenticated separately from the trusted-network
+service. A client that can reach the controller can deliberately imitate a
+display node's POST and refresh the aggregate signal. Keep the controller port
+private and do not use these heartbeats as an identity or authorization check.
+
+For one compatibility release, older display nodes may still use `GET
+/v1/catalog?reports_success=1` and `GET /v1/display-success`. The controller
+requires both the fixed Inky display user agent and no `Origin` header; current
+display nodes fall back to these routes only when a telemetry POST fails. These
+state-changing GET forms are deprecated and will be removed in the next feature
+release. The service logs each request locally with source IP address, path and
+query, and status. It does not log headers or send external browser telemetry.
 
 Native installations use launchd or systemd to schedule the controller's
 one-shot commands. Generated systemd serve and display units carry basic
@@ -166,19 +206,19 @@ enabled work.
 
 The display node does not discover birds or generate art. Each timer cycle:
 
-1. fetches the private active catalog;
+1. fetches and validates the private active catalog, then reports that fetch;
 2. selects an entry using the configured sequential, shuffle, `shuffle_bag`, or
-   observation-weighted policy and durable local state. The newest BirdWeather
-   or Bird Buddy detection may take priority once and counts as shown in the
-   current rotation. `shuffle_bag` keeps its own remaining and shown lists, so
-   a newly active species joins the current bag without restoring species
-   already shown;
+   observation-weighted policy and durable local state. The newest BirdWeather,
+   BirdNET-Go, or Bird Buddy detection may take priority once and counts as
+   shown in the current rotation. `shuffle_bag` keeps its own remaining and
+   shown lists, so a newly active species joins the current bag without
+   restoring species already shown;
 3. downloads the canonical display asset;
 4. verifies its SHA-256 checksum;
 5. writes it to a local cache atomically;
 6. fits it without cropping when the detected panel uses the 800x480 geometry;
    and
-7. updates the Inky panel before advancing state.
+7. updates the Inky panel before advancing state and reporting success.
 
 Display cycles use a nonblocking local process lock. A cycle that cannot obtain
 the lock fails without changing state, and failed panel updates also leave the

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,6 +7,10 @@ The normal Docker path pulls a published image from GitHub Container Registry.
 It does not build the project from source. Images are available for AMD64 and
 ARM64 hosts.
 
+The image includes the project license and the pinned Codex CLI and GitHub CLI
+license material under `/usr/share/licenses/inky-bird-frame/`. See
+[`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md) for component details.
+
 ## What runs
 
 Compose starts three services from the same image:
@@ -46,8 +50,9 @@ You need:
   billing; and
 - a controller address that the display Pi can reach on TCP 8793.
 
-Do not expose port 8793 to the public internet. It is an unauthenticated,
-read-only service intended for a trusted network.
+Do not expose port 8793 to the public internet. It serves a read-only catalog
+and accepts narrow, unauthenticated display-health reports on a trusted
+network.
 
 ## 1. Download the deployment bundle
 
@@ -256,11 +261,13 @@ secret.
 ```bash
 docker compose up --detach
 docker compose ps
+docker compose run --rm --no-deps controller --version
 curl --fail --silent http://127.0.0.1:8793/health
 docker compose logs --tail 100 scheduler
 ```
 
-The health response should contain `"ok": true`. The first scheduler pass
+The command and the health response identify the running application version.
+The health response should also contain `"ok": true`. The first scheduler pass
 refreshes observations before generation is allowed. `bootstrap` should finish
 with exit code zero; it safely checks the catalog again whenever Compose
 recreates the project.
@@ -318,6 +325,7 @@ docker compose pull
 docker compose run --rm --no-deps -T scheduler \
   config install --destination /data/config.toml < config.toml
 docker compose up --detach --remove-orphans --force-recreate
+docker compose run --rm --no-deps controller --version
 curl --fail --silent http://127.0.0.1:8793/health
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,7 +70,7 @@ CLI. The display requires `git`, `rsync`, and Pimoroni's Python environment.
 | --- | --- | --- |
 | Controller | Internet HTTPS (TCP 443) | Codex, internet-backed observation services and geocoder, licensed references, and configured research sources |
 | Controller | BirdNET-Go HTTP(S) endpoint | Read-only summaries from an explicitly configured self-hosted station |
-| Display node | Configured controller TCP port (8793 in the supplied example) | Read-only health, catalog, and image downloads |
+| Display node | Configured controller TCP port (8793 in the supplied example) | Health and catalog reads, image downloads, and narrow display-health reports |
 | Trusted browser application | Same-origin proxy, HTTPS endpoint, or controller HTTP port for an HTTP application | Optional read-only catalog and image downloads; an exact allowed origin is required when the request is cross-origin |
 | Application proxy or TLS terminator | Configured controller TCP port (8793 in the supplied example) | Server-side catalog and image requests; keep this hop on the trusted network |
 | Setup computer | Display node SSH (TCP 22) | Installation, updates, and troubleshooting |
@@ -82,8 +82,10 @@ the display stores its URL. The display itself may use ordinary DHCP because it
 initiates every application connection.
 
 Do not expose the configured controller port to the public internet. The
-built-in server is an unauthenticated, read-only LAN service. Use a VPN or an
-authenticated TLS reverse proxy if traffic must cross an untrusted network.
+built-in server is an unauthenticated LAN service. It serves the active catalog
+and accepts only narrow display-health reports; it does not provide user
+authentication. Use a VPN or an authenticated TLS reverse proxy if traffic must
+cross an untrusted network.
 
 The example configuration sets `controller.bind_host = "0.0.0.0"`, which
 listens on every interface of the controller host. On a multi-homed
@@ -104,22 +106,36 @@ cors_allowed_origins = ["https://frame.example.test"]
 An origin contains only the scheme, host, and optional port. Inky rejects
 wildcards, credentials, paths, queries, and fragments. Use an ASCII hostname
 or the canonical form of an IP address. Internationalized and punycode
-hostnames are not supported. A matching origin can read `GET
-/v1/catalog` and `GET /v1/assets/*`; health and display-heartbeat responses do
-not receive cross-origin access headers. Requests from other origins receive
-the normal response without an `Access-Control-Allow-Origin` header.
+hostnames are not supported. A matching origin can read `GET /v1/catalog` and
+the active catalog's portrait and display PNGs under `GET /v1/assets/`. Other
+catalog files, inactive plates, health, and display telemetry do not receive
+cross-origin access. Requests from other origins receive the normal response
+without an `Access-Control-Allow-Origin` header.
+
+The browser catalog includes active species identity, approval time, image
+paths and checksums, and any available observation count and latest-detection
+time. It does not include provider names, raw observations, locations,
+credentials, or private provider state. Browser reads never refresh the
+physical display's health signals. The server also verifies an active image's
+catalog checksum before it sends the file.
 
 This setting does not add authentication, TLS, or public-internet safety. Keep
-the controller private. Browsers also block an HTTPS application from fetching
-a plain-HTTP controller as mixed content. Prefer a same-origin application
-proxy, which needs no CORS permission and can authenticate the browser before
-making a server-side request to Inky. If the browser reaches the controller
-through a VPN, terminate HTTPS for the controller endpoint as well; the VPN
-alone does not prevent mixed content. Direct cross-origin access through cookie,
-session, client-certificate, or HTTP Authorization proxies is not compatible
-with this interface because Inky does not permit credentialed CORS requests or
-implement preflight. Standard `GET` requests need no preflight or custom request
-headers.
+the controller private. Prefer a same-origin application proxy, which needs no
+CORS permission and can authenticate the browser before making a server-side
+request to Inky. Direct public-HTTPS-to-local-network behavior varies by
+browser: the browser may block mixed content, ask for local-network permission,
+or allow only specific local address forms. A VPN does not make those browser
+rules consistent. Terminate HTTPS for the controller or use the same-origin
+proxy when you need a portable path.
+
+Direct cross-origin access through cookie, session, client-certificate, or HTTP
+Authorization proxies is not compatible with this interface. Inky does not
+permit credentialed CORS requests and does not implement CORS or Private
+Network Access preflight. Standard catalog `GET` requests use no custom request
+headers. The service logs each request locally with the source IP address,
+request path and query, and HTTP status. It does not log request headers or send
+browser analytics to an external service. Normal systemd journal or macOS log
+retention applies.
 
 ## 1. Install the controller
 
@@ -283,12 +299,15 @@ IBF="$HOME/Services/inky-bird-frame/.venv/bin/inky-bird-frame"
 curl --fail --silent "http://127.0.0.1:8793/health"
 ```
 
-The health response must have `"ok": true`. `approved_species` is the reusable
-catalog size. `active_species` is the approved subset currently observed in the
-configured window and radius or retained in the private collection. It may
-initially be zero in a region whose birds have not been generated yet. Both
-counts are read from the last built catalog index rather than a fresh catalog
-scan, so the endpoint stays fast as the catalog grows.
+The health response must have `"ok": true`. `version` identifies the running
+application. `approved_species` is the reusable catalog size. `active_species`
+is the approved subset currently observed in the configured window and radius
+or retained in the private collection. It may initially be zero in a region
+whose birds have not been generated yet. The approved count comes from the last
+built catalog index; the active count comes from current active-catalog state.
+The endpoint does not rebuild or scan the catalog, so it stays fast as the
+catalog grows. Run `"$IBF" --version` to identify the command-line installation
+directly.
 
 An existing controller can explicitly retain every currently approved plate
 after upgrading by previewing and applying `collection import-approved`; see
@@ -530,6 +549,18 @@ first. The active catalog wire format is `schema_version: 1`, and a display
 node refuses a catalog with a newer schema version: the cycle fails closed
 and the panel keeps its last image until the display is updated. Private
 collection membership does not change this wire schema.
+
+Current display nodes report a parsed catalog fetch through `POST
+/v1/display-fetch` and a verified panel update through `POST
+/v1/display-success`. The reports contain only `{"schema_version": 1}`. If an
+older controller rejects either POST, the display retries that report through
+the former GET contract after it has validated the catalog or completed the
+panel update. Display rotation therefore keeps working, and health reports
+continue, during a display-first update. For one compatibility release, the
+controller accepts `GET /v1/catalog?reports_success=1` and `GET
+/v1/display-success` only from clients with no `Origin` header and the fixed
+Inky display user agent. Those GET forms are deprecated and will be removed in
+the next feature release.
 
 Docker controller updates pull a published image and recreate the services. See
 the [Docker update instructions](docker.md#update) for version pinning and

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -61,17 +61,23 @@ Each destination has its own `events` list:
 | `display_recovered` | Display catalog fetches resume after a `display_stale` notice |
 
 The controller's HTTP server records the display's most recent catalog fetch
-in `display-last-fetch.json` and, when the display reports a completed update
-through `GET /v1/display-success`, the completion time in
-`display-last-success.json`, both under `state_dir`. Staleness is measured
+in `display-last-fetch.json` through `POST /v1/display-fetch` and records a
+completed update through `POST /v1/display-success` in
+`display-last-success.json`, both under `state_dir`. Each request contains only
+the fixed JSON object `{"schema_version": 1}`. Staleness is measured
 against completed updates: `display_stale` is raised when no update has
 completed for three times `schedule.rotation_minutes` (minimum 60 minutes),
 and also when a current display node keeps fetching the catalog without ever
 completing an update, so a panel that fails before its first success is still
-detected. Only display nodes refresh these signals; other catalog readers
-never mask a silent display. Display nodes that predate success reporting
-write no heartbeat and are not monitored until they are updated, so update
-display nodes first. `display_recovered` is sent once updates resume.
+detected. Ordinary catalog reads never refresh either signal or mask a silent
+display. Browser requests with an `Origin` header cannot write either signal.
+The endpoints are otherwise unauthenticated inside the trusted network, so a
+client that deliberately calls them can imitate a display node. For one
+compatibility release, older display nodes can also use the former GET marker
+and success route when they send the fixed Inky display user agent without an
+`Origin` header. Current displays use those routes only as a fallback when a
+telemetry POST fails. These GET forms are deprecated; update display nodes
+first. `display_recovered` is sent once updates resume.
 
 Routine successes do not notify. Transient failures notify only after
 `degradation_failure_threshold` consecutive failures or

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -493,7 +493,9 @@ only; they never enter the approved catalog or rotation.
   ancestry when an installation skips an intermediate release.
 - Controller unavailable: the current e-paper image remains visible. Display
   state is not advanced.
-- Checksum mismatch: the display refuses the asset and preserves current state.
+- Checksum mismatch: the controller refuses an active on-disk asset that no
+  longer matches its catalog digest. The display also verifies every downloaded
+  image and preserves its current state if that check fails.
 - Catalog publication failure: inspect `catalog-publish.log` for the structured
   command error; `catalog-publish.error.log` is reserved for process-level
   diagnostics. Run `gh auth status --hostname github.com` as the

--- a/src/inky_bird_frame/__init__.py
+++ b/src/inky_bird_frame/__init__.py
@@ -1,3 +1,16 @@
 """Local bird field-journal plates for Pimoroni Inky displays."""
 
-__version__ = "0.6.0"
+from importlib import metadata
+
+PACKAGE_NAME = "inky-bird-frame"
+
+
+def application_version() -> str:
+    """Return installed package metadata without failing in a source checkout."""
+    try:
+        return metadata.version(PACKAGE_NAME)
+    except metadata.PackageNotFoundError:
+        return "0+unknown"
+
+
+__version__ = application_version()

--- a/src/inky_bird_frame/cli.py
+++ b/src/inky_bird_frame/cli.py
@@ -15,6 +15,7 @@ from datetime import date
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
+from . import __version__
 from .birdbuddy import (
     AUTHORIZED_ACCESS_ATTESTATION,
     birdbuddy_status,
@@ -1506,6 +1507,7 @@ def build_parser() -> argparse.ArgumentParser:
         prog="inky-bird-frame",
         description="Generate, approve, serve, and display bird field-journal plates.",
     )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     setup_parser = subparsers.add_parser(

--- a/src/inky_bird_frame/display_node.py
+++ b/src/inky_bird_frame/display_node.py
@@ -18,7 +18,7 @@ from .catalog import CatalogEntry
 from .config import DisplayNodeConfig, RotationMode
 from .display import detect_inky_display, show_on_inky
 from .errors import CatalogError, DataSourceError
-from .http import get_bytes, get_json, write_bytes_atomic, write_json_atomic
+from .http import get_bytes, get_json, post_json, write_bytes_atomic, write_json_atomic
 from .selection import select_catalog_entry, select_shuffle_bag_entry
 from .timeutil import parse_utc_timestamp
 
@@ -305,10 +305,26 @@ def _evict_stale_cache_entries(current_image_path: Path, taxon_id: int) -> None:
                 stale.unlink(missing_ok=True)
 
 
-def _report_display_success(controller_url: str) -> None:
-    # Best-effort: the update already succeeded; an older controller returns 404.
+def _report_display_event(controller_url: str, event: str) -> None:
+    # Best-effort: retry the one-release GET contract when an older controller
+    # rejects the POST route. Both forms run only after the corresponding
+    # catalog or panel state has been verified.
+    try:
+        post_json(
+            f"{controller_url}/v1/display-{event}",
+            {"schema_version": 1},
+            10.0,
+        )
+        return
+    except DataSourceError:
+        pass
+    legacy_url = (
+        f"{controller_url}/v1/catalog?reports_success=1"
+        if event == "fetch"
+        else f"{controller_url}/v1/display-success"
+    )
     with suppress(DataSourceError):
-        get_json(f"{controller_url}/v1/display-success", 10.0)
+        get_json(legacy_url, 10.0)
 
 
 def run_display_cycle(
@@ -324,8 +340,9 @@ def run_display_cycle(
         state = _read_state(state_path)
         display = detect_inky_display()
         display_size = (display.width, display.height)
-        catalog_payload = get_json(f"{config.controller_url}/v1/catalog?reports_success=1", 20.0)
+        catalog_payload = get_json(f"{config.controller_url}/v1/catalog", 20.0)
         entries = parse_catalog_entries(catalog_payload)
+        _report_display_event(config.controller_url, "fetch")
         shuffle_remaining = list(state.shuffle_remaining)
         shuffle_bag_remaining = list(state.shuffle_bag_remaining)
         shuffle_bag_seen = list(state.shuffle_bag_seen)
@@ -405,7 +422,7 @@ def run_display_cycle(
             # is only ever recorded after a successful panel update, so the
             # current plate is verifiably on the panel; without this report a
             # single-species catalog would go stale despite being correct.
-            _report_display_success(config.controller_url)
+            _report_display_event(config.controller_url, "success")
             return {
                 "display_update": "unchanged",
                 "taxon_id": selected.taxon_id,
@@ -439,7 +456,7 @@ def run_display_cycle(
             last_display_size=display_size,
         )
         _evict_stale_cache_entries(image_path, selected.taxon_id)
-        _report_display_success(config.controller_url)
+        _report_display_event(config.controller_url, "success")
         return {
             "display_update": "sent",
             "taxon_id": selected.taxon_id,

--- a/src/inky_bird_frame/http.py
+++ b/src/inky_bird_frame/http.py
@@ -17,6 +17,7 @@ from .errors import DataSourceError
 
 MAX_JSON_BYTES = 8 * 1024 * 1024
 MAX_ASSET_BYTES = 64 * 1024 * 1024
+USER_AGENT = "inky-bird-frame/0.1"
 
 
 def _read_capped(response: HTTPResponse, limit: int, display_url: str) -> bytes:
@@ -93,7 +94,7 @@ def get_json(
     headers: Mapping[str, str] | None = None,
     error_label: str | None = None,
 ) -> object:
-    request_headers = {"User-Agent": "inky-bird-frame/0.1"}
+    request_headers = {"User-Agent": USER_AGENT}
     if headers is not None:
         request_headers.update(headers)
     display_url = error_label or url
@@ -129,7 +130,7 @@ def post_json(
     request_headers = {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "User-Agent": "inky-bird-frame/0.1",
+        "User-Agent": USER_AGENT,
     }
     if headers is not None:
         request_headers.update(headers)
@@ -160,7 +161,7 @@ def post_json(
 
 
 def get_bytes(url: str, timeout_seconds: float = 30.0) -> bytes:
-    request = _checked_request(url, {"User-Agent": "inky-bird-frame/0.1"})
+    request = _checked_request(url, {"User-Agent": USER_AGENT})
     try:
         with _OPENER.open(request, timeout=timeout_seconds) as response:
             return _read_capped(cast(HTTPResponse, response), MAX_ASSET_BYTES, url)

--- a/src/inky_bird_frame/notifications.py
+++ b/src/inky_bird_frame/notifications.py
@@ -419,10 +419,11 @@ def check_display_heartbeat(config: AppConfig, *, now: datetime | None = None) -
         stale = current - success_at > threshold
         described = f"completed a display update at {success_at.isoformat()}"
     else:
-        # Only display nodes write the fetch heartbeat, so fetches without a
-        # completed update mean every cycle fails after the catalog download;
-        # the incident failure threshold absorbs the window between a node's
-        # first fetch and its first success.
+        # The supported display client reports a fetch only after parsing the
+        # catalog. A fetch without a completed update therefore indicates a
+        # later cycle failure. Heartbeats are unauthenticated trusted-network
+        # health hints, not client identity proof; the incident failure
+        # threshold also absorbs the first-fetch-to-first-success window.
         assert fetched_at is not None
         signal = "catalog-fetch"
         seen_at = fetched_at

--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -241,6 +241,14 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
                 {"schema_version": 1, timestamp_field: utc_now()},
             )
         except OSError:
+            print(
+                json.dumps(
+                    {
+                        "event": "display_telemetry_write_failed",
+                        "file": filename,
+                    }
+                )
+            )
             return False
         return True
 
@@ -295,7 +303,13 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
                 {"ok": False, "error": "invalid JSON", "schema_version": 1},
             )
             return False
-        if payload != {"schema_version": 1}:
+        if (
+            not isinstance(payload, dict)
+            or set(payload) != {"schema_version"}
+            or not isinstance(payload.get("schema_version"), int)
+            or isinstance(payload.get("schema_version"), bool)
+            or payload["schema_version"] != 1
+        ):
             self._send_json(
                 HTTPStatus.BAD_REQUEST,
                 {"ok": False, "error": "invalid telemetry payload", "schema_version": 1},
@@ -330,13 +344,12 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
                 return
             # Compatibility bridge for one release. Only the fixed user agent
             # used by older display nodes can update physical-display health.
-            if (
-                self._is_legacy_display_request()
-                and parse_qs(split.query).get("reports_success") == ["1"]
-                and not self._record_display_event("display-last-fetch.json", "fetched_at")
-            ):
-                self._send_telemetry_unavailable()
-                return
+            if self._is_legacy_display_request() and parse_qs(split.query).get(
+                "reports_success"
+            ) == ["1"]:
+                # Legacy telemetry is best effort: a state-write failure must
+                # never withhold an otherwise valid catalog from the display.
+                self._record_display_event("display-last-fetch.json", "fetched_at")
             self._send_json(HTTPStatus.OK, payload, allow_browser_access=True)
             return
         if request_path == "/v1/display-success":
@@ -371,12 +384,14 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
             expected_sha256 = asset_hashes.get(relative_text)
             relative = Path(relative_text)
             root = self.catalog_dir.resolve()
-            candidate = (root / relative).resolve()
+            candidate = root / relative
+            resolved_candidate = candidate.resolve()
             if (
                 expected_sha256 is None
                 or relative.suffix.lower() != ".png"
                 or any(part.startswith(".") for part in relative.parts)
-                or not candidate.is_relative_to(root)
+                or not resolved_candidate.is_relative_to(root)
+                or resolved_candidate != candidate
                 or not candidate.is_file()
             ):
                 self._send_json(

--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -1,26 +1,154 @@
-"""Read-only HTTP service for approved catalog metadata and assets."""
+"""HTTP service for approved catalog reads and display-node health reports."""
 
 from __future__ import annotations
 
 import hashlib
 import json
-import mimetypes
-from contextlib import suppress
+import re
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from urllib.parse import parse_qs, unquote, urlsplit
 
+from . import __version__
 from .catalog import read_json, rebuild_catalog_index, utc_now
 from .config import ControllerConfig
 from .errors import CatalogError
-from .http import write_json_atomic
+from .http import USER_AGENT, write_json_atomic
+from .images import slugify
+from .timeutil import parse_utc_timestamp
+
+CATALOG_SCHEMA_VERSION = 1
+MAX_TELEMETRY_REQUEST_BYTES = 1024
+_SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+_CATALOG_STRING_FIELDS = (
+    "common_name",
+    "scientific_name",
+    "slug",
+    "portrait_path",
+    "portrait_sha256",
+    "display_path",
+    "display_sha256",
+    "approved_at",
+)
+
+
+def _catalog_asset_path(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        raise CatalogError(f"Active catalog entry has invalid {field}")
+    path = PurePosixPath(value)
+    if (
+        not value
+        or "\\" in value
+        or path.is_absolute()
+        or path.as_posix() != value
+        or path.suffix.lower() != ".png"
+        or any(part in {"", ".", ".."} or part.startswith(".") for part in path.parts)
+    ):
+        raise CatalogError(f"Active catalog entry has invalid {field}")
+    return value
+
+
+def _project_active_catalog(payload: object) -> tuple[dict[str, object], dict[str, str]]:
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema_version") != CATALOG_SCHEMA_VERSION
+        or isinstance(payload.get("schema_version"), bool)
+    ):
+        raise CatalogError("Active catalog has an unsupported schema")
+    generated_at = payload.get("generated_at")
+    if not isinstance(generated_at, str) or parse_utc_timestamp(generated_at) is None:
+        raise CatalogError("Active catalog has an invalid generated timestamp")
+    raw_species = payload.get("species")
+    if not isinstance(raw_species, list):
+        raise CatalogError("Active catalog has no species list")
+
+    species: list[dict[str, object]] = []
+    asset_hashes: dict[str, str] = {}
+    taxon_ids: set[int] = set()
+    for raw in raw_species:
+        if not isinstance(raw, dict):
+            raise CatalogError("Active catalog entry must be an object")
+        taxon_id = raw.get("taxon_id")
+        if (
+            not isinstance(taxon_id, int)
+            or isinstance(taxon_id, bool)
+            or taxon_id <= 0
+            or taxon_id in taxon_ids
+        ):
+            raise CatalogError("Active catalog entry has an invalid or duplicate taxon ID")
+        taxon_ids.add(taxon_id)
+
+        strings = {field: raw.get(field) for field in _CATALOG_STRING_FIELDS}
+        if any(not isinstance(value, str) or not value for value in strings.values()):
+            raise CatalogError("Active catalog entry has invalid fields")
+        slug = strings["slug"]
+        if not isinstance(slug, str) or slugify(slug) != slug:
+            raise CatalogError("Active catalog entry has an invalid slug")
+        portrait_path = _catalog_asset_path(strings["portrait_path"], "portrait path")
+        display_path = _catalog_asset_path(strings["display_path"], "display path")
+        species_directory = f"species/{taxon_id}-{slug}"
+        if (
+            portrait_path != f"{species_directory}/portrait.png"
+            or display_path != f"{species_directory}/display.png"
+        ):
+            raise CatalogError("Active catalog entry has noncanonical asset paths")
+        portrait_sha256 = strings["portrait_sha256"]
+        display_sha256 = strings["display_sha256"]
+        if (
+            not isinstance(portrait_sha256, str)
+            or _SHA256_PATTERN.fullmatch(portrait_sha256) is None
+            or not isinstance(display_sha256, str)
+            or _SHA256_PATTERN.fullmatch(display_sha256) is None
+        ):
+            raise CatalogError("Active catalog entry has an invalid asset checksum")
+        approved_at = strings["approved_at"]
+        if not isinstance(approved_at, str) or parse_utc_timestamp(approved_at) is None:
+            raise CatalogError("Active catalog entry has an invalid approval timestamp")
+
+        entry: dict[str, object] = {"taxon_id": taxon_id}
+        entry.update(strings)
+        if "observation_count" in raw:
+            observation_count = raw["observation_count"]
+            if (
+                not isinstance(observation_count, int)
+                or isinstance(observation_count, bool)
+                or observation_count < 0
+            ):
+                raise CatalogError("Active catalog entry has an invalid observation count")
+            entry["observation_count"] = observation_count
+        if "latest_detection_at" in raw:
+            latest_detection_at = raw["latest_detection_at"]
+            if (
+                not isinstance(latest_detection_at, str)
+                or parse_utc_timestamp(latest_detection_at) is None
+            ):
+                raise CatalogError("Active catalog entry has an invalid detection timestamp")
+            entry["latest_detection_at"] = latest_detection_at
+
+        for path, digest in (
+            (portrait_path, portrait_sha256),
+            (display_path, display_sha256),
+        ):
+            prior_digest = asset_hashes.setdefault(path, digest)
+            if prior_digest != digest:
+                raise CatalogError("Active catalog assigns conflicting checksums to one asset")
+        species.append(entry)
+
+    return (
+        {
+            "schema_version": CATALOG_SCHEMA_VERSION,
+            "generated_at": generated_at,
+            "species": species,
+        },
+        asset_hashes,
+    )
 
 
 def _species_count(path: Path) -> int:
     try:
         value = read_json(path)
-    except CatalogError:
+    except (CatalogError, OSError):
         return 0
     if isinstance(value, dict) and isinstance(value.get("species"), list):
         return len(value["species"])
@@ -32,6 +160,17 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
     active_catalog_path: Path
     state_dir: Path
     cors_allowed_origins: tuple[str, ...] = ()
+
+    def _has_origin(self) -> bool:
+        return bool(self.headers.get_all("Origin", failobj=[]))
+
+    def _is_legacy_display_request(self) -> bool:
+        return not self._has_origin() and self.headers.get_all("User-Agent", failobj=[]) == [
+            USER_AGENT
+        ]
+
+    def _load_active_catalog(self) -> tuple[dict[str, object], dict[str, str]]:
+        return _project_active_catalog(read_json(self.active_catalog_path))
 
     def _send_browser_access_headers(self) -> None:
         if not self.cors_allowed_origins:
@@ -53,18 +192,40 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Cache-Control", "no-store")
+        self.send_header("X-Content-Type-Options", "nosniff")
         if allow_browser_access:
             self._send_browser_access_headers()
         self.end_headers()
         self.wfile.write(body)
 
-    def _send_file(self, path: Path, requested_sha256: list[str] | None) -> None:
-        body = path.read_bytes()
-        content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
-        content_addressed = requested_sha256 == [hashlib.sha256(body).hexdigest()]
+    def _send_file(
+        self,
+        path: Path,
+        requested_sha256: list[str] | None,
+        expected_sha256: str,
+    ) -> None:
+        try:
+            body = path.read_bytes()
+        except OSError:
+            self._send_json(
+                HTTPStatus.SERVICE_UNAVAILABLE,
+                {"ok": False, "error": "active asset unavailable", "schema_version": 1},
+                allow_browser_access=True,
+            )
+            return
+        actual_sha256 = hashlib.sha256(body).hexdigest()
+        if actual_sha256 != expected_sha256:
+            self._send_json(
+                HTTPStatus.SERVICE_UNAVAILABLE,
+                {"ok": False, "error": "active asset unavailable", "schema_version": 1},
+                allow_browser_access=True,
+            )
+            return
+        content_addressed = requested_sha256 == [expected_sha256]
         self.send_response(HTTPStatus.OK)
-        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Type", "image/png")
         self.send_header("Content-Length", str(len(body)))
+        self.send_header("X-Content-Type-Options", "nosniff")
         self._send_browser_access_headers()
         self.send_header(
             "Cache-Control",
@@ -72,6 +233,75 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
         )
         self.end_headers()
         self.wfile.write(body)
+
+    def _record_display_event(self, filename: str, timestamp_field: str) -> bool:
+        try:
+            write_json_atomic(
+                self.state_dir / filename,
+                {"schema_version": 1, timestamp_field: utc_now()},
+            )
+        except OSError:
+            return False
+        return True
+
+    def _send_telemetry_unavailable(self) -> None:
+        self._send_json(
+            HTTPStatus.SERVICE_UNAVAILABLE,
+            {"ok": False, "error": "display telemetry unavailable", "schema_version": 1},
+        )
+
+    def _read_telemetry_payload(self) -> bool:
+        if self._has_origin():
+            self._send_json(
+                HTTPStatus.FORBIDDEN,
+                {"ok": False, "error": "browser telemetry is not accepted", "schema_version": 1},
+            )
+            return False
+        media_type = self.headers.get("Content-Type", "").partition(";")[0].strip().lower()
+        if media_type != "application/json":
+            self._send_json(
+                HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
+                {"ok": False, "error": "expected application/json", "schema_version": 1},
+            )
+            return False
+        lengths = self.headers.get_all("Content-Length", failobj=[])
+        if len(lengths) != 1:
+            self._send_json(
+                HTTPStatus.LENGTH_REQUIRED,
+                {"ok": False, "error": "content length required", "schema_version": 1},
+            )
+            return False
+        try:
+            content_length = int(lengths[0])
+        except ValueError:
+            content_length = -1
+        if content_length < 0:
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                {"ok": False, "error": "invalid content length", "schema_version": 1},
+            )
+            return False
+        if content_length > MAX_TELEMETRY_REQUEST_BYTES:
+            self._send_json(
+                HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                {"ok": False, "error": "request body too large", "schema_version": 1},
+            )
+            return False
+        try:
+            payload = json.loads(self.rfile.read(content_length))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                {"ok": False, "error": "invalid JSON", "schema_version": 1},
+            )
+            return False
+        if payload != {"schema_version": 1}:
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                {"ok": False, "error": "invalid telemetry payload", "schema_version": 1},
+            )
+            return False
+        return True
 
     def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
         split = urlsplit(self.path)
@@ -83,45 +313,69 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
                     "ok": True,
                     "approved_species": _species_count(self.catalog_dir / "index.json"),
                     "active_species": _species_count(self.active_catalog_path),
+                    "version": __version__,
                     "schema_version": 1,
                 },
             )
             return
         if request_path == "/v1/catalog":
             try:
-                payload = read_json(self.active_catalog_path)
-            except CatalogError:
+                payload, _asset_hashes = self._load_active_catalog()
+            except (CatalogError, OSError):
                 self._send_json(
                     HTTPStatus.SERVICE_UNAVAILABLE,
                     {"ok": False, "error": "active catalog unavailable", "schema_version": 1},
                     allow_browser_access=True,
                 )
                 return
-            # Only display nodes send the marker; a curl or monitor fetch must
-            # not refresh the liveness signal.
-            if parse_qs(split.query).get("reports_success") == ["1"]:
-                with suppress(OSError):
-                    write_json_atomic(
-                        self.state_dir / "display-last-fetch.json",
-                        {"schema_version": 1, "fetched_at": utc_now()},
-                    )
+            # Compatibility bridge for one release. Only the fixed user agent
+            # used by older display nodes can update physical-display health.
+            if (
+                self._is_legacy_display_request()
+                and parse_qs(split.query).get("reports_success") == ["1"]
+                and not self._record_display_event("display-last-fetch.json", "fetched_at")
+            ):
+                self._send_telemetry_unavailable()
+                return
             self._send_json(HTTPStatus.OK, payload, allow_browser_access=True)
             return
         if request_path == "/v1/display-success":
-            with suppress(OSError):
-                write_json_atomic(
-                    self.state_dir / "display-last-success.json",
-                    {"schema_version": 1, "succeeded_at": utc_now()},
+            if not self._is_legacy_display_request():
+                self._send_json(
+                    HTTPStatus.FORBIDDEN,
+                    {
+                        "ok": False,
+                        "error": "browser telemetry is not accepted",
+                        "schema_version": 1,
+                    },
                 )
+                return
+            # Compatibility bridge for one release. New display nodes use POST.
+            if not self._record_display_event("display-last-success.json", "succeeded_at"):
+                self._send_telemetry_unavailable()
+                return
             self._send_json(HTTPStatus.OK, {"ok": True, "schema_version": 1})
             return
         prefix = "/v1/assets/"
         if request_path.startswith(prefix):
-            relative = Path(unquote(request_path.removeprefix(prefix)))
+            relative_text = unquote(request_path.removeprefix(prefix))
+            try:
+                _payload, asset_hashes = self._load_active_catalog()
+            except (CatalogError, OSError):
+                self._send_json(
+                    HTTPStatus.SERVICE_UNAVAILABLE,
+                    {"ok": False, "error": "active catalog unavailable", "schema_version": 1},
+                    allow_browser_access=True,
+                )
+                return
+            expected_sha256 = asset_hashes.get(relative_text)
+            relative = Path(relative_text)
             root = self.catalog_dir.resolve()
             candidate = (root / relative).resolve()
             if (
-                any(part.startswith(".") for part in relative.parts)
+                expected_sha256 is None
+                or relative.suffix.lower() != ".png"
+                or any(part.startswith(".") for part in relative.parts)
                 or not candidate.is_relative_to(root)
                 or not candidate.is_file()
             ):
@@ -131,9 +385,30 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
                     allow_browser_access=True,
                 )
                 return
-            self._send_file(candidate, parse_qs(split.query).get("sha256"))
+            self._send_file(
+                candidate,
+                parse_qs(split.query).get("sha256"),
+                expected_sha256,
+            )
             return
         self._send_json(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not found"})
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        request_path = urlsplit(self.path).path
+        events = {
+            "/v1/display-fetch": ("display-last-fetch.json", "fetched_at"),
+            "/v1/display-success": ("display-last-success.json", "succeeded_at"),
+        }
+        event = events.get(request_path)
+        if event is None:
+            self._send_json(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not found"})
+            return
+        if not self._read_telemetry_payload():
+            return
+        if not self._record_display_event(*event):
+            self._send_telemetry_unavailable()
+            return
+        self._send_json(HTTPStatus.OK, {"ok": True, "schema_version": 1})
 
     def log_message(self, message_format: str, *args: object) -> None:
         message = message_format % args

--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -52,6 +52,7 @@ def _catalog_asset_path(value: object, field: str) -> str:
 def _project_active_catalog(payload: object) -> tuple[dict[str, object], dict[str, str]]:
     if (
         not isinstance(payload, dict)
+        or not isinstance(payload.get("schema_version"), int)
         or payload.get("schema_version") != CATALOG_SCHEMA_VERSION
         or isinstance(payload.get("schema_version"), bool)
     ):
@@ -382,13 +383,27 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
                 )
                 return
             expected_sha256 = asset_hashes.get(relative_text)
-            relative = Path(relative_text)
-            root = self.catalog_dir.resolve()
-            candidate = root / relative
-            resolved_candidate = candidate.resolve()
+            if expected_sha256 is None:
+                self._send_json(
+                    HTTPStatus.NOT_FOUND,
+                    {"ok": False, "error": "not found"},
+                    allow_browser_access=True,
+                )
+                return
+            try:
+                relative = Path(relative_text)
+                root = self.catalog_dir.resolve()
+                candidate = root / relative
+                resolved_candidate = candidate.resolve()
+            except (OSError, RuntimeError, ValueError):
+                self._send_json(
+                    HTTPStatus.NOT_FOUND,
+                    {"ok": False, "error": "not found"},
+                    allow_browser_access=True,
+                )
+                return
             if (
-                expected_sha256 is None
-                or relative.suffix.lower() != ".png"
+                relative.suffix.lower() != ".png"
                 or any(part.startswith(".") for part in relative.parts)
                 or not resolved_candidate.is_relative_to(root)
                 or resolved_candidate != candidate

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ from argparse import Namespace
 from collections.abc import Iterator
 from contextlib import contextmanager, redirect_stdout
 from datetime import UTC, date, datetime
+from importlib import metadata
 from importlib.metadata import version
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -364,6 +365,21 @@ class CliTests(unittest.TestCase):
 
     def test_runtime_version_matches_package_metadata(self) -> None:
         self.assertEqual(inky_bird_frame.__version__, version("inky-bird-frame"))
+
+    def test_source_checkout_version_falls_back_safely(self) -> None:
+        with patch(
+            "inky_bird_frame.metadata.version",
+            side_effect=metadata.PackageNotFoundError,
+        ):
+            self.assertEqual(inky_bird_frame.application_version(), "0+unknown")
+
+    def test_version_flag_reports_application_version(self) -> None:
+        output = io.StringIO()
+        with redirect_stdout(output), self.assertRaises(SystemExit) as raised:
+            main(["--version"])
+
+        self.assertEqual(raised.exception.code, 0)
+        self.assertEqual(output.getvalue(), f"inky-bird-frame {inky_bird_frame.__version__}\n")
 
     def test_status_requires_explicit_config(self) -> None:
         args = build_parser().parse_args(["status", "--config", "instance.toml"])

--- a/tests/test_display_node.py
+++ b/tests/test_display_node.py
@@ -13,7 +13,7 @@ from urllib.parse import urlsplit
 
 from inky_bird_frame.config import DisplayNodeConfig, RotationMode
 from inky_bird_frame.display_node import _read_state, parse_catalog_entries, run_display_cycle
-from inky_bird_frame.errors import CatalogError
+from inky_bird_frame.errors import CatalogError, DataSourceError
 
 
 def catalog_payload(images: dict[int, bytes]) -> dict[str, object]:
@@ -47,11 +47,17 @@ def asset_response(images: dict[int, bytes]) -> Callable[[str, float], bytes]:
 class DisplayNodeTests(unittest.TestCase):
     def setUp(self) -> None:
         self.display = SimpleNamespace(width=1600, height=1200)
-        patcher = patch(
+        display_patcher = patch(
             "inky_bird_frame.display_node.detect_inky_display", return_value=self.display
         )
-        patcher.start()
-        self.addCleanup(patcher.stop)
+        display_patcher.start()
+        self.addCleanup(display_patcher.stop)
+        telemetry_patcher = patch(
+            "inky_bird_frame.display_node.post_json",
+            return_value={"ok": True, "schema_version": 1},
+        )
+        self.post_json = telemetry_patcher.start()
+        self.addCleanup(telemetry_patcher.stop)
 
     def test_downloads_verifies_displays_then_skips_unchanged_single_plate(self) -> None:
         image = b"display-image"
@@ -165,42 +171,87 @@ class DisplayNodeTests(unittest.TestCase):
 
     def test_successful_cycle_reports_display_success(self) -> None:
         payload = catalog_payload({1: b"one"})
-        requested: list[str] = []
-
-        def fake_get_json(url: str, timeout: float) -> object:
-            requested.append(url)
-            return payload if "/v1/catalog" in url else {"ok": True}
 
         with TemporaryDirectory() as temporary:
             config = DisplayNodeConfig("http://controller.test", Path(temporary))
             with (
-                patch("inky_bird_frame.display_node.get_json", side_effect=fake_get_json),
+                patch("inky_bird_frame.display_node.get_json", return_value=payload) as get_json,
                 patch("inky_bird_frame.display_node.get_bytes", return_value=b"one"),
                 patch("inky_bird_frame.display_node.show_on_inky", return_value=(1600, 1200)),
             ):
                 run_display_cycle(config)
 
-        self.assertEqual(requested[-1], "http://controller.test/v1/display-success")
+        get_json.assert_called_once_with("http://controller.test/v1/catalog", 20.0)
+        self.assertEqual(
+            [call.args for call in self.post_json.call_args_list],
+            [
+                (
+                    "http://controller.test/v1/display-fetch",
+                    {"schema_version": 1},
+                    10.0,
+                ),
+                (
+                    "http://controller.test/v1/display-success",
+                    {"schema_version": 1},
+                    10.0,
+                ),
+            ],
+        )
 
     def test_failed_cycle_does_not_report_display_success(self) -> None:
         payload = catalog_payload({1: b"one"})
-        requested: list[str] = []
-
-        def fake_get_json(url: str, timeout: float) -> object:
-            requested.append(url)
-            return payload
 
         with TemporaryDirectory() as temporary:
             config = DisplayNodeConfig("http://controller.test", Path(temporary))
             with (
-                patch("inky_bird_frame.display_node.get_json", side_effect=fake_get_json),
+                patch("inky_bird_frame.display_node.get_json", return_value=payload),
                 patch("inky_bird_frame.display_node.get_bytes", return_value=b"tampered"),
                 patch("inky_bird_frame.display_node.show_on_inky"),
                 self.assertRaisesRegex(CatalogError, "checksum mismatch"),
             ):
                 run_display_cycle(config)
 
-        self.assertEqual([url for url in requested if url.endswith("/v1/display-success")], [])
+        self.assertEqual(
+            [call.args[0] for call in self.post_json.call_args_list],
+            ["http://controller.test/v1/display-fetch"],
+        )
+
+    def test_invalid_catalog_does_not_report_display_fetch(self) -> None:
+        with TemporaryDirectory() as temporary:
+            config = DisplayNodeConfig("http://controller.test", Path(temporary))
+            with (
+                patch(
+                    "inky_bird_frame.display_node.get_json",
+                    return_value={"schema_version": 1, "species": "invalid"},
+                ),
+                self.assertRaisesRegex(CatalogError, "no species list"),
+            ):
+                run_display_cycle(config)
+
+        self.post_json.assert_not_called()
+
+    def test_older_controller_without_post_telemetry_does_not_block_display(self) -> None:
+        payload = catalog_payload({1: b"one"})
+        self.post_json.side_effect = DataSourceError("HTTP 501 from controller")
+        with TemporaryDirectory() as temporary:
+            config = DisplayNodeConfig("http://controller.test", Path(temporary))
+            with (
+                patch("inky_bird_frame.display_node.get_json", return_value=payload) as get_json,
+                patch("inky_bird_frame.display_node.get_bytes", return_value=b"one"),
+                patch("inky_bird_frame.display_node.show_on_inky", return_value=(1600, 1200)),
+            ):
+                result = run_display_cycle(config)
+
+        self.assertEqual(result["display_update"], "sent")
+        self.assertEqual(self.post_json.call_count, 2)
+        self.assertEqual(
+            [call.args for call in get_json.call_args_list],
+            [
+                ("http://controller.test/v1/catalog", 20.0),
+                ("http://controller.test/v1/catalog?reports_success=1", 10.0),
+                ("http://controller.test/v1/display-success", 10.0),
+            ],
+        )
 
     def test_unsupported_hardware_fails_before_controller_fetch(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,19 +1,56 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 import threading
 import unittest
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stdout
 from http.client import HTTPConnection
 from http.server import ThreadingHTTPServer
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
-from inky_bird_frame.server import CatalogRequestHandler, rebuild_index_logging_failures
+from inky_bird_frame import __version__
+from inky_bird_frame.http import USER_AGENT
+from inky_bird_frame.server import (
+    MAX_TELEMETRY_REQUEST_BYTES,
+    CatalogRequestHandler,
+    rebuild_index_logging_failures,
+)
 
 PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+GENERATED_AT = "2026-08-30T12:00:00+00:00"
+
+
+def _catalog_entry(
+    *,
+    taxon_id: int = 1,
+    directory: str = "species/1-robin",
+    image: bytes = PNG_BYTES,
+) -> dict[str, object]:
+    digest = hashlib.sha256(image).hexdigest()
+    return {
+        "taxon_id": taxon_id,
+        "common_name": "Robin",
+        "scientific_name": "Turdus migratorius",
+        "slug": "robin",
+        "portrait_path": f"{directory}/portrait.png",
+        "portrait_sha256": digest,
+        "display_path": f"{directory}/display.png",
+        "display_sha256": digest,
+        "approved_at": "2026-07-10T00:00:00+00:00",
+    }
+
+
+def _active_catalog(*species: dict[str, object]) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "generated_at": GENERATED_AT,
+        "species": list(species),
+    }
 
 
 @contextmanager
@@ -57,6 +94,41 @@ def _get(
         connection.close()
 
 
+def _post(
+    port: int,
+    path: str,
+    *,
+    body: bytes = b'{"schema_version": 1}',
+    headers: dict[str, str] | None = None,
+) -> tuple[int, dict[str, str], bytes]:
+    request_headers = {"Content-Type": "application/json", **(headers or {})}
+    connection = HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        connection.request("POST", path, body=body, headers=request_headers)
+        response = connection.getresponse()
+        return response.status, dict(response.getheaders()), response.read()
+    finally:
+        connection.close()
+
+
+def _post_with_content_length(
+    port: int,
+    path: str,
+    content_length: str | None,
+) -> tuple[int, dict[str, str], bytes]:
+    connection = HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        connection.putrequest("POST", path)
+        connection.putheader("Content-Type", "application/json")
+        if content_length is not None:
+            connection.putheader("Content-Length", content_length)
+        connection.endheaders()
+        response = connection.getresponse()
+        return response.status, dict(response.getheaders()), response.read()
+    finally:
+        connection.close()
+
+
 class ServerTests(unittest.TestCase):
     @contextmanager
     def _environment(self) -> Iterator[tuple[Path, Path, Path]]:
@@ -71,7 +143,7 @@ class ServerTests(unittest.TestCase):
     def test_active_catalog_is_not_cached_as_an_immutable_asset(self) -> None:
         with self._environment() as (_, catalog_dir, state_dir):
             active_catalog_path = state_dir / "active-catalog.json"
-            active_catalog_path.write_text(json.dumps({"schema_version": 1, "species": []}))
+            active_catalog_path.write_text(json.dumps(_active_catalog()))
             with _serving(catalog_dir, active_catalog_path, state_dir) as port:
                 status, headers, _ = _get(port, "/v1/catalog")
 
@@ -81,7 +153,7 @@ class ServerTests(unittest.TestCase):
     def test_browser_access_is_disabled_by_default(self) -> None:
         with self._environment() as (_, catalog_dir, state_dir):
             active_catalog_path = state_dir / "active-catalog.json"
-            active_catalog_path.write_text(json.dumps({"schema_version": 1, "species": []}))
+            active_catalog_path.write_text(json.dumps(_active_catalog()))
             with _serving(catalog_dir, active_catalog_path, state_dir) as port:
                 status, headers, _ = _get(
                     port,
@@ -97,7 +169,7 @@ class ServerTests(unittest.TestCase):
         trusted_origin = "https://display.example.test"
         with self._environment() as (_, catalog_dir, state_dir):
             active_catalog_path = state_dir / "active-catalog.json"
-            active_catalog_path.write_text(json.dumps({"schema_version": 1, "species": []}))
+            active_catalog_path.write_text(json.dumps(_active_catalog(_catalog_entry())))
             asset = catalog_dir / "species" / "1-robin" / "portrait.png"
             asset.parent.mkdir(parents=True)
             asset.write_bytes(PNG_BYTES)
@@ -128,7 +200,7 @@ class ServerTests(unittest.TestCase):
     def test_untrusted_browser_origin_is_not_allowed(self) -> None:
         with self._environment() as (_, catalog_dir, state_dir):
             active_catalog_path = state_dir / "active-catalog.json"
-            active_catalog_path.write_text(json.dumps({"schema_version": 1, "species": []}))
+            active_catalog_path.write_text(json.dumps(_active_catalog()))
             with _serving(
                 catalog_dir,
                 active_catalog_path,
@@ -145,7 +217,7 @@ class ServerTests(unittest.TestCase):
         self.assertNotIn("Access-Control-Allow-Origin", headers)
         self.assertEqual(headers.get("Vary"), "Origin")
 
-    def test_browser_access_does_not_cover_health_or_display_heartbeat(self) -> None:
+    def test_browser_access_does_not_cover_health_or_display_telemetry(self) -> None:
         trusted_origin = "https://display.example.test"
         with (
             self._environment() as (_, catalog_dir, state_dir),
@@ -161,16 +233,82 @@ class ServerTests(unittest.TestCase):
                 "/health",
                 headers={"Origin": trusted_origin},
             )
-            heartbeat_status, heartbeat_headers, _ = _get(
+            heartbeat_status, heartbeat_headers, _ = _post(
                 port,
                 "/v1/display-success",
                 headers={"Origin": trusted_origin},
             )
+            legacy_status, _, _ = _get(
+                port,
+                "/v1/display-success",
+                headers={"Origin": trusted_origin},
+            )
+            heartbeat_written = (state_dir / "display-last-success.json").exists()
 
         self.assertEqual(health_status, 200)
         self.assertNotIn("Access-Control-Allow-Origin", health_headers)
-        self.assertEqual(heartbeat_status, 200)
+        self.assertEqual(heartbeat_status, 403)
+        self.assertEqual(legacy_status, 403)
         self.assertNotIn("Access-Control-Allow-Origin", heartbeat_headers)
+        self.assertFalse(heartbeat_written)
+
+    def test_catalog_projects_only_documented_v1_fields(self) -> None:
+        entry = _catalog_entry()
+        entry.update(
+            {
+                "observation_count": 7,
+                "latest_detection_at": "2026-08-30T11:45:00+00:00",
+                "provider": "private-provider",
+            }
+        )
+        active = _active_catalog(entry)
+        active["internal_state"] = "private"
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(active))
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                status, headers, body = _get(port, "/v1/catalog")
+
+        payload = json.loads(body)
+        self.assertEqual(status, 200)
+        self.assertEqual(set(payload), {"schema_version", "generated_at", "species"})
+        self.assertEqual(
+            set(payload["species"][0]),
+            {
+                "taxon_id",
+                "common_name",
+                "scientific_name",
+                "slug",
+                "portrait_path",
+                "portrait_sha256",
+                "display_path",
+                "display_sha256",
+                "approved_at",
+                "observation_count",
+                "latest_detection_at",
+            },
+        )
+        self.assertEqual(payload["species"][0]["observation_count"], 7)
+        self.assertEqual(
+            payload["species"][0]["latest_detection_at"],
+            "2026-08-30T11:45:00+00:00",
+        )
+        self.assertEqual(headers.get("X-Content-Type-Options"), "nosniff")
+
+    def test_catalog_fails_closed_when_documented_fields_are_invalid(self) -> None:
+        invalid = _catalog_entry()
+        invalid["portrait_path"] = "species/1-robin/manifest.json"
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog(invalid)))
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                status, _, body = _get(port, "/v1/catalog")
+
+        self.assertEqual(status, 503)
+        self.assertEqual(
+            json.loads(body),
+            {"ok": False, "error": "active catalog unavailable", "schema_version": 1},
+        )
 
     def test_non_utf8_state_files_degrade_gracefully(self) -> None:
         with self._environment() as (_, catalog_dir, state_dir):
@@ -212,13 +350,15 @@ class ServerTests(unittest.TestCase):
 
     def test_staging_and_dot_paths_are_never_served(self) -> None:
         with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog()))
             staged = catalog_dir / ".staging" / "1-robin"
             staged.mkdir(parents=True)
             (staged / "manifest.json").write_text("{}")
             hidden = catalog_dir / "species" / ".hidden.png"
             hidden.parent.mkdir(parents=True)
             hidden.write_bytes(b"secret")
-            with _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port:
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
                 staging_status, _, staging_body = _get(
                     port, "/v1/assets/.staging/1-robin/manifest.json"
                 )
@@ -228,10 +368,14 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(hidden_status, 404)
         self.assertNotIn(b"{}", staging_body)
 
-    def test_display_success_report_is_recorded(self) -> None:
+    def test_legacy_display_success_get_without_origin_is_recorded(self) -> None:
         with self._environment() as (_, catalog_dir, state_dir):
             with _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port:
-                status, _, body = _get(port, "/v1/display-success")
+                status, _, body = _get(
+                    port,
+                    "/v1/display-success",
+                    headers={"User-Agent": USER_AGENT},
+                )
 
             recorded = json.loads((state_dir / "display-last-success.json").read_text())
 
@@ -242,24 +386,29 @@ class ServerTests(unittest.TestCase):
 
     def test_asset_is_served_with_png_content_type(self) -> None:
         with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog(_catalog_entry())))
             asset = catalog_dir / "species" / "1-robin" / "portrait.png"
             asset.parent.mkdir(parents=True)
             asset.write_bytes(PNG_BYTES)
-            with _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port:
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
                 status, headers, body = _get(port, "/v1/assets/species/1-robin/portrait.png")
 
         self.assertEqual(status, 200)
         self.assertEqual(headers.get("Content-Type"), "image/png")
         self.assertEqual(headers.get("Cache-Control"), "no-cache")
+        self.assertEqual(headers.get("X-Content-Type-Options"), "nosniff")
         self.assertEqual(body, PNG_BYTES)
 
     def test_content_addressed_asset_is_immutable(self) -> None:
         with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog(_catalog_entry())))
             asset = catalog_dir / "species" / "1-robin" / "portrait.png"
             asset.parent.mkdir(parents=True)
             asset.write_bytes(PNG_BYTES)
             digest = hashlib.sha256(PNG_BYTES).hexdigest()
-            with _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port:
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
                 status, headers, body = _get(
                     port,
                     f"/v1/assets/species/1-robin/portrait.png?sha256={digest}",
@@ -269,11 +418,88 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(headers.get("Cache-Control"), "public, max-age=86400, immutable")
         self.assertEqual(body, PNG_BYTES)
 
+    def test_unlisted_catalog_files_and_inactive_pngs_are_not_served(self) -> None:
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog(_catalog_entry())))
+            species_dir = catalog_dir / "species" / "1-robin"
+            species_dir.mkdir(parents=True)
+            (species_dir / "manifest.json").write_text('{"private": true}')
+            (species_dir / "quality-review.json").write_text('{"private": true}')
+            (species_dir / "inactive.png").write_bytes(PNG_BYTES)
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                for path in (
+                    "/v1/assets/species/1-robin/manifest.json",
+                    "/v1/assets/species/1-robin/quality-review.json",
+                    "/v1/assets/species/1-robin/inactive.png",
+                ):
+                    status, _, body = _get(port, path)
+                    self.assertEqual(status, 404, path)
+                    self.assertNotIn(b"private", body, path)
+
+    def test_active_state_cannot_allowlist_a_noncanonical_png(self) -> None:
+        entry = _catalog_entry()
+        entry["portrait_path"] = "species/1-robin/inactive.png"
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog(entry)))
+            inactive = catalog_dir / "species" / "1-robin" / "inactive.png"
+            inactive.parent.mkdir(parents=True)
+            inactive.write_bytes(PNG_BYTES)
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                catalog_status, _, _ = _get(port, "/v1/catalog")
+                asset_status, _, asset_body = _get(
+                    port,
+                    "/v1/assets/species/1-robin/inactive.png",
+                )
+
+        self.assertEqual(catalog_status, 503)
+        self.assertEqual(asset_status, 503)
+        self.assertNotIn(PNG_BYTES, asset_body)
+
+    def test_active_asset_checksum_mismatch_never_returns_file_bytes(self) -> None:
+        corrupted = b"corrupted image bytes"
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog(_catalog_entry())))
+            asset = catalog_dir / "species" / "1-robin" / "portrait.png"
+            asset.parent.mkdir(parents=True)
+            asset.write_bytes(corrupted)
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                status, _, body = _get(port, "/v1/assets/species/1-robin/portrait.png")
+
+        self.assertEqual(status, 503)
+        self.assertNotIn(corrupted, body)
+        self.assertEqual(
+            json.loads(body),
+            {"ok": False, "error": "active asset unavailable", "schema_version": 1},
+        )
+
+    def test_allowlisted_asset_symlink_cannot_escape_catalog_root(self) -> None:
+        secret = b"private image outside the catalog"
+        with self._environment() as (root, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(
+                json.dumps(_active_catalog(_catalog_entry(image=secret)))
+            )
+            outside = root / "private.png"
+            outside.write_bytes(secret)
+            asset = catalog_dir / "species" / "1-robin" / "portrait.png"
+            asset.parent.mkdir(parents=True)
+            asset.symlink_to(outside)
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                status, _, body = _get(port, "/v1/assets/species/1-robin/portrait.png")
+
+        self.assertEqual(status, 404)
+        self.assertNotIn(secret, body)
+
     def test_asset_path_traversal_is_rejected(self) -> None:
         secret = b"top secret"
         with self._environment() as (root, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog()))
             (root / "secret.txt").write_bytes(secret)
-            with _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port:
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
                 for path in (
                     "/v1/assets/..%2f..%2fsecret.txt",
                     "/v1/assets/%2e%2e/%2e%2e/secret.txt",
@@ -323,8 +549,8 @@ class ServerTests(unittest.TestCase):
             {"ok": False, "error": "active catalog unavailable", "schema_version": 1},
         )
 
-    def test_catalog_success_records_display_fetch_heartbeat(self) -> None:
-        active = {"schema_version": 1, "species": [{"taxon_id": 1}]}
+    def test_legacy_catalog_marker_without_origin_records_display_fetch(self) -> None:
+        active = _active_catalog(_catalog_entry())
         with self._environment() as (_, catalog_dir, state_dir):
             active_catalog_path = state_dir / "active-catalog.json"
             active_catalog_path.write_text(json.dumps(active))
@@ -333,7 +559,11 @@ class ServerTests(unittest.TestCase):
                 _get(port, "/v1/catalog?not_reports_success=1")
                 _get(port, "/v1/catalog?reports_success=10")
                 plain_written = (state_dir / "display-last-fetch.json").exists()
-                status, _, body = _get(port, "/v1/catalog?reports_success=1")
+                status, _, body = _get(
+                    port,
+                    "/v1/catalog?reports_success=1",
+                    headers={"User-Agent": USER_AGENT},
+                )
             heartbeat = json.loads((state_dir / "display-last-fetch.json").read_text())
 
         self.assertEqual(plain_status, 200)
@@ -343,13 +573,174 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(heartbeat["schema_version"], 1)
         self.assertRegex(heartbeat["fetched_at"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
 
+    def test_nonlegacy_gets_cannot_write_display_telemetry(self) -> None:
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog()))
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                catalog_status, _, _ = _get(port, "/v1/catalog?reports_success=1")
+                success_status, _, _ = _get(port, "/v1/display-success")
+
+        self.assertEqual(catalog_status, 200)
+        self.assertEqual(success_status, 403)
+        self.assertFalse((state_dir / "display-last-fetch.json").exists())
+        self.assertFalse((state_dir / "display-last-success.json").exists())
+
+    def test_post_display_telemetry_records_fetch_and_success_without_cors(self) -> None:
+        with self._environment() as (_, catalog_dir, state_dir):
+            with _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port:
+                fetch_status, fetch_headers, fetch_body = _post(port, "/v1/display-fetch")
+                success_status, success_headers, success_body = _post(port, "/v1/display-success")
+            fetched = json.loads((state_dir / "display-last-fetch.json").read_text())
+            succeeded = json.loads((state_dir / "display-last-success.json").read_text())
+
+        self.assertEqual(fetch_status, 200)
+        self.assertEqual(success_status, 200)
+        self.assertEqual(json.loads(fetch_body), {"ok": True, "schema_version": 1})
+        self.assertEqual(json.loads(success_body), {"ok": True, "schema_version": 1})
+        self.assertNotIn("Access-Control-Allow-Origin", fetch_headers)
+        self.assertNotIn("Access-Control-Allow-Origin", success_headers)
+        self.assertIn("fetched_at", fetched)
+        self.assertIn("succeeded_at", succeeded)
+
+    def test_post_display_telemetry_reports_persistence_failure(self) -> None:
+        with (
+            self._environment() as (_, catalog_dir, state_dir),
+            patch(
+                "inky_bird_frame.server.write_json_atomic",
+                side_effect=OSError("state unavailable"),
+            ),
+            _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port,
+        ):
+            status, _, body = _post(port, "/v1/display-success")
+
+        self.assertEqual(status, 503)
+        self.assertEqual(
+            json.loads(body),
+            {"ok": False, "error": "display telemetry unavailable", "schema_version": 1},
+        )
+        self.assertFalse((state_dir / "display-last-success.json").exists())
+
+    def test_post_display_telemetry_rejects_unbounded_or_unexpected_data(self) -> None:
+        with self._environment() as (_, catalog_dir, state_dir):
+            with _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port:
+                cases: tuple[tuple[bytes, dict[str, str], int], ...] = (
+                    (
+                        b"x" * (MAX_TELEMETRY_REQUEST_BYTES + 1),
+                        {"Content-Type": "application/json"},
+                        413,
+                    ),
+                    (b"not-json", {"Content-Type": "application/json"}, 400),
+                    (b'{"schema_version": 1, "client": "browser"}', {}, 400),
+                    (b'{"schema_version": 1}', {"Content-Type": "text/plain"}, 415),
+                )
+                for body, headers, expected_status in cases:
+                    status, _, _ = _post(
+                        port,
+                        "/v1/display-success",
+                        body=body,
+                        headers=headers,
+                    )
+                    self.assertEqual(status, expected_status)
+            heartbeat_written = (state_dir / "display-last-success.json").exists()
+
+        self.assertFalse(heartbeat_written)
+
+    def test_post_display_telemetry_requires_one_valid_content_length(self) -> None:
+        with self._environment() as (_, catalog_dir, state_dir):
+            with _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port:
+                missing_status, _, _ = _post_with_content_length(port, "/v1/display-success", None)
+                invalid_status, _, _ = _post_with_content_length(
+                    port, "/v1/display-success", "not-a-number"
+                )
+            heartbeat_written = (state_dir / "display-last-success.json").exists()
+
+        self.assertEqual(missing_status, 411)
+        self.assertEqual(invalid_status, 400)
+        self.assertFalse(heartbeat_written)
+
+    def test_options_does_not_enable_private_network_or_cors_preflight(self) -> None:
+        with (
+            self._environment() as (_, catalog_dir, state_dir),
+            _serving(
+                catalog_dir,
+                state_dir / "active-catalog.json",
+                state_dir,
+                cors_allowed_origins=("https://display.example.test",),
+            ) as port,
+        ):
+            connection = HTTPConnection("127.0.0.1", port, timeout=5)
+            try:
+                connection.request(
+                    "OPTIONS",
+                    "/v1/catalog",
+                    headers={
+                        "Origin": "https://display.example.test",
+                        "Access-Control-Request-Private-Network": "true",
+                    },
+                )
+                response = connection.getresponse()
+                status = response.status
+                headers = dict(response.getheaders())
+                response.read()
+            finally:
+                connection.close()
+
+        self.assertEqual(status, 501)
+        self.assertNotIn("Access-Control-Allow-Origin", headers)
+        self.assertNotIn("Access-Control-Allow-Private-Network", headers)
+
+    def test_request_log_is_local_and_header_free(self) -> None:
+        output = io.StringIO()
+        with (
+            self._environment() as (_, catalog_dir, state_dir),
+            redirect_stdout(output),
+            _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port,
+        ):
+            _get(
+                port,
+                "/health?probe=1",
+                headers={
+                    "Origin": "https://display.example.test",
+                    "User-Agent": "private-browser-detail",
+                },
+            )
+
+        log = json.loads(output.getvalue().strip())
+        self.assertEqual(log["event"], "http_request")
+        self.assertEqual(log["client"], "127.0.0.1")
+        self.assertIn("GET /health?probe=1", log["message"])
+        self.assertNotIn("display.example.test", output.getvalue())
+        self.assertNotIn("private-browser-detail", output.getvalue())
+
+    def test_browser_catalog_marker_never_records_display_fetch(self) -> None:
+        trusted_origin = "https://display.example.test"
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog()))
+            with _serving(
+                catalog_dir,
+                active_catalog_path,
+                state_dir,
+                cors_allowed_origins=(trusted_origin,),
+            ) as port:
+                status, headers, _ = _get(
+                    port,
+                    "/v1/catalog?reports_success=1",
+                    headers={"Origin": trusted_origin},
+                )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(headers.get("Access-Control-Allow-Origin"), trusted_origin)
+        self.assertFalse((state_dir / "display-last-fetch.json").exists())
+
     def test_health_reports_counts_without_touching_the_index(self) -> None:
         with self._environment() as (_, catalog_dir, state_dir):
             index_path = catalog_dir / "index.json"
             index_path.write_text(json.dumps({"schema_version": 1, "species": [{}, {}]}))
             index_stat = index_path.stat()
             active_catalog_path = state_dir / "active-catalog.json"
-            active_catalog_path.write_text(json.dumps({"schema_version": 1, "species": [{}]}))
+            active_catalog_path.write_text(json.dumps(_active_catalog(_catalog_entry())))
             with _serving(catalog_dir, active_catalog_path, state_dir) as port:
                 status, _, body = _get(port, "/health")
             self.assertEqual(index_path.stat().st_mtime_ns, index_stat.st_mtime_ns)
@@ -358,7 +749,13 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertEqual(
             json.loads(body),
-            {"ok": True, "approved_species": 2, "active_species": 1, "schema_version": 1},
+            {
+                "ok": True,
+                "approved_species": 2,
+                "active_species": 1,
+                "version": __version__,
+                "schema_version": 1,
+            },
         )
 
     def test_health_tolerates_missing_index_and_corrupt_active_catalog(self) -> None:
@@ -372,7 +769,13 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertEqual(
             json.loads(body),
-            {"ok": True, "approved_species": 0, "active_species": 0, "schema_version": 1},
+            {
+                "ok": True,
+                "approved_species": 0,
+                "active_species": 0,
+                "version": __version__,
+                "schema_version": 1,
+            },
         )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -310,6 +310,27 @@ class ServerTests(unittest.TestCase):
             {"ok": False, "error": "active catalog unavailable", "schema_version": 1},
         )
 
+    def test_catalog_rejects_non_integer_schema_versions(self) -> None:
+        for schema_version in (True, 1.0):
+            with self.subTest(schema_version=schema_version):
+                active = _active_catalog()
+                active["schema_version"] = schema_version
+                with self._environment() as (_, catalog_dir, state_dir):
+                    active_catalog_path = state_dir / "active-catalog.json"
+                    active_catalog_path.write_text(json.dumps(active))
+                    with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                        status, _, body = _get(port, "/v1/catalog")
+
+                self.assertEqual(status, 503)
+                self.assertEqual(
+                    json.loads(body),
+                    {
+                        "ok": False,
+                        "error": "active catalog unavailable",
+                        "schema_version": 1,
+                    },
+                )
+
     def test_non_utf8_state_files_degrade_gracefully(self) -> None:
         with self._environment() as (_, catalog_dir, state_dir):
             active_catalog_path = state_dir / "active-catalog.json"
@@ -511,6 +532,20 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(status, 404)
         self.assertNotIn(secret, body)
 
+    def test_allowlisted_asset_symlink_loop_returns_controlled_not_found(self) -> None:
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog(_catalog_entry())))
+            species_dir = catalog_dir / "species" / "1-robin"
+            species_dir.mkdir(parents=True)
+            portrait = species_dir / "portrait.png"
+            portrait.symlink_to(portrait)
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                status, _, body = _get(port, "/v1/assets/species/1-robin/portrait.png")
+
+        self.assertEqual(status, 404)
+        self.assertEqual(json.loads(body), {"ok": False, "error": "not found"})
+
     def test_asset_path_traversal_is_rejected(self) -> None:
         secret = b"top secret"
         with self._environment() as (root, catalog_dir, state_dir):
@@ -522,6 +557,7 @@ class ServerTests(unittest.TestCase):
                     "/v1/assets/..%2f..%2fsecret.txt",
                     "/v1/assets/%2e%2e/%2e%2e/secret.txt",
                     "/v1/assets//etc/hostname",
+                    "/v1/assets/bad%00.png",
                 ):
                     status, _, body = _get(port, path)
                     self.assertEqual(status, 404, path)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -493,6 +493,24 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(status, 404)
         self.assertNotIn(secret, body)
 
+    def test_allowlisted_asset_symlink_cannot_alias_unlisted_catalog_asset(self) -> None:
+        secret = b"private inactive image inside the catalog"
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(
+                json.dumps(_active_catalog(_catalog_entry(image=secret)))
+            )
+            species_dir = catalog_dir / "species" / "1-robin"
+            species_dir.mkdir(parents=True)
+            inactive = species_dir / "inactive.png"
+            inactive.write_bytes(secret)
+            (species_dir / "portrait.png").symlink_to(inactive)
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                status, _, body = _get(port, "/v1/assets/species/1-robin/portrait.png")
+
+        self.assertEqual(status, 404)
+        self.assertNotIn(secret, body)
+
     def test_asset_path_traversal_is_rejected(self) -> None:
         secret = b"top secret"
         with self._environment() as (root, catalog_dir, state_dir):
@@ -573,6 +591,40 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(heartbeat["schema_version"], 1)
         self.assertRegex(heartbeat["fetched_at"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
 
+    def test_legacy_catalog_remains_available_when_fetch_telemetry_cannot_persist(
+        self,
+    ) -> None:
+        active = _active_catalog(_catalog_entry())
+        output = io.StringIO()
+        with (
+            self._environment() as (_, catalog_dir, state_dir),
+            patch(
+                "inky_bird_frame.server.write_json_atomic",
+                side_effect=OSError("state unavailable"),
+            ),
+            redirect_stdout(output),
+        ):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(active))
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                status, _, body = _get(
+                    port,
+                    "/v1/catalog?reports_success=1",
+                    headers={"User-Agent": USER_AGENT},
+                )
+
+        events = [json.loads(line) for line in output.getvalue().splitlines()]
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(body), active)
+        self.assertFalse((state_dir / "display-last-fetch.json").exists())
+        self.assertIn(
+            {
+                "event": "display_telemetry_write_failed",
+                "file": "display-last-fetch.json",
+            },
+            events,
+        )
+
     def test_nonlegacy_gets_cannot_write_display_telemetry(self) -> None:
         with self._environment() as (_, catalog_dir, state_dir):
             active_catalog_path = state_dir / "active-catalog.json"
@@ -632,6 +684,8 @@ class ServerTests(unittest.TestCase):
                     ),
                     (b"not-json", {"Content-Type": "application/json"}, 400),
                     (b'{"schema_version": 1, "client": "browser"}', {}, 400),
+                    (b'{"schema_version": true}', {}, 400),
+                    (b'{"schema_version": 1.0}', {}, 400),
                     (b'{"schema_version": 1}', {"Content-Type": "text/plain"}, 415),
                 )
                 for body, headers, expected_status in cases:


### PR DESCRIPTION
## Summary

- serve a validated, allowlisted v1 catalog instead of exposing private controller state or arbitrary catalog files
- verify active PNG checksums before returning bytes, reject path and symlink aliases, and keep browser reads side-effect-free
- move display health reporting to bounded JSON POSTs while retaining a one-release, fixed-client compatibility bridge
- expose the running application version through `--version` and `/health`
- preserve and verify the exact Codex and GitHub CLI license/notice files bundled in the controller image

## Compatibility and privacy

The documented v1 catalog shape remains compatible, including observation counts and latest-detection timestamps. Unknown internal fields are dropped. Only the current active portrait and display PNGs are readable; undocumented access to manifests, review data, inactive plates, and arbitrary catalog files now fails closed.

New display nodes use POST telemetry and fall back to the legacy GET contract when talking to an older controller. Older display nodes remain supported for one release through the exact Inky user agent, without allowing ordinary browser reads to affect physical-display health.

## Validation

- full Pytest suite
- Ruff format and lint
- strict MyPy
- public catalog validation: 162 species
- workflow action pinning: 6 workflows
- sdist and wheel build
- independent exact-head security and compatibility review

Docker is not installed on the development Mac, so the image build, runtime license assertions, Compose validation, and container smoke tests are intentionally left to this PR's hosted CI.
