### PR TITLE
Remove legacy display telemetry GETs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -226,12 +226,9 @@ service. A client that can reach the controller can deliberately imitate a
 display node's POST and refresh the aggregate signal. Keep the controller port
 private and do not use these heartbeats as an identity or authorization check.
 
-For one compatibility release, older display nodes may still use `GET
-/v1/catalog?reports_success=1` and `GET /v1/display-success`. The controller
-requires both the fixed Inky display user agent and no `Origin` header; current
-display nodes fall back to these routes only when a telemetry POST fails. These
-state-changing GET forms are deprecated and will be removed in the next feature
-release. The service logs each request locally with source IP address, path and
+Catalog `GET` and `HEAD` requests are side-effect free, including requests with
+query parameters. Display health changes only through the two bounded POST
+routes. The service logs each request locally with source IP address, path and
 query, and status. It does not log headers or send external browser telemetry.
 
 Native installations use launchd or systemd to schedule the controller's

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -687,14 +687,14 @@ schema.
 Current display nodes report a parsed catalog fetch through `POST
 /v1/display-fetch` and a verified panel update through `POST
 /v1/display-success`. The reports contain only `{"schema_version": 1}`. If an
-older controller rejects either POST, the display retries that report through
-the former GET contract after it has validated the catalog or completed the
-panel update. Display rotation therefore keeps working, and health reports
-continue, during a display-first update. For one compatibility release, the
-controller accepts `GET /v1/catalog?reports_success=1` and `GET
-/v1/display-success` only from clients with no `Origin` header and the fixed
-Inky display user agent. Those GET forms are deprecated and will be removed in
-the next feature release.
+older controller rejects either POST, the display ignores the telemetry
+failure and continues rotating plates. Controller and display releases before
+v0.7.0 used state-changing GET telemetry that is no longer accepted. A direct
+split upgrade from an older release cannot preserve heartbeat reporting: the
+old role uses GET while the new role uses POST. Update the controller first,
+then update the display promptly, and expect a temporary telemetry gap. If
+uninterrupted heartbeat monitoring is required, update both roles to v0.7.0
+first, verify POST telemetry, and then continue to the newer release.
 
 Docker controller updates pull a published image and recreate the services. See
 the [Docker update instructions](docker.md#update) for version pinning and

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -72,12 +72,13 @@ completing an update, so a panel that fails before its first success is still
 detected. Ordinary catalog reads never refresh either signal or mask a silent
 display. Browser requests with an `Origin` header cannot write either signal.
 The endpoints are otherwise unauthenticated inside the trusted network, so a
-client that deliberately calls them can imitate a display node. For one
-compatibility release, older display nodes can also use the former GET marker
-and success route when they send the fixed Inky display user agent without an
-`Origin` header. Current displays use those routes only as a fallback when a
-telemetry POST fails. These GET forms are deprecated; update display nodes
-first. `display_recovered` is sent once updates resume.
+client that deliberately calls them can imitate a display node. Catalog `GET`
+and `HEAD` requests never write heartbeat state. Releases before v0.7.0 used a
+former GET telemetry contract that is no longer accepted. A direct split
+upgrade from an older release has a temporary telemetry gap regardless of
+upgrade order. Update the controller first and then the display promptly, or
+move both roles through v0.7.0 first when uninterrupted heartbeat monitoring is
+required. `display_recovered` is sent once updates resume.
 
 Routine successes do not notify. Transient failures notify only after
 `degradation_failure_threshold` consecutive failures or

--- a/src/inky_bird_frame/display_node.py
+++ b/src/inky_bird_frame/display_node.py
@@ -306,25 +306,14 @@ def _evict_stale_cache_entries(current_image_path: Path, taxon_id: int) -> None:
 
 
 def _report_display_event(controller_url: str, event: str) -> None:
-    # Best-effort: retry the one-release GET contract when an older controller
-    # rejects the POST route. Both forms run only after the corresponding
-    # catalog or panel state has been verified.
-    try:
+    # Telemetry is best effort and runs only after the corresponding catalog or
+    # panel state has been verified. A reporting failure never blocks rotation.
+    with suppress(DataSourceError):
         post_json(
             f"{controller_url}/v1/display-{event}",
             {"schema_version": 1},
             10.0,
         )
-        return
-    except DataSourceError:
-        pass
-    legacy_url = (
-        f"{controller_url}/v1/catalog?reports_success=1"
-        if event == "fetch"
-        else f"{controller_url}/v1/display-success"
-    )
-    with suppress(DataSourceError):
-        get_json(legacy_url, 10.0)
 
 
 def run_display_cycle(

--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -17,7 +17,7 @@ from . import __version__
 from .catalog import read_json, rebuild_catalog_index, utc_now
 from .config import ControllerConfig
 from .errors import CatalogError
-from .http import USER_AGENT, write_json_atomic
+from .http import write_json_atomic
 from .images import slugify
 from .timeutil import parse_utc_timestamp
 
@@ -246,11 +246,6 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
     def _has_origin(self) -> bool:
         return bool(self.headers.get_all("Origin", failobj=[]))
 
-    def _is_legacy_display_request(self) -> bool:
-        return not self._has_origin() and self.headers.get_all("User-Agent", failobj=[]) == [
-            USER_AGENT
-        ]
-
     def _load_active_catalog(self) -> tuple[dict[str, object], dict[str, str]]:
         return _project_active_catalog(read_json(self.active_catalog_path))
 
@@ -457,14 +452,6 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
                     allow_browser_access=True,
                 )
                 return
-            # Compatibility bridge for one release. Only the fixed user agent
-            # used by older display nodes can update physical-display health.
-            if self._is_legacy_display_request() and parse_qs(split.query).get(
-                "reports_success"
-            ) == ["1"]:
-                # Legacy telemetry is best effort: a state-write failure must
-                # never withhold an otherwise valid catalog from the display.
-                self._record_display_event("display-last-fetch.json", "fetched_at")
             self._send_json(HTTPStatus.OK, payload, allow_browser_access=True)
             return
         if request_path == "/v1/embed/featured-plate":
@@ -483,23 +470,6 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
                 entry,
                 empty_message="No active plate yet",
             )
