### PR TITLE
Add Homepage dashboard integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ appear. Your discovery location and observation history stay private.
   the [discovery guide](docs/discovery.md).
 - **Connect a trusted browser application:** read the
   [browser application boundary](docs/installation.md#browser-applications).
-  Inky provides a read-only catalog and image interface, not a browser UI.
+  Inky provides a read-only catalog, image interface, and narrow plate embed,
+  not a standalone browser application.
+- **Add Inky to a Homepage dashboard:** use the
+  [stock Homepage recipe](docs/installation.md#homepage-dashboard) for compact
+  catalog stats and an optional upright plate.
 - **Request or contribute a bird:** start with
   [Contributing](CONTRIBUTING.md).
 
@@ -87,9 +91,10 @@ The project has two installed roles:
   rotates them on the Inky panel. It never runs discovery or Codex.
 
 A trusted browser application may also read the catalog through a same-origin
-proxy or an explicitly allowed origin. Inky supplies the interface, not the
-browser application. The controller has no built-in authentication or TLS and
-must not be exposed directly to the internet.
+proxy or an explicitly allowed origin. Inky supplies the data interface and a
+narrow, script-free plate embed, not a standalone application. The controller
+has no built-in authentication or TLS and must not be exposed directly to the
+internet.
 
 The controller and display may run on one capable Raspberry Pi, but the
 recommended wall build keeps a lightweight Pi behind the frame and runs the
@@ -105,7 +110,7 @@ permission or fail even when its origin is allowed. Browser reads never count
 as display-node health. Allowing an origin does not add authentication or make
 the controller safe to expose to the internet. See
 [Browser applications](docs/installation.md#browser-applications) for the
-API, privacy, and network limits.
+API, embed, privacy, and network limits.
 
 ## Observation sources
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -58,6 +58,10 @@ port = 8793
 # Use ASCII hostnames or canonical IP addresses. Internationalized names, punycode,
 # wildcards, credentials, paths, queries, and fragments are rejected.
 # cors_allowed_origins = ["https://frame.example.test"]
+# Cross-origin framing of the featured plate is a separate permission. Content Security
+# Policy does not reliably match IP address sources, so these origins must use DNS hostnames.
+# Underscores and trailing dots are also rejected.
+# embed_allowed_origins = ["https://home.example.test"]
 references_per_species = 4
 generations_per_cycle = 1
 # Failed visual reviews are regenerated with their findings as corrective input.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,16 +157,21 @@ The controller exposes a small HTTP interface:
 
 - `GET /health`: service state, catalog counts, and application version
 - `GET /v1/catalog`
+- `HEAD /v1/catalog`: the same fail-closed readiness status without a body
 - `GET /v1/assets/<active-image-path>`
+- `GET /v1/embed/featured-plate`
 - `POST /v1/display-fetch`
 - `POST /v1/display-success`
 
-Cross-origin browser access to the catalog and assets is disabled unless the
-operator configures exact trusted origins. The server echoes a matching origin
-and varies cache entries by `Origin`; it never enables credentialed browser
-requests or grants wildcard access. Health and display telemetry responses are
-served without cross-origin access headers. Ordinary catalog and browser reads
-never update physical-display health.
+Cross-origin browser access to the catalog and assets, and cross-origin framing
+of the plate embed, are separate, disabled-by-default permissions. The server
+echoes a matching `cors_allowed_origins` request origin and varies cache entries
+by `Origin`; it never enables credentialed browser requests or grants wildcard
+access. `embed_allowed_origins` becomes the embed's Content Security Policy
+`frame-ancestors` allowlist. Framing origins must use DNS hostnames because CSP
+does not reliably match IP-address sources. Health, embed, and display telemetry
+responses are served without cross-origin access headers. Ordinary catalog,
+asset, and embed reads never update physical-display health.
 
 Catalog schema version 1 has three top-level fields: `schema_version`,
 `generated_at`, and `species`. Each species entry contains `taxon_id`,
@@ -182,6 +187,21 @@ sending bytes. Catalog responses use `no-store`; an image request becomes
 immutable-cacheable only when its `sha256` query matches the verified active
 catalog digest. Catalog JSON and image responses carry
 `X-Content-Type-Options: nosniff`.
+
+The featured-plate route is a small HTML representation for dashboards. It
+selects the active entry with the newest valid `latest_detection_at`, then the
+newest `approved_at`, then the lower taxon ID for a deterministic tie. Entries
+without detection times participate only when no active entry has one. Because
+only BirdWeather, BirdNET-Go, and Bird Buddy currently provide detection
+timestamps, the result is deliberately called featured: it is neither the
+newest observation across every provider nor the plate currently shown on the
+physical frame. The page loads the selected upright portrait through its
+content-addressed asset URL and exposes no observation count, timestamp,
+provider, location, or private controller field. It contains no JavaScript,
+form, control, external resource, or display-health write. A script-free HTML
+refresh reloads the no-store document every 15 minutes, replacing the old page
+instead of accumulating client timers. A valid empty catalog returns a quiet
+empty state; unavailable or invalid catalog state returns a generic `503` page.
 
 Schema version 1 may gain an optional field only after a privacy review.
 Removing a required field, changing a field's meaning or type, or exposing a

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -94,11 +94,12 @@ the service is not offered on other networks.
 
 ### Browser applications
 
-Inky does not include a browser interface. This section is for an
-operator-supplied application that consumes Inky's read-only catalog API.
-Cross-origin browser access is disabled by default. To let a trusted web
-application fetch the active catalog and its images directly, list its exact
-origin under `[controller]`:
+Inky does not include a standalone browser application. This section is for an
+operator-supplied application that consumes Inky's read-only catalog API or
+frames its narrow featured-plate embed.
+Both permissions are disabled by default. To let a trusted web application
+fetch the active catalog and its images directly, list its exact origin under
+`[controller]`:
 
 ```toml
 [controller]
@@ -110,9 +111,23 @@ wildcards, credentials, paths, queries, and fragments. Use an ASCII hostname
 or the canonical form of an IP address. Internationalized and punycode
 hostnames are not supported. A matching origin can read `GET /v1/catalog` and
 the active catalog's portrait and display PNGs under `GET /v1/assets/`. Other
-catalog files, inactive plates, health, and display telemetry do not receive
-cross-origin access. Requests from other origins receive the normal response
-without an `Access-Control-Allow-Origin` header.
+catalog files, inactive plates, health, the featured-plate embed, and display
+telemetry do not receive cross-origin access. Requests from other origins
+receive the normal response without an `Access-Control-Allow-Origin` header.
+
+Framing is a separate permission. List each trusted parent origin explicitly:
+
+```toml
+[controller]
+embed_allowed_origins = ["https://home.example.test"]
+```
+
+The controller adds those origins to the embed's Content Security Policy
+`frame-ancestors` directive. CSP does not reliably match IP-address sources, so
+framing origins must use DNS hostnames. Underscores and trailing dots are also
+rejected. Unlisted sites cannot frame the embed. Keeping CORS and framing
+separate means an existing catalog reader does not silently gain permission to
+present controller content inside its pages.
 
 The browser catalog includes active species identity, approval time, image
 paths and checksums, and any available observation count and latest-detection
@@ -138,6 +153,77 @@ headers. The service logs each request locally with the source IP address,
 request path and query, and HTTP status. It does not log request headers or send
 browser analytics to an external service. Normal systemd journal or macOS log
 retention applies.
+
+#### Homepage dashboard
+
+[Homepage](https://gethomepage.dev/) can show Inky with its stock service
+widgets; no Homepage fork, custom JavaScript, or Inky-specific plugin is
+required. Its `customapi` widget fetches through the Homepage server, while its
+`iframe` widget loads in the browser. A compact card can use both:
+
+```yaml
+- Birds:
+    - Inky Bird Frame:
+        icon: mdi-bird
+        href: https://github.com/veteranbv/inky-bird-frame
+        description: Observation-driven field-journal plates
+        siteMonitor: http://inky-controller:8793/v1/catalog
+        widgets:
+          - type: customapi
+            url: http://inky-controller:8793/health
+            refreshInterval: 300000
+            mappings:
+              - field: active_species
+                label: Active
+                format: number
+              - field: approved_species
+                label: Plates
+                format: number
+              - field: version
+                label: Version
+                format: text
+          - type: iframe
+            src: https://inky.example.test/v1/embed/featured-plate
+            classes: h-60
+            allowScrolling: no
+            referrerPolicy: no-referrer
+```
+
+Replace the names and URLs with addresses reachable from the Homepage server
+and browser. `siteMonitor` uses `/v1/catalog`, not `/health`, because the
+catalog route fails closed when active catalog state is unavailable. Inky
+answers Homepage's `HEAD` readiness probe without transferring the catalog.
+The stats request is server-side and needs no CORS permission. Polling every
+five minutes avoids Homepage's much noisier default while keeping the counts
+useful.
+
+The optional image needs a browser-reachable HTTPS route for the controller. A
+true same-origin proxy beneath the Homepage origin works with the default
+`frame-ancestors 'self'` policy. For a separate controller origin, as shown
+above, add the Homepage origin to `embed_allowed_origins`. Make sure a reverse
+proxy forwards both `/v1/embed/featured-plate` and `/v1/assets/`, and does not
+replace the controller's CSP with a conflicting frame-denial header. The embed
+uses a relative asset URL so those routes can share a direct origin or the same
+proxy path prefix. Keep the route private; use authentication or a VPN before
+traffic crosses an untrusted boundary. Allowing the origin does not secure the
+controller. The iframe refreshes every 15 minutes and displays the upright
+portrait, never the rotated hardware image. The embed refreshes itself, so do
+not add Homepage's `refreshInterval` option. Homepage 2.1.2 accumulates iframe
+timers when that option is enabled. That release also drops its documented
+iframe `name` setting before rendering, so the example omits an ineffective
+setting. This is an upstream accessibility limitation: Homepage 2.1.2 renders
+the stock iframe without an accessible frame name. The embedded document itself
+still has a descriptive title, and its image has alternative text.
+
+Whenever any active entry has a valid detection time, the featured plate comes
+from that set: newest detection wins, with approval time and taxon ID breaking
+ties. Only when no active entry has a detection time does newest approval become
+the fallback. BirdWeather, BirdNET-Go, and Bird Buddy are currently the only
+sources that contribute those times, so this is not a universal
+latest-observation view and does not claim to match the plate currently on the
+frame. The embed exposes only the selected approved bird identity and image. A
+valid empty catalog shows a quiet empty state; invalid or unavailable catalog
+state returns `503`.
 
 ## 1. Install the controller
 

--- a/src/inky_bird_frame/config.py
+++ b/src/inky_bird_frame/config.py
@@ -118,6 +118,7 @@ class ControllerConfig:
     retry_max_minutes: int = 1440
     insufficient_references_retry_minutes: int = 10080
     cors_allowed_origins: tuple[str, ...] = ()
+    embed_allowed_origins: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -356,6 +357,27 @@ def _http_origins(section: dict[str, object], name: str) -> tuple[str, ...]:
     if len(origins) != len(set(origins)):
         raise ConfigurationError(f"{name} must not contain equivalent duplicate origins")
     return tuple(origins)
+
+
+def _csp_frame_origins(section: dict[str, object], name: str) -> tuple[str, ...]:
+    origins = _http_origins(section, name)
+    for origin in origins:
+        host = urlsplit(origin).hostname
+        if host is None:
+            raise ConfigurationError(f"{name} must contain valid HTTP or HTTPS origins")
+        try:
+            ip_address(host)
+        except ValueError:
+            if "_" in host or host.endswith("."):
+                raise ConfigurationError(
+                    f"{name} must use DNS hostnames supported by Content Security Policy"
+                ) from None
+        else:
+            raise ConfigurationError(
+                f"{name} must use DNS hostnames because Content Security Policy does not "
+                "reliably match IP addresses"
+            )
+    return origins
 
 
 def _notification_destinations(
@@ -728,6 +750,7 @@ def load_config(path: Path, *, load_secrets: bool = True) -> AppConfig:
                 controller, "insufficient_references_retry_minutes", default=10080
             ),
             cors_allowed_origins=_http_origins(controller, "cors_allowed_origins"),
+            embed_allowed_origins=_csp_frame_origins(controller, "embed_allowed_origins"),
         ),
         display_node=DisplayNodeConfig(
             controller_url=controller_url,

--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 import re
+from datetime import datetime
+from html import escape
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path, PurePosixPath
-from urllib.parse import parse_qs, unquote, urlsplit
+from urllib.parse import parse_qs, quote, unquote, urlsplit
 
 from . import __version__
 from .catalog import read_json, rebuild_catalog_index, utc_now
@@ -20,6 +23,7 @@ from .timeutil import parse_utc_timestamp
 
 CATALOG_SCHEMA_VERSION = 1
 MAX_TELEMETRY_REQUEST_BYTES = 1024
+FEATURED_PLATE_REFRESH_SECONDS = 15 * 60
 _SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
 _CATALOG_STRING_FIELDS = (
     "common_name",
@@ -31,6 +35,18 @@ _CATALOG_STRING_FIELDS = (
     "display_sha256",
     "approved_at",
 )
+_FEATURED_PLATE_STYLE = (
+    "html,body{height:100%;margin:0;width:100%}"
+    "body{background:transparent;color:#94a3b8;display:grid;font:500 14px "
+    "system-ui,sans-serif;overflow:hidden;place-items:center}"
+    "main{display:grid;inset:0;min-height:0;min-width:0;place-items:center;"
+    "position:fixed}"
+    "img{display:block;height:100vh;object-fit:contain;width:100vw}"
+    "p{margin:1rem;text-align:center}"
+)
+_FEATURED_PLATE_STYLE_HASH = base64.b64encode(
+    hashlib.sha256(_FEATURED_PLATE_STYLE.encode()).digest()
+).decode("ascii")
 
 
 def _catalog_asset_path(value: object, field: str) -> str:
@@ -156,11 +172,76 @@ def _species_count(path: Path) -> int:
     return 0
 
 
+def _featured_plate_entry(payload: dict[str, object]) -> dict[str, object] | None:
+    raw_species = payload.get("species")
+    if not isinstance(raw_species, list):
+        raise CatalogError("Active catalog has no species list")
+
+    candidates: list[dict[str, object]] = []
+    for entry in raw_species:
+        if not isinstance(entry, dict):
+            raise CatalogError("Active catalog entry must be an object")
+        candidates.append(entry)
+
+    def rank(entry: dict[str, object]) -> tuple[int, datetime, datetime, int]:
+        detected_at = parse_utc_timestamp(entry.get("latest_detection_at"))
+        approved_at = parse_utc_timestamp(entry.get("approved_at"))
+        taxon_id = entry.get("taxon_id")
+        if approved_at is None or not isinstance(taxon_id, int) or isinstance(taxon_id, bool):
+            raise CatalogError("Active catalog entry has invalid featured-plate fields")
+        return (
+            1 if detected_at is not None else 0,
+            detected_at or approved_at,
+            approved_at,
+            -taxon_id,
+        )
+
+    return max(candidates, key=rank, default=None)
+
+
+def _featured_plate_document(
+    entry: dict[str, object] | None,
+    *,
+    empty_message: str,
+) -> bytes:
+    if entry is None:
+        title = "Inky Bird Frame"
+        content = f'<p role="status">{escape(empty_message)}</p>'
+    else:
+        common_name = entry.get("common_name")
+        portrait_path = entry.get("portrait_path")
+        portrait_sha256 = entry.get("portrait_sha256")
+        if not isinstance(common_name, str) or not common_name:
+            raise CatalogError("Active catalog entry has invalid featured-plate fields")
+        if not isinstance(portrait_path, str) or not portrait_path:
+            raise CatalogError("Active catalog entry has invalid featured-plate fields")
+        if (
+            not isinstance(portrait_sha256, str)
+            or _SHA256_PATTERN.fullmatch(portrait_sha256) is None
+        ):
+            raise CatalogError("Active catalog entry has invalid featured-plate checksum")
+        title = f"{common_name} | Inky Bird Frame"
+        portrait_url = f"../assets/{quote(portrait_path, safe='/')}?sha256={portrait_sha256}"
+        content = (
+            f'<img src="{escape(portrait_url, quote=True)}" '
+            f'alt="Field-journal plate for {escape(common_name, quote=True)}">'
+        )
+
+    return (
+        '<!doctype html><html lang="en"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1">'
+        f'<meta http-equiv="refresh" content="{FEATURED_PLATE_REFRESH_SECONDS}">'
+        f"<title>{escape(title)}</title><style>{_FEATURED_PLATE_STYLE}</style>"
+        f"</head><body><main>{content}</main></body></html>"
+    ).encode()
+
+
 class CatalogRequestHandler(BaseHTTPRequestHandler):
     catalog_dir: Path
     active_catalog_path: Path
     state_dir: Path
     cors_allowed_origins: tuple[str, ...] = ()
+    embed_allowed_origins: tuple[str, ...] = ()
 
     def _has_origin(self) -> bool:
         return bool(self.headers.get_all("Origin", failobj=[]))
@@ -187,6 +268,7 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
         payload: object,
         *,
         allow_browser_access: bool = False,
+        head_only: bool = False,
     ) -> None:
         body = json.dumps(payload, sort_keys=True).encode()
         self.send_response(status)
@@ -196,6 +278,38 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
         self.send_header("X-Content-Type-Options", "nosniff")
         if allow_browser_access:
             self._send_browser_access_headers()
+        self.end_headers()
+        if not head_only:
+            self.wfile.write(body)
+
+    def _send_featured_plate(
+        self,
+        status: HTTPStatus,
+        entry: dict[str, object] | None,
+        *,
+        empty_message: str,
+    ) -> None:
+        body = _featured_plate_document(entry, empty_message=empty_message)
+        frame_ancestors = " ".join(("'self'", *self.embed_allowed_origins))
+        content_security_policy = "; ".join(
+            (
+                "default-src 'none'",
+                "img-src 'self'",
+                f"style-src 'sha256-{_FEATURED_PLATE_STYLE_HASH}'",
+                "script-src 'none'",
+                "object-src 'none'",
+                "base-uri 'none'",
+                "form-action 'none'",
+                f"frame-ancestors {frame_ancestors}",
+            )
+        )
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Security-Policy", content_security_policy)
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("X-Content-Type-Options", "nosniff")
         self.end_headers()
         self.wfile.write(body)
 
@@ -353,6 +467,23 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
                 self._record_display_event("display-last-fetch.json", "fetched_at")
             self._send_json(HTTPStatus.OK, payload, allow_browser_access=True)
             return
+        if request_path == "/v1/embed/featured-plate":
+            try:
+                payload, _asset_hashes = self._load_active_catalog()
+                entry = _featured_plate_entry(payload)
+            except (CatalogError, OSError):
+                self._send_featured_plate(
+                    HTTPStatus.SERVICE_UNAVAILABLE,
+                    None,
+                    empty_message="Featured plate unavailable",
+                )
+                return
+            self._send_featured_plate(
+                HTTPStatus.OK,
+                entry,
+                empty_message="No active plate yet",
+            )
+            return
         if request_path == "/v1/display-success":
             if not self._is_legacy_display_request():
                 self._send_json(
@@ -423,6 +554,32 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
             return
         self._send_json(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not found"})
 
+    def do_HEAD(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        request_path = urlsplit(self.path).path
+        if request_path != "/v1/catalog":
+            self._send_json(
+                HTTPStatus.NOT_FOUND,
+                {"ok": False, "error": "not found"},
+                head_only=True,
+            )
+            return
+        try:
+            payload, _asset_hashes = self._load_active_catalog()
+        except (CatalogError, OSError):
+            self._send_json(
+                HTTPStatus.SERVICE_UNAVAILABLE,
+                {"ok": False, "error": "active catalog unavailable", "schema_version": 1},
+                allow_browser_access=True,
+                head_only=True,
+            )
+            return
+        self._send_json(
+            HTTPStatus.OK,
+            payload,
+            allow_browser_access=True,
+            head_only=True,
+        )
+
     def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
         request_path = urlsplit(self.path).path
         events = {
@@ -467,6 +624,7 @@ def serve_catalog(config: ControllerConfig) -> None:
             "active_catalog_path": config.state_dir / "active-catalog.json",
             "state_dir": config.state_dir,
             "cors_allowed_origins": config.cors_allowed_origins,
+            "embed_allowed_origins": config.embed_allowed_origins,
         },
     )
     server = ThreadingHTTPServer((config.bind_host, config.port), handler)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,6 +73,7 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(config.controller.max_generation_attempts, 3)
         self.assertIsNone(config.controller.codex_model)
         self.assertEqual(config.controller.cors_allowed_origins, ())
+        self.assertEqual(config.controller.embed_allowed_origins, ())
         self.assertEqual(config.display_node.controller_url, "http://controller.test:8793")
         self.assertEqual(config.display_node.rotation_mode, RotationMode.WEIGHTED)
         self.assertTrue(config.display_node.prioritize_latest_detection)
@@ -176,6 +177,43 @@ class ConfigTests(unittest.TestCase):
 
             with self.assertRaisesRegex(ConfigurationError, "equivalent duplicate origins"):
                 load_config(path)
+
+    def test_loads_and_normalizes_featured_plate_embed_origins(self) -> None:
+        configured = CONFIG.replace(
+            'bind_host = "0.0.0.0"',
+            'bind_host = "0.0.0.0"\n'
+            'embed_allowed_origins = ["HTTPS://Home.Example.Test:443/", '
+            '"http://dashboard.local:8080"]',
+        )
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "config.toml"
+            path.write_text(configured)
+
+            config = load_config(path)
+
+        self.assertEqual(
+            config.controller.embed_allowed_origins,
+            ("https://home.example.test", "http://dashboard.local:8080"),
+        )
+
+    def test_rejects_embed_origins_that_csp_cannot_reliably_match(self) -> None:
+        for origin in (
+            "https://10.0.0.1",
+            "http://[2001:db8::1]:8080",
+            "https://frame_server.local",
+            "https://home.example.test.",
+        ):
+            with self.subTest(origin=origin), TemporaryDirectory() as temporary:
+                path = Path(temporary) / "config.toml"
+                path.write_text(
+                    CONFIG.replace(
+                        'bind_host = "0.0.0.0"',
+                        f'bind_host = "0.0.0.0"\nembed_allowed_origins = ["{origin}"]',
+                    )
+                )
+
+                with self.assertRaisesRegex(ConfigurationError, "embed_allowed_origins"):
+                    load_config(path)
 
     def test_loads_optional_codex_model_pin(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -28,21 +28,29 @@ GENERATED_AT = "2026-08-30T12:00:00+00:00"
 def _catalog_entry(
     *,
     taxon_id: int = 1,
-    directory: str = "species/1-robin",
+    common_name: str = "Robin",
+    scientific_name: str = "Turdus migratorius",
+    slug: str = "robin",
+    approved_at: str = "2026-07-10T00:00:00+00:00",
+    latest_detection_at: str | None = None,
     image: bytes = PNG_BYTES,
 ) -> dict[str, object]:
     digest = hashlib.sha256(image).hexdigest()
-    return {
+    directory = f"species/{taxon_id}-{slug}"
+    entry: dict[str, object] = {
         "taxon_id": taxon_id,
-        "common_name": "Robin",
-        "scientific_name": "Turdus migratorius",
-        "slug": "robin",
+        "common_name": common_name,
+        "scientific_name": scientific_name,
+        "slug": slug,
         "portrait_path": f"{directory}/portrait.png",
         "portrait_sha256": digest,
         "display_path": f"{directory}/display.png",
         "display_sha256": digest,
-        "approved_at": "2026-07-10T00:00:00+00:00",
+        "approved_at": approved_at,
     }
+    if latest_detection_at is not None:
+        entry["latest_detection_at"] = latest_detection_at
+    return entry
 
 
 def _active_catalog(*species: dict[str, object]) -> dict[str, object]:
@@ -60,6 +68,7 @@ def _serving(
     state_dir: Path,
     *,
     cors_allowed_origins: tuple[str, ...] = (),
+    embed_allowed_origins: tuple[str, ...] = (),
 ) -> Iterator[int]:
     handler = type(
         "TestCatalogRequestHandler",
@@ -69,6 +78,7 @@ def _serving(
             "active_catalog_path": active_catalog_path,
             "state_dir": state_dir,
             "cors_allowed_origins": cors_allowed_origins,
+            "embed_allowed_origins": embed_allowed_origins,
         },
     )
     server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
@@ -88,6 +98,18 @@ def _get(
     connection = HTTPConnection("127.0.0.1", port, timeout=5)
     try:
         connection.request("GET", path, headers=headers or {})
+        response = connection.getresponse()
+        return response.status, dict(response.getheaders()), response.read()
+    finally:
+        connection.close()
+
+
+def _head(
+    port: int, path: str, *, headers: dict[str, str] | None = None
+) -> tuple[int, dict[str, str], bytes]:
+    connection = HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        connection.request("HEAD", path, headers=headers or {})
         response = connection.getresponse()
         return response.status, dict(response.getheaders()), response.read()
     finally:
@@ -251,6 +273,267 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(legacy_status, 403)
         self.assertNotIn("Access-Control-Allow-Origin", heartbeat_headers)
         self.assertFalse(heartbeat_written)
+
+    def test_featured_plate_uses_the_newest_detection_across_timezone_offsets(self) -> None:
+        older = _catalog_entry(
+            taxon_id=1,
+            common_name="Older Bird",
+            scientific_name="Avis prior",
+            slug="older-bird",
+            approved_at="2026-08-29T12:00:00+00:00",
+            latest_detection_at="2026-08-30T08:00:00-04:00",
+        )
+        newer = _catalog_entry(
+            taxon_id=2,
+            common_name="Newer Bird",
+            scientific_name="Avis recentior",
+            slug="newer-bird",
+            approved_at="2026-08-28T12:00:00+00:00",
+            latest_detection_at="2026-08-30T12:01:00+00:00",
+        )
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog(older, newer)))
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                status, _, body = _get(port, "/v1/embed/featured-plate")
+
+        self.assertEqual(status, 200)
+        self.assertIn(b"Newer Bird", body)
+        self.assertNotIn(b"Older Bird", body)
+
+    def test_featured_plate_prefers_any_detection_over_approval_only_entries(self) -> None:
+        detected = _catalog_entry(
+            taxon_id=1,
+            common_name="Detected Bird",
+            scientific_name="Avis observata",
+            slug="detected-bird",
+            approved_at="2026-08-01T00:00:00+00:00",
+            latest_detection_at="2026-08-02T00:00:00+00:00",
+        )
+        approval_only = _catalog_entry(
+            taxon_id=2,
+            common_name="Recently Approved Bird",
+            scientific_name="Avis probata",
+            slug="recently-approved-bird",
+            approved_at="2026-08-30T00:00:00+00:00",
+        )
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog(detected, approval_only)))
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                status, _, body = _get(port, "/v1/embed/featured-plate")
+
+        self.assertEqual(status, 200)
+        self.assertIn(b"Detected Bird", body)
+        self.assertNotIn(b"Recently Approved Bird", body)
+
+    def test_featured_plate_selection_has_deterministic_ties_and_approval_fallback(
+        self,
+    ) -> None:
+        detection = "2026-08-30T12:00:00+00:00"
+        tied_newer_approval = _catalog_entry(
+            taxon_id=20,
+            common_name="Newer Approval",
+            scientific_name="Avis viginti",
+            slug="newer-approval",
+            approved_at="2026-08-30T11:00:00+00:00",
+            latest_detection_at=detection,
+        )
+        tied_older_approval = _catalog_entry(
+            taxon_id=10,
+            common_name="Older Approval",
+            scientific_name="Avis decem",
+            slug="older-approval",
+            approved_at="2026-08-30T10:00:00+00:00",
+            latest_detection_at=detection,
+        )
+        tied_higher_taxon = _catalog_entry(
+            taxon_id=20,
+            common_name="Higher Taxon",
+            scientific_name="Avis viginti",
+            slug="higher-taxon",
+            approved_at="2026-08-30T10:00:00+00:00",
+            latest_detection_at=detection,
+        )
+        tied_lower_taxon = _catalog_entry(
+            taxon_id=10,
+            common_name="Lower Taxon",
+            scientific_name="Avis decem",
+            slug="lower-taxon",
+            approved_at="2026-08-30T10:00:00+00:00",
+            latest_detection_at=detection,
+        )
+        older_approval = _catalog_entry(
+            taxon_id=30,
+            common_name="Older Approval",
+            scientific_name="Avis prior",
+            slug="older-approval",
+            approved_at="2026-08-29T10:00:00+00:00",
+        )
+        newer_approval = _catalog_entry(
+            taxon_id=40,
+            common_name="Approval Winner",
+            scientific_name="Avis probata",
+            slug="approval-winner",
+            approved_at="2026-08-30T10:00:00+00:00",
+        )
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                active_catalog_path.write_text(
+                    json.dumps(_active_catalog(tied_newer_approval, tied_older_approval))
+                )
+                approval_tie_status, _, approval_tie_body = _get(port, "/v1/embed/featured-plate")
+                active_catalog_path.write_text(
+                    json.dumps(_active_catalog(tied_higher_taxon, tied_lower_taxon))
+                )
+                taxon_tie_status, _, taxon_tie_body = _get(port, "/v1/embed/featured-plate")
+                active_catalog_path.write_text(
+                    json.dumps(_active_catalog(older_approval, newer_approval))
+                )
+                fallback_status, _, fallback_body = _get(port, "/v1/embed/featured-plate")
+
+        self.assertEqual(approval_tie_status, 200)
+        self.assertIn(b"Newer Approval", approval_tie_body)
+        self.assertEqual(taxon_tie_status, 200)
+        self.assertIn(b"Lower Taxon", taxon_tie_body)
+        self.assertEqual(fallback_status, 200)
+        self.assertIn(b"Approval Winner", fallback_body)
+
+    def test_featured_plate_is_an_upright_content_addressed_private_embed(self) -> None:
+        entry = _catalog_entry(
+            common_name='Robin <script>alert("private")</script>',
+            latest_detection_at="2026-08-30T11:45:00+00:00",
+        )
+        entry.update(
+            {
+                "observation_count": 7,
+                "provider": "private-provider",
+                "internal_path": "/private/controller/state",
+            }
+        )
+        digest = hashlib.sha256(PNG_BYTES).hexdigest()
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog(entry)))
+            portrait = catalog_dir / "species" / "1-robin" / "portrait.png"
+            portrait.parent.mkdir(parents=True)
+            portrait.write_bytes(PNG_BYTES)
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                status, headers, body = _get(port, "/v1/embed/featured-plate")
+                asset_status, asset_headers, asset_body = _get(
+                    port,
+                    f"/v1/assets/species/1-robin/portrait.png?sha256={digest}",
+                )
+
+        rendered = body.decode()
+        self.assertEqual(status, 200)
+        self.assertEqual(headers.get("Content-Type"), "text/html; charset=utf-8")
+        self.assertEqual(headers.get("Cache-Control"), "no-store")
+        self.assertEqual(headers.get("Referrer-Policy"), "no-referrer")
+        self.assertEqual(headers.get("X-Content-Type-Options"), "nosniff")
+        self.assertIn(
+            f"../assets/species/1-robin/portrait.png?sha256={digest}",
+            rendered,
+        )
+        self.assertNotIn("display.png", rendered)
+        self.assertNotIn("<script>alert", rendered)
+        self.assertIn("&lt;script&gt;alert", rendered)
+        self.assertNotIn("private-provider", rendered)
+        self.assertNotIn("/private/controller/state", rendered)
+        self.assertNotIn("2026-08-30T11:45:00", rendered)
+        self.assertNotIn(">7<", rendered)
+        self.assertIn('<meta http-equiv="refresh" content="900">', rendered)
+        self.assertNotIn("<script", rendered)
+        self.assertIn("inset:0;min-height:0;min-width:0", rendered)
+        self.assertIn("position:fixed", rendered)
+        self.assertIn("height:100vh;object-fit:contain;width:100vw", rendered)
+        self.assertEqual(asset_status, 200)
+        self.assertEqual(asset_headers.get("Cache-Control"), "public, max-age=86400, immutable")
+        self.assertEqual(asset_body, PNG_BYTES)
+        self.assertEqual(list(state_dir.glob("display-last-*.json")), [])
+
+    def test_featured_plate_csp_allows_only_configured_frame_ancestors(self) -> None:
+        trusted_origins = (
+            "https://home.example.test",
+            "https://secondary.example.test:8443",
+        )
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog(_catalog_entry())))
+            with _serving(
+                catalog_dir,
+                active_catalog_path,
+                state_dir,
+                embed_allowed_origins=trusted_origins,
+            ) as port:
+                status, headers, _ = _get(port, "/v1/embed/featured-plate")
+
+        csp = headers["Content-Security-Policy"]
+        self.assertEqual(status, 200)
+        self.assertIn("default-src 'none'", csp)
+        self.assertIn("img-src 'self'", csp)
+        self.assertIn("script-src 'none'", csp)
+        self.assertIn("object-src 'none'", csp)
+        self.assertIn("base-uri 'none'", csp)
+        self.assertIn("form-action 'none'", csp)
+        self.assertRegex(csp, r"style-src 'sha256-[A-Za-z0-9+/=]+'")
+        self.assertNotIn("'unsafe-inline'", csp)
+        self.assertIn(
+            "frame-ancestors 'self' https://home.example.test https://secondary.example.test:8443",
+            csp,
+        )
+
+    def test_featured_plate_keeps_cors_and_framing_permissions_separate(self) -> None:
+        catalog_reader = "https://reader.example.test"
+        frame_parent = "https://home.example.test"
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog(_catalog_entry())))
+            with _serving(
+                catalog_dir,
+                active_catalog_path,
+                state_dir,
+                cors_allowed_origins=(catalog_reader,),
+                embed_allowed_origins=(frame_parent,),
+            ) as port:
+                status, headers, _ = _get(
+                    port,
+                    "/v1/embed/featured-plate",
+                    headers={"Origin": catalog_reader},
+                )
+
+        csp = headers["Content-Security-Policy"]
+        self.assertEqual(status, 200)
+        self.assertIn(f"frame-ancestors 'self' {frame_parent}", csp)
+        self.assertNotIn(catalog_reader, csp)
+        self.assertNotIn("Access-Control-Allow-Origin", headers)
+
+    def test_featured_plate_empty_and_unavailable_states_are_distinct(self) -> None:
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
+                missing_status, _, missing_body = _get(port, "/v1/embed/featured-plate")
+                active_catalog_path.write_text(json.dumps(_active_catalog()))
+                empty_status, empty_headers, empty_body = _get(port, "/v1/embed/featured-plate")
+                active_catalog_path.write_text('{"schema_version": 1, "species"')
+                invalid_status, invalid_headers, invalid_body = _get(
+                    port, "/v1/embed/featured-plate"
+                )
+
+        self.assertEqual(missing_status, 503)
+        self.assertIn(b"Featured plate unavailable", missing_body)
+        self.assertEqual(empty_status, 200)
+        self.assertIn(b"No active plate yet", empty_body)
+        self.assertEqual(invalid_status, 503)
+        self.assertIn(b"Featured plate unavailable", invalid_body)
+        self.assertNotIn(b"schema_version", invalid_body)
+        self.assertEqual(empty_headers.get("Cache-Control"), "no-store")
+        self.assertEqual(invalid_headers.get("Cache-Control"), "no-store")
+        self.assertRegex(
+            empty_headers["Content-Security-Policy"],
+            r"(?:^|; )frame-ancestors 'self'(?:;|$)",
+        )
 
     def test_catalog_projects_only_documented_v1_fields(self) -> None:
         entry = _catalog_entry()
@@ -602,6 +885,47 @@ class ServerTests(unittest.TestCase):
             json.loads(body),
             {"ok": False, "error": "active catalog unavailable", "schema_version": 1},
         )
+
+    def test_catalog_head_reports_readiness_without_body_or_telemetry(self) -> None:
+        trusted_origin = "https://reader.example.test"
+        with self._environment() as (_, catalog_dir, state_dir):
+            active_catalog_path = state_dir / "active-catalog.json"
+            active_catalog_path.write_text(json.dumps(_active_catalog(_catalog_entry())))
+            with _serving(
+                catalog_dir,
+                active_catalog_path,
+                state_dir,
+                cors_allowed_origins=(trusted_origin,),
+            ) as port:
+                ready_status, ready_headers, ready_body = _head(
+                    port,
+                    "/v1/catalog?reports_success=1",
+                    headers={"User-Agent": USER_AGENT},
+                )
+                browser_status, browser_headers, browser_body = _head(
+                    port,
+                    "/v1/catalog",
+                    headers={"Origin": trusted_origin},
+                )
+                active_catalog_path.write_text('{"schema_version": 1, "species"')
+                unavailable_status, unavailable_headers, unavailable_body = _head(
+                    port, "/v1/catalog"
+                )
+                unknown_status, _, unknown_body = _head(port, "/nope")
+
+        self.assertEqual(ready_status, 200)
+        self.assertEqual(ready_headers.get("Content-Type"), "application/json")
+        self.assertGreater(int(ready_headers["Content-Length"]), 0)
+        self.assertEqual(ready_body, b"")
+        self.assertFalse((state_dir / "display-last-fetch.json").exists())
+        self.assertEqual(browser_status, 200)
+        self.assertEqual(browser_headers.get("Access-Control-Allow-Origin"), trusted_origin)
+        self.assertEqual(browser_body, b"")
+        self.assertEqual(unavailable_status, 503)
+        self.assertGreater(int(unavailable_headers["Content-Length"]), 0)
+        self.assertEqual(unavailable_body, b"")
+        self.assertEqual(unknown_status, 404)
+        self.assertEqual(unknown_body, b"")
 
     def test_legacy_catalog_marker_without_origin_records_display_fetch(self) -> None:
         active = _active_catalog(_catalog_entry())


### PR DESCRIPTION
## Summary

- add a narrow, script-free featured-plate embed for stock Homepage dashboards
- add fail-closed `HEAD /v1/catalog` readiness for Homepage monitoring
- keep catalog CORS and iframe permission separate with exact CSP-compatible origins
- document compact statistics and optional image configurations, including privacy and proxy boundaries
- make the embed refresh itself every 15 minutes without Homepage client timers

Closes #253.

## Privacy and security

The embed projects only one active approved bird identity and its upright, checksum-addressed portrait. It does not serialize providers, locations, observation counts or times, queue state, credentials, account data, or private paths. It has no JavaScript, forms, controls, external resources, or display-health writes. Framing is disabled beyond same-origin unless an operator explicitly configures an exact trusted DNS origin.

The public diff was also scanned for private hostnames, IPs, user paths, email addresses, secret references, tokens, and private-key markers; no matches were found.

## Validation

- `ruff format --check .`
- `ruff check .`
- strict `mypy`
- full `pytest`, including loopback HTTP tests
- `inky-bird-frame catalog validate --catalog catalog` (162 species, valid)
- workflow action pinning check (6 files)
- source distribution and wheel build
- desktop and mobile stock-Homepage rendering/geometry check with an upright catalog portrait
- independent security, privacy, API-contract, and documentation review
- `git diff --check`

