### PR TITLE
Release version 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.7.0"
+version = "0.8.0"
 description = "Discover birds and display reviewed field-journal plates on color e-paper"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -247,7 +247,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary

Release Inky Bird Frame 0.8.0 after the completed compatibility and hardening work:

- remove the deprecated state-changing GET display-telemetry bridge;
- defer research-budget retries to the exact UTC reset;
- reconcile directly supported measurement variation in profile review;
- refresh the controller toolchain and development dependencies;
- qualify Python 3.11 through 3.14 and add CodeQL plus native uv maintenance; and
- publish the version 1 compatibility contract.

This PR intentionally changes only the project version and root lock entry from 0.7.0 to 0.8.0.

## Change type

- [ ] Code
- [ ] Documentation
- [ ] Catalog plate
- [ ] Tests or continuous integration
- [x] Other maintenance

## Validation

- `uv lock --check`
- `uv sync --extra dev --locked`
- `uv run inky-bird-frame --version` -> `inky-bird-frame 0.8.0`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q -p no:cacheprovider` (full suite passed with loopback access)
- `uv run inky-bird-frame catalog validate --catalog catalog` (163 species)
- `uv run python .github/scripts/check_workflow_pinning.py` (7 workflow files)
- `uv build --out-dir /private/tmp/inky-release-080-dist`
- verified wheel and source-distribution metadata both report 0.8.0
- `git diff --check`

## Review notes

No private configuration or state migration is required. Release notes will document the intentional removal of pre-v0.7 GET telemetry and the controller-first upgrade order.
