### PR TITLE
Release version 0.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inky-bird-frame"
-version = "0.8.0"
+version = "0.8.1"
 description = "Discover birds and display reviewed field-journal plates on color e-paper"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -247,7 +247,7 @@ wheels = [
 
 [[package]]
 name = "inky-bird-frame"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
## Summary

Prepare the v0.8.1 patch release. This release ships the canonical-CORS response hardening from #269 after CodeQL identified a request-derived header value in v0.8.0.

The release changes no configuration, state, catalog, CLI, or HTTP contract.

## Change type

- [ ] Code
- [ ] Documentation
- [ ] Catalog plate
- [ ] Tests or continuous integration
- [x] Other maintenance

## Validation

- `uv lock --check`
- `uv sync --extra dev --locked`
- `inky-bird-frame --version` — 0.8.1
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy` — 57 source files
- `uv run pytest` — full suite passed
- `uv run inky-bird-frame catalog validate --catalog catalog` — 164 species
- `uv run python .github/scripts/check_workflow_pinning.py` — 7 workflow files
- `uv build` — v0.8.1 sdist and wheel built

## Review notes

Version-only diff: `pyproject.toml` and the root package entry in `uv.lock`.