-            return
-        if request_path == "/v1/display-success":
-            if not self._is_legacy_display_request():
-                self._send_json(
-                    HTTPStatus.FORBIDDEN,
-                    {
-                        "ok": False,
-                        "error": "browser telemetry is not accepted",
-                        "schema_version": 1,
-                    },
-                )
-                return
-            # Compatibility bridge for one release. New display nodes use POST.
-            if not self._record_display_event("display-last-success.json", "succeeded_at"):
-                self._send_telemetry_unavailable()
-                return
-            self._send_json(HTTPStatus.OK, {"ok": True, "schema_version": 1})
             return
         prefix = "/v1/assets/"
         if request_path.startswith(prefix):

--- a/tests/test_display_node.py
+++ b/tests/test_display_node.py
@@ -230,7 +230,7 @@ class DisplayNodeTests(unittest.TestCase):
 
         self.post_json.assert_not_called()
 
-    def test_older_controller_without_post_telemetry_does_not_block_display(self) -> None:
+    def test_controller_without_post_telemetry_does_not_block_display(self) -> None:
         payload = catalog_payload({1: b"one"})
         self.post_json.side_effect = DataSourceError("HTTP 501 from controller")
         with TemporaryDirectory() as temporary:
@@ -244,14 +244,7 @@ class DisplayNodeTests(unittest.TestCase):
 
         self.assertEqual(result["display_update"], "sent")
         self.assertEqual(self.post_json.call_count, 2)
-        self.assertEqual(
-            [call.args for call in get_json.call_args_list],
-            [
-                ("http://controller.test/v1/catalog", 20.0),
-                ("http://controller.test/v1/catalog?reports_success=1", 10.0),
-                ("http://controller.test/v1/display-success", 10.0),
-            ],
-        )
+        get_json.assert_called_once_with("http://controller.test/v1/catalog", 20.0)
 
     def test_unsupported_hardware_fails_before_controller_fetch(self) -> None:
         with TemporaryDirectory() as temporary:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -260,7 +260,7 @@ class ServerTests(unittest.TestCase):
                 "/v1/display-success",
                 headers={"Origin": trusted_origin},
             )
