### PR TITLE
Defer research retries until budget reset

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -26,6 +26,11 @@ often, review and raise `max_searches_per_day` to match. Cached profiles do not
 consume the budget again. Use `seed` for a broad historical catalog instead of
 making the active observation window permanently broad.
 
+Research counters reset at midnight UTC. When a daily or per-species limit is
+reached, the controller records the next attempt at that reset instead of
+running backoff retries that cannot succeed. An explicit `retry` never bypasses
+the configured research budget.
+
 The controller's `workspace_dir` must be writable because the Codex image tool
 copies its final image there. Keep it separate from configuration, catalog, and
 state; the example uses a dedicated `workspace` directory. `catalog_dir` and

--- a/src/inky_bird_frame/controller.py
+++ b/src/inky_bird_frame/controller.py
@@ -79,6 +79,7 @@ from .errors import (
     InsufficientReferencesError,
     MissingDependencyError,
     QualityReviewError,
+    ResearchLimitError,
     SpeciesStateError,
 )
 from .geo import DiscoveryLocation, resolve_discovery_location
@@ -2454,6 +2455,26 @@ def run_generation_cycle(config: AppConfig) -> dict[str, object]:
                     now=datetime.now(UTC),
                     initial_minutes=config.controller.retry_initial_minutes,
                     maximum_minutes=config.controller.retry_max_minutes,
