### PR TITLE
Release version 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.6.0"
+version = "0.7.0"
 description = "Discover birds and display reviewed field-journal plates on color e-paper"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary

- bump the package and lockfile metadata from `0.6.0` to `0.7.0`
- prepare the next feature release after the catalog/status hardening, controller HTTP boundary work, documentation overhaul, and opt-in Homepage integration

No configuration or state migration is required for existing installations. The new Homepage embed remains opt-in.

## Validation

- `uv lock --check`
- `uv sync --python 3.11 --extra dev --locked`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest` — 673 passed, 81 subtests passed
- `uv run inky-bird-frame catalog validate --catalog catalog` — 162 species
- workflow action pinning — 6 workflows
- package build — wheel and sdist report `0.7.0`
- independent exact-tree review — clean
- public privacy scrub — clean