-            legacy_status, _, _ = _get(
+            get_status, _, _ = _get(
                 port,
                 "/v1/display-success",
                 headers={"Origin": trusted_origin},
@@ -270,7 +270,7 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(health_status, 200)
         self.assertNotIn("Access-Control-Allow-Origin", health_headers)
         self.assertEqual(heartbeat_status, 403)
-        self.assertEqual(legacy_status, 403)
+        self.assertEqual(get_status, 404)
         self.assertNotIn("Access-Control-Allow-Origin", heartbeat_headers)
         self.assertFalse(heartbeat_written)
 
@@ -672,21 +672,20 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(hidden_status, 404)
         self.assertNotIn(b"{}", staging_body)
 
-    def test_legacy_display_success_get_without_origin_is_recorded(self) -> None:
-        with self._environment() as (_, catalog_dir, state_dir):
-            with _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port:
-                status, _, body = _get(
-                    port,
-                    "/v1/display-success",
-                    headers={"User-Agent": USER_AGENT},
-                )
+    def test_display_success_get_is_not_found_and_does_not_write(self) -> None:
+        with (
+            self._environment() as (_, catalog_dir, state_dir),
+            _serving(catalog_dir, state_dir / "active-catalog.json", state_dir) as port,
+        ):
+            status, _, body = _get(
+                port,
+                "/v1/display-success",
+                headers={"User-Agent": USER_AGENT},
+            )
 
-            recorded = json.loads((state_dir / "display-last-success.json").read_text())
-
-        self.assertEqual(status, 200)
-        self.assertTrue(json.loads(body)["ok"])
-        self.assertEqual(recorded["schema_version"], 1)
-        self.assertIn("succeeded_at", recorded)
+        self.assertEqual(status, 404)
+        self.assertEqual(json.loads(body), {"ok": False, "error": "not found"})
+        self.assertFalse((state_dir / "display-last-success.json").exists())
 
     def test_asset_is_served_with_png_content_type(self) -> None:
         with self._environment() as (_, catalog_dir, state_dir):
@@ -900,7 +899,6 @@ class ServerTests(unittest.TestCase):
                 ready_status, ready_headers, ready_body = _head(
                     port,
                     "/v1/catalog?reports_success=1",
-                    headers={"User-Agent": USER_AGENT},
                 )
                 browser_status, browser_headers, browser_body = _head(
                     port,
@@ -927,65 +925,28 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(unknown_status, 404)
         self.assertEqual(unknown_body, b"")
 
-    def test_legacy_catalog_marker_without_origin_records_display_fetch(self) -> None:
+    def test_catalog_queries_never_record_display_fetch(self) -> None:
         active = _active_catalog(_catalog_entry())
         with self._environment() as (_, catalog_dir, state_dir):
             active_catalog_path = state_dir / "active-catalog.json"
             active_catalog_path.write_text(json.dumps(active))
             with _serving(catalog_dir, active_catalog_path, state_dir) as port:
-                plain_status, _, _ = _get(port, "/v1/catalog")
-                _get(port, "/v1/catalog?not_reports_success=1")
-                _get(port, "/v1/catalog?reports_success=10")
-                plain_written = (state_dir / "display-last-fetch.json").exists()
-                status, _, body = _get(
-                    port,
-                    "/v1/catalog?reports_success=1",
-                    headers={"User-Agent": USER_AGENT},
-                )
-            heartbeat = json.loads((state_dir / "display-last-fetch.json").read_text())
+                responses = [
+                    _get(port, "/v1/catalog"),
+                    _get(port, "/v1/catalog?not_reports_success=1"),
+                    _get(port, "/v1/catalog?reports_success=10"),
+                    _get(
+                        port,
+                        "/v1/catalog?reports_success=1",
+                        headers={"User-Agent": USER_AGENT},
+                    ),
+                ]
 
-        self.assertEqual(plain_status, 200)
-        self.assertFalse(plain_written)
-        self.assertEqual(status, 200)
-        self.assertEqual(json.loads(body), active)
-        self.assertEqual(heartbeat["schema_version"], 1)
-        self.assertRegex(heartbeat["fetched_at"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
-
-    def test_legacy_catalog_remains_available_when_fetch_telemetry_cannot_persist(
-        self,
-    ) -> None:
-        active = _active_catalog(_catalog_entry())
-        output = io.StringIO()
-        with (
-            self._environment() as (_, catalog_dir, state_dir),
-            patch(
-                "inky_bird_frame.server.write_json_atomic",
-                side_effect=OSError("state unavailable"),
-            ),
-            redirect_stdout(output),
-        ):
-            active_catalog_path = state_dir / "active-catalog.json"
-            active_catalog_path.write_text(json.dumps(active))
-            with _serving(catalog_dir, active_catalog_path, state_dir) as port:
-                status, _, body = _get(
-                    port,
-                    "/v1/catalog?reports_success=1",
-                    headers={"User-Agent": USER_AGENT},
-                )
-
-        events = [json.loads(line) for line in output.getvalue().splitlines()]
-        self.assertEqual(status, 200)
-        self.assertEqual(json.loads(body), active)
+        self.assertTrue(all(status == 200 for status, _, _ in responses))
+        self.assertTrue(all(json.loads(body) == active for _, _, body in responses))
         self.assertFalse((state_dir / "display-last-fetch.json").exists())
-        self.assertIn(
-            {
-                "event": "display_telemetry_write_failed",
-                "file": "display-last-fetch.json",
-            },
-            events,
-        )
 
-    def test_nonlegacy_gets_cannot_write_display_telemetry(self) -> None:
+    def test_gets_cannot_write_display_telemetry(self) -> None:
         with self._environment() as (_, catalog_dir, state_dir):
             active_catalog_path = state_dir / "active-catalog.json"
             active_catalog_path.write_text(json.dumps(_active_catalog()))
@@ -994,7 +955,7 @@ class ServerTests(unittest.TestCase):
                 success_status, _, _ = _get(port, "/v1/display-success")
 
         self.assertEqual(catalog_status, 200)
-        self.assertEqual(success_status, 403)
+        self.assertEqual(success_status, 404)
         self.assertFalse((state_dir / "display-last-fetch.json").exists())
         self.assertFalse((state_dir / "display-last-success.json").exists())
 
@@ -1127,7 +1088,7 @@ class ServerTests(unittest.TestCase):
         self.assertNotIn("display.example.test", output.getvalue())
         self.assertNotIn("private-browser-detail", output.getvalue())
 
-    def test_browser_catalog_marker_never_records_display_fetch(self) -> None:
+    def test_browser_catalog_query_never_records_display_fetch(self) -> None:
         trusted_origin = "https://display.example.test"
         with self._environment() as (_, catalog_dir, state_dir):
             active_catalog_path = state_dir / "active-catalog.json"


### PR DESCRIPTION
Fixes #252

## Summary

The v0.7.0 controller introduced bounded POST endpoints for display fetch and success telemetry while retaining the former state-changing GET forms for one compatibility release. That window has elapsed.

This change removes the controller GET bridge and the display client fallback. Catalog GET and HEAD requests are now unconditionally side-effect free, `GET /v1/display-success` returns 404, and POST telemetry remains best effort so reporting failures never block plate rotation. The installation and operations-facing HTTP documentation now identify v0.7.0 as the minimum version for uninterrupted heartbeat reporting across this upgrade.

## Change type

- [x] Code
- [x] Documentation
- [ ] Catalog plate
- [x] Tests or continuous integration
- [ ] Other maintenance

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest` (673 passed, 81 subtests passed)
- `uv run inky-bird-frame catalog validate --catalog catalog` (163 species)
- `uv run python .github/scripts/check_workflow_pinning.py .github/workflows`
- `uv build` (sdist and wheel)
- `git diff --check`

## Review notes

There is no catalog-schema, configuration, or private-state migration. Update the controller first and then the display when either role is older than v0.7.0. Older roles continue rotating plates if telemetry is unavailable, but health reporting resumes only after both sides support the POST contract.