+                    species=species,
+                )
+                failures.append(
+                    {
+                        "taxon_id": species.taxon_id,
+                        "common_name": species.common_name,
+                        "error": str(exc),
+                        "retry_at": retry.next_attempt_at.isoformat(),
+                        "terminal": False,
+                    }
+                )
+            except ResearchLimitError as exc:
+                now = datetime.now(UTC)
+                retry = retry_store.record_failure(
+                    species.taxon_id,
+                    exc,
+                    now=now,
+                    initial_minutes=config.controller.retry_initial_minutes,
+                    maximum_minutes=config.controller.retry_max_minutes,
+                    retry_at=max(exc.retry_at, now),
                     species=species,
                 )
                 failures.append(

--- a/src/inky_bird_frame/errors.py
+++ b/src/inky_bird_frame/errors.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -54,6 +55,14 @@ class CatalogPublishError(InkyBirdFrameError):
 
 class GenerationError(InkyBirdFrameError):
     """Raised when Codex cannot produce or validate an artifact."""
+
+
+class ResearchLimitError(GenerationError):
+    """Raised when durable research capacity is unavailable until a known time."""
+
+    def __init__(self, message: str, *, retry_at: datetime) -> None:
+        super().__init__(message)
+        self.retry_at = retry_at
 
 
 class QualityReviewError(GenerationError):

--- a/src/inky_bird_frame/research.py
+++ b/src/inky_bird_frame/research.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, time, timedelta
 from pathlib import Path
 
-from .errors import CatalogError, GenerationError
+from .errors import CatalogError, ResearchLimitError
 from .http import write_json_atomic
 
 
@@ -23,13 +23,16 @@ class ResearchBudget:
             total = 0
             species = {}
         species_count = species.get(taxon_id, 0)
+        retry_at = datetime.combine(current.date() + timedelta(days=1), time.min, tzinfo=UTC)
         if total >= self.daily_limit:
-            raise GenerationError(
-                f"Daily research limit of {self.daily_limit} searches has been reached"
+            raise ResearchLimitError(
+                f"Daily research limit of {self.daily_limit} searches has been reached",
+                retry_at=retry_at,
             )
         if species_count >= self.species_limit:
-            raise GenerationError(
-                f"Taxon {taxon_id} reached its research limit of {self.species_limit} searches"
+            raise ResearchLimitError(
+                f"Taxon {taxon_id} reached its research limit of {self.species_limit} searches",
+                retry_at=retry_at,
             )
         species[taxon_id] = species_count + 1
         write_json_atomic(

--- a/src/inky_bird_frame/retry.py
+++ b/src/inky_bird_frame/retry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, replace
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path, PurePosixPath
 from typing import cast
 from urllib.parse import urlsplit
@@ -117,6 +117,7 @@ class RetryStore:
         initial_minutes: int,
         maximum_minutes: int,
         fixed_minutes: int | None = None,
+        retry_at: datetime | None = None,
         species: BirdSpecies | None = None,
     ) -> RetryRecord:
         previous = self.get(taxon_id)
@@ -133,11 +134,21 @@ class RetryStore:
             common_name = previous.common_name if previous is not None else None
             scientific_name = previous.scientific_name if previous is not None else None
         attempts = (previous.attempts if previous is not None else 0) + 1
-        delay = (
-            fixed_minutes
-            if fixed_minutes is not None
-            else min(initial_minutes * (2 ** (attempts - 1)), maximum_minutes)
-        )
+        if retry_at is not None:
+            if fixed_minutes is not None:
+                raise ValueError("retry_at and fixed_minutes are mutually exclusive")
+            if retry_at.tzinfo is None or retry_at.utcoffset() is None:
+                raise ValueError("retry_at must be timezone-aware")
+            if retry_at < now:
+                raise ValueError("retry_at cannot be earlier than now")
+            next_attempt_at = retry_at.astimezone(UTC)
+        else:
+            delay = (
+                fixed_minutes
+                if fixed_minutes is not None
+                else min(initial_minutes * (2 ** (attempts - 1)), maximum_minutes)
+            )
+            next_attempt_at = now + timedelta(minutes=delay)
         record = RetryRecord(
             taxon_id=taxon_id,
             attempts=attempts,
@@ -145,7 +156,7 @@ class RetryStore:
             error=str(error),
             first_failed_at=previous.first_failed_at if previous is not None else now,
             last_failed_at=now,
-            next_attempt_at=now + timedelta(minutes=delay),
+            next_attempt_at=next_attempt_at,
             common_name=common_name,
             scientific_name=scientific_name,
         )

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -74,6 +74,7 @@ from inky_bird_frame.errors import (
     GenerationError,
     InsufficientReferencesError,
     QualityReviewError,
+    ResearchLimitError,
     SpeciesStateError,
 )
 from inky_bird_frame.geo import DiscoveryLocation
@@ -3423,6 +3424,42 @@ class ControllerTests(unittest.TestCase):
             generate.call_args.kwargs["invariant_correction_findings"],
             ("Keep the eyes clearly visible",),
         )
+
+    def test_research_limit_retries_at_the_budget_reset(self) -> None:
+        species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")
+        location = DiscoveryLocation("12345", "Exampleville", "XY", 1.0, 2.0)
+        retry_at = datetime(2099, 1, 2, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            config_path = Path(temporary) / "config.toml"
+            config_path.write_text(CONFIG)
+            config = load_config(config_path)
+            config.controller.state_dir.mkdir(parents=True)
+            with (
+                patch(
+                    "inky_bird_frame.controller.discover_species",
+                    return_value=discovery_result(location, [species]),
+                ),
+                patch("inky_bird_frame.controller.generate_candidate") as generate,
+            ):
+                generate.side_effect = ResearchLimitError(
+                    "research limit reached",
+                    retry_at=retry_at,
+                )
+                result = run_controller_cycle(config)
+
+            retry = RetryStore(config.controller.state_dir / "generation-retries.json").get(
+                species.taxon_id
+            )
+
+        self.assertIsNotNone(retry)
+        if retry is not None:
+            self.assertEqual(retry.next_attempt_at, retry_at)
+            self.assertEqual(retry.error_type, "ResearchLimitError")
+        failures = result["failures"]
+        self.assertIsInstance(failures, list)
+        if isinstance(failures, list):
+            self.assertEqual(failures[0]["retry_at"], retry_at.isoformat())
+            self.assertFalse(failures[0]["terminal"])
 
     def test_catalog_wide_error_still_aborts_the_cycle(self) -> None:
         species = BirdSpecies(9083, "Northern Cardinal", "Cardinalis cardinalis", 2, "test")

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from inky_bird_frame.errors import GenerationError
+from inky_bird_frame.errors import ResearchLimitError
 from inky_bird_frame.research import ResearchBudget
 
 
@@ -16,11 +16,13 @@ class ResearchBudgetTests(unittest.TestCase):
             budget = ResearchBudget(Path(temporary) / "budget.json", daily_limit=3, species_limit=2)
             budget.consume(1, now)
             budget.consume(1, now)
-            with self.assertRaisesRegex(GenerationError, "research limit"):
+            with self.assertRaisesRegex(ResearchLimitError, "research limit") as species_limit:
                 budget.consume(1, now)
+            self.assertEqual(species_limit.exception.retry_at, now + timedelta(days=1))
             budget.consume(2, now)
-            with self.assertRaisesRegex(GenerationError, "Daily research limit"):
+            with self.assertRaisesRegex(ResearchLimitError, "Daily research limit") as daily_limit:
                 budget.consume(3, now)
+            self.assertEqual(daily_limit.exception.retry_at, now + timedelta(days=1))
 
     def test_new_utc_day_resets_budget(self) -> None:
         now = datetime(2026, 7, 10, 23, 59, tzinfo=UTC)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -60,6 +60,37 @@ class RetryStoreTests(unittest.TestCase):
         self.assertEqual(record.next_attempt_at, now + timedelta(days=7))
         self.assertIsNone(store.get(42))
 
+    def test_explicit_retry_time_is_durable_and_exclusive(self) -> None:
+        now = datetime(2026, 7, 10, 23, 30, tzinfo=UTC)
+        retry_at = datetime(2026, 7, 11, tzinfo=UTC)
+        with TemporaryDirectory() as temporary:
+            path = Path(temporary) / "retries.json"
+            store = RetryStore(path)
+            record = store.record_failure(
+                42,
+                RuntimeError("research limit"),
+                now=now,
+                initial_minutes=30,
+                maximum_minutes=60,
+                retry_at=retry_at,
+            )
+
+            with self.assertRaisesRegex(ValueError, "mutually exclusive"):
+                store.record_failure(
+                    43,
+                    RuntimeError("invalid"),
+                    now=now,
+                    initial_minutes=30,
+                    maximum_minutes=60,
+                    fixed_minutes=60,
+                    retry_at=retry_at,
+                )
+
+            reloaded = RetryStore(path).get(42)
+
+        self.assertEqual(record.next_attempt_at, retry_at)
+        self.assertEqual(reloaded, record)
+
     def test_identity_can_be_added_without_changing_backoff(self) -> None:
         now = datetime(2026, 7, 10, tzinfo=UTC)
         with TemporaryDirectory() as temporary:


### PR DESCRIPTION
## What changed

- report the exact next UTC research-budget reset with a typed error
- persist that reset as the retry time instead of applying generic exponential backoff
- keep explicit retry times durable and validated in the retry store
- document that operator retries do not bypass configured research limits

## Why

A profile can consume its per-species allowance through the initial research pass and one conflict-reconciliation pass. Retrying every 30 minutes after that cannot succeed until the UTC budget resets, so it creates noise without progress. This change preserves the limit and defers work to the first time it can actually succeed.

## Verification

- focused budget, retry-store, and controller regressions
- Ruff format and lint
- strict MyPy
- 675 Pytest tests plus 81 subtests
- documentation links and anchors
- 163-species catalog validation
- workflow action-pinning validation
- sdist and wheel build
