### PR TITLE
Harden CI and dependency maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,15 @@
 version: 2
 updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ permissions:
   contents: read
 
 jobs:
-  quality:
+  core-quality:
+    name: Core quality
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -180,3 +181,49 @@ jobs:
             --volume "$config_volume:/data" \
             --entrypoint python inky-bird-frame:ci -c \
             "from pathlib import Path; from inky_bird_frame.config import load_config; config = load_config(Path('/data/config.toml')); assert config.controller.workspace_dir == Path('/data/workspace'); assert config.controller.workspace_dir.is_dir()"
+
+  python-compatibility:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.12"
+          - "3.13"
+          - "3.14"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: "false"
+
+      - name: Install dependencies
+        run: uv sync --extra dev --locked
+
+      - name: Run tests
+        run: uv run pytest
+
+  quality:
+    name: quality
+    if: always()
+    needs:
+      - core-quality
+      - python-compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every quality job
+        env:
+          CORE_RESULT: ${{ needs.core-quality.result }}
+          COMPATIBILITY_RESULT: ${{ needs.python-compatibility.result }}
+        run: |
+          test "$CORE_RESULT" = "success"
+          test "$COMPATIBILITY_RESULT" = "success"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: codeql
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    # Re-scan each Monday at 06:00 UTC so new CodeQL queries run without a code change.
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@a35ac6e6798d72df5475948b28efb89edc2e19ca # v4.37.9
+        with:
+          languages: python
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@a35ac6e6798d72df5475948b28efb89edc2e19ca # v4.37.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Multimedia :: Graphics",
 ]
 dependencies = [


### PR DESCRIPTION
## What changed

- keep the existing required `quality` check as an aggregate over the full Python 3.11/container gate and tests on Python 3.12, 3.13, and 3.14
- add a commit-pinned CodeQL v4 workflow for pull requests, main, and a weekly scan
- enable weekly native uv dependency updates alongside the existing GitHub Actions updates
- publish the Python 3.12–3.14 classifiers now that those runtimes are tested

## Why

The package already declares Python 3.11 or newer, but CI previously proved only 3.11. This makes the support claim real and keeps every runtime behind the already-required `quality` status. CodeQL and uv updates close two supply-chain maintenance gaps without changing runtime behavior.

Docker and bundled CLI pins are intentionally not delegated to Dependabot: its Docker updater does not support this repository’s `ARG`-driven `FROM` pattern, and Codex/GitHub CLI archives must continue to be reviewed with their architecture-specific checksums and notices.

## Verification

- Actionlint and ShellCheck
- workflow action-pinning validation across seven workflows
- YAML parse validation
- 673 tests plus 81 subtests on each of Python 3.11, 3.12, 3.13, and 3.14
- Ruff format and lint
- strict MyPy
- 163-species catalog validation
- sdist and wheel build
