### PR TITLE
Reconcile supported measurement variation

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -129,6 +129,15 @@ profile field. A reviewer must also explicitly identify earlier image
 corrections that the current attempt resolves; disappearance alone never turns
 a correction into a non-regression invariant.
 
+Published dimensions can differ across reputable sources because their samples
+or methods differ. A profile uses one compatible, directly supported
+measurement set and preserves any material sex, age, or season qualifier. The
+reviewer does not fail that choice merely because another allowed source
+publishes a different supported set. It reports a profile conflict when the
+chosen value is unsupported, misquoted, assembled from incompatible endpoints,
+missing a material qualifier, or presented as broader agreement than its source
+establishes.
+
 `state_dir/runs/*/attempt-history.json` is a private, schema-versioned record of
 every started image attempt. It includes prompt version, requested model,
 generation and review latency, score-axis failures, correction regressions,

--- a/src/inky_bird_frame/prompts.py
+++ b/src/inky_bird_frame/prompts.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from .birds import BirdSpecies, TaxonContext
 from .models import ProfileConflict, ReferencePhoto, SpeciesProfileData
 
-PROMPT_VERSION = "field-journal-v5"
+PROMPT_VERSION = "field-journal-v6"
 
 
 class _TextExtractor(HTMLParser):
@@ -307,6 +307,14 @@ interior ticks are visual subdivisions, not unit increments: their exact count o
 variation is not a factual error and must not lower a score below 4 by itself. Missing or reversed
 endpoints, wrong values or units, a contradictory marker, or a ruler presented as the printed
 bird's scale remains a material text error with a specific correction.
+Authoritative sources may publish different measurements because they use different samples,
+methods, ages, sexes, or seasons. The proposed profile is required to use one compatible published
+measurement set, not synthesize a consensus range. Do not report a profile conflict merely because
+another allowed source publishes a different supported set. Accept a measurement when its value
+and material qualifiers faithfully match a direct allowed source. Report a measurement conflict
+only when the proposed value has no direct support, misstates its supporting source, combines
+incompatible endpoints, omits a material qualifier, or falsely claims broader agreement than the
+source establishes.
 Read every visible text line in full rather than summarizing it. Compare its spelling, numbers,
 and word order to the proposed facts; treat duplicated, omitted, substituted, or nonsensical words
 as material text errors and give the exact replacement. When unequal mandibles are a field mark,

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -10,7 +10,7 @@ from inky_bird_frame.prompts import PROMPT_VERSION, plate_prompt, profile_prompt
 
 class PromptTests(unittest.TestCase):
     def test_prompt_contract_version(self) -> None:
-        self.assertEqual(PROMPT_VERSION, "field-journal-v5")
+        self.assertEqual(PROMPT_VERSION, "field-journal-v6")
 
     def test_plate_prompt_contains_species_facts_and_excludes_location(self) -> None:
         species = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 26, "iNaturalist")
@@ -149,6 +149,12 @@ class PromptTests(unittest.TestCase):
         self.assertIn(
             "drop a conflict that the current direct sources no longer support", normalized_review
         )
+        self.assertIn(
+            "Do not report a profile conflict merely because another allowed source publishes a "
+            "different supported set",
+            normalized_review,
+        )
+        self.assertIn("required to use one compatible published measurement set", normalized_review)
 
     def test_plate_and_review_prompts_enforce_schematic_ruler(self) -> None:
         species = BirdSpecies(12942, "Eastern Bluebird", "Sialia sialis", 26, "iNaturalist")


### PR DESCRIPTION
## What changed

- align independent review with the existing rule that a profile uses one compatible published measurement set
- accept a directly supported, properly qualified measurement even when another reputable source publishes a different set
- keep conflicts mandatory for unsupported, misquoted, synthesized, under-qualified, or falsely generalized measurements
- version the changed generation/review contract as `field-journal-v6`

## Why

Different field guides can publish different body measurements because they use different samples or methods. The profile prompt already forbids inventing a consensus range, but the reviewer treated any alternate published set as a profile defect. That contradiction could make an otherwise accurate plate fail forever. The new rule preserves strict factual review without manufacturing a false consensus.

## Verification

- focused profile/review prompt contract tests
- documentation link and anchor tests
- Ruff format and lint
- strict MyPy
- 673 Pytest tests plus 81 subtests
- 163-species catalog validation
- workflow action-pinning validation
- sdist and wheel build
