### PR TITLE
Emit canonical CORS origins in responses

### DIFF
--- a/src/inky_bird_frame/server.py
+++ b/src/inky_bird_frame/server.py
@@ -254,8 +254,15 @@ class CatalogRequestHandler(BaseHTTPRequestHandler):
             return
         self.send_header("Vary", "Origin")
         origins = self.headers.get_all("Origin", failobj=[])
-        if len(origins) == 1 and origins[0] in self.cors_allowed_origins:
-            self.send_header("Access-Control-Allow-Origin", origins[0])
+        if len(origins) != 1:
+            return
+        # Emit the canonical configured value, never the request header value.
+        allowed_origin = next(
+            (candidate for candidate in self.cors_allowed_origins if candidate == origins[0]),
+            None,
+        )
+        if allowed_origin is not None:
+            self.send_header("Access-Control-Allow-Origin", allowed_origin)
 
     def _send_json(
         self,


### PR DESCRIPTION
## Summary

CodeQL correctly identified that the catalog server returned the request-derived `Origin` string in `Access-Control-Allow-Origin` after an allowlist match. The configured origins are already normalized and reject control characters; this change completes the boundary by returning the matching canonical configured value instead of reflecting request bytes.

The trusted/untrusted and duplicate-Origin behavior is otherwise unchanged.

## Change type

- [x] Code
- [ ] Documentation
- [ ] Catalog plate
- [ ] Tests or continuous integration
- [ ] Other maintenance

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy` — 57 source files
- `uv run pytest` — full suite passed
- `uv run inky-bird-frame catalog validate --catalog catalog` — 164 species
- `uv run python .github/scripts/check_workflow_pinning.py` — 7 workflow files
- `uv build` — v0.8.0 sdist and wheel built

## Review notes

Closes the data flow reported by CodeQL alert #1 without widening CORS or changing the public